### PR TITLE
Feature/89 debug ktools run

### DIFF
--- a/Dockerfile.model_worker
+++ b/Dockerfile.model_worker
@@ -2,7 +2,7 @@ FROM python:3.6
 
 ENV OASIS_MEDIA_ROOT=/shared-fs
 
-RUN apt-get update && apt-get install -y --no-install-recommends git libspatialindex-dev && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends git vim libspatialindex-dev && rm -rf /var/lib/apt/lists/*
 
 RUN adduser --shell /bin/bash --disabled-password --gecos "" worker
 WORKDIR /home/worker

--- a/conf.ini
+++ b/conf.ini
@@ -21,6 +21,6 @@ DO_GZIP_RESPONSE = True
 
 [worker]
 oasislmf_config = /var/oasis/model_data/oasislmf.json
-KEEP_RUN_DIR = True
+DEBUG_MODE = True
 
 [celery]

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -69,7 +69,8 @@ class StartAnalysis(TestCase):
                         '--analysis-settings-file-path', 'analysis_settings.json',
                         '--ktools-num-processes', settings.get('worker', 'KTOOLS_BATCH_COUNT'),
                         '--ktools-alloc-rule', settings.get('worker', 'KTOOLS_ALLOC_RULE'),
-                        '--ktools-fifo-relative'
+                        '--ktools-fifo-relative',
+                        '--verbose'
                     ])
                     cmd_instance.run.assert_called_once_with()
                     self.assertEqual(tarfile.open.call_args_list[1][0], (str(Path(media_root, output_location)), 'w:gz'))


### PR DESCRIPTION
Linked to:
https://github.com/OasisLMF/OasisLMF/pull/240

* Switch Env var `` to `DEBUG_MODE`  `KEEP_RUN_DIR`  which now 
    - Keeps the run dirs 
    - Prints out an equivalent MDK command to reproduce (Input generation / Model run)
    - Logs the bash trace of the run_ktools.sh script if something fails 