### PR TITLE
Extend token settings in conf.ini

### DIFF
--- a/conf.ini
+++ b/conf.ini
@@ -19,8 +19,11 @@ LOG_FILENAME = oasis_api_worker.log
 [server]
 ALLOWED_HOSTS=*
 DO_GZIP_RESPONSE = True
-TOKEN_SIGINING_KEY=JsVzvtWw2EwksaYCZsMmd2zmm
 SECRET_KEY=OmuudYrSFVxcIVIWf6YlYdkP6NXApP
+TOKEN_SIGINING_KEY=JsVzvtWw2EwksaYCZsMmd2zmm
+TOKEN_REFRESH_ROTATE = True
+#TOKEN_ACCESS_LIFETIME = minutes=0, hours=0, days=0, weeks=0
+#TOKEN_REFRESH_LIFETIME = minutes=0, hours=0, days=0, weeks=0
 
 [worker]
 OASISLMF_CONFIG = /var/oasis/oasislmf.json

--- a/src/conf/iniconf.py
+++ b/src/conf/iniconf.py
@@ -2,6 +2,8 @@ from __future__ import absolute_import, unicode_literals
 
 import os
 
+from datetime import timedelta
+
 from chainmap import ChainMap
 
 from configparser import ConfigParser
@@ -41,6 +43,26 @@ class Settings(ConfigParser):
     def getint(self, section, option, **kwargs):
         kwargs.setdefault('vars', self._get_section_env_vars(section))
         return super(Settings, self).getint(section, option, **kwargs)
+
+    def get_timedelta(self, section, option, **kwargs):
+        ''' Use for reading timedelta argument strings and returns a timedelta
+            object
+
+            Example
+            =======
+            in: settings.get_timedelta('server', 'TOKEN_ACCESS_LIFETIME', fallback='days=5')
+            out: datetime.timedelta(days=5)
+        '''
+        kwargs.setdefault('vars', self._get_section_env_vars(section))
+        kwargs_string = super(Settings, self).get(section, option, **kwargs)
+        try:
+            kwargs = {k.split('=')[0].strip():int(k.split('=')[1]) 
+                      for k in kwargs_string.split(',')}
+        except (TypeError, IndexError):
+            kwargs = {k.split('=')[0].strip():int(k.split('=')[1]) 
+                      for k in kwargs['fallback'].split(',')}
+        return timedelta(**kwargs)
+
 
     def getboolean(self, section, option, **kwargs):
         kwargs.setdefault('vars', self._get_section_env_vars(section))

--- a/src/server/oasisapi/auth/tests/test_jwt.py
+++ b/src/server/oasisapi/auth/tests/test_jwt.py
@@ -56,7 +56,7 @@ class AccessToken(WebTest):
 
         self.assertEqual(user.id, actual_refresh_ident['user_id'])
         self.assertEqual(user.id, actual_access_ident['user_id'])
-        self.assertEqual(data['expires_in'], 86400)
+        self.assertEqual(data['expires_in'], 3600)
         self.assertEqual(data['token_type'], 'Bearer')
 
 

--- a/src/server/oasisapi/settings.py
+++ b/src/server/oasisapi/settings.py
@@ -13,8 +13,6 @@ https://docs.djangoproject.com/en/2.0/ref/settings/
 import os
 import sys
 
-from datetime import timedelta
-
 from rest_framework.reverse import reverse_lazy
 
 from ...conf import iniconf  # noqa
@@ -54,6 +52,7 @@ INSTALLED_APPS = [
     'django_filters',
     'rest_framework',
     'drf_yasg',
+    'rest_framework_simplejwt.token_blacklist',
 
     'src.server.oasisapi.files',
     'src.server.oasisapi.portfolios',
@@ -155,8 +154,10 @@ MEDIA_ROOT = iniconf.settings.get('server', 'media_root', fallback=os.path.join(
 
 # https://github.com/davesque/django-rest-framework-simplejwt
 SIMPLE_JWT = {
-    'ACCESS_TOKEN_LIFETIME': timedelta(hours=1),
-    'REFRESH_TOKEN_LIFETIME': timedelta(days=1),
+    'ACCESS_TOKEN_LIFETIME':  iniconf.settings.get_timedelta('server', 'TOKEN_ACCESS_LIFETIME', fallback='hours=1'),
+    'REFRESH_TOKEN_LIFETIME': iniconf.settings.get_timedelta('server', 'TOKEN_REFRESH_LIFETIME', fallback='days=2'),
+    'ROTATE_REFRESH_TOKENS': iniconf.settings.getboolean('server', 'TOKEN_REFRESH_ROTATE', fallback=True),
+    'BLACKLIST_AFTER_ROTATION': iniconf.settings.getboolean('server', 'TOKEN_REFRESH_ROTATE', fallback=True),
     'SIGNING_KEY': iniconf.settings.get('server', 'token_sigining_key', fallback=SECRET_KEY),
 }
 


### PR DESCRIPTION
### Access token
* Default Value increased to `days=2`
* New setting added to conf.ini `TOKEN_REFRESH_LIFETIME` it takes a list of comma delimited values as args to
https://docs.python.org/3/library/datetime.html#datetime.timedelta
```
TOKEN_ACCESS_LIFETIME = minutes=1, hours=1, days=1, weeks=1
```

### Refresh token
* added `TOKEN_REFRESH_ROTATE` which returns a new refresh token when receiving a POST to `/refresh_token/`
  The Previous refresh token is then black listed

* New setting added to conf.ini `TOKEN_ACCESS_LIFETIME` it accepts same types of args as `TOKEN_REFRESH_LIFETIME`
* the **expires_in** field from both `/refresh_token/` and `/access_token/` is set to the access_token expire time