### PR TITLE
Add string, list and dict params to model settings schema

### DIFF
--- a/src/server/oasisapi/schemas/model_settings.json
+++ b/src/server/oasisapi/schemas/model_settings.json
@@ -114,6 +114,99 @@
                    },
                    "required": ["name", "desc", "default", "options"]
                },
+               "string_parameters": {
+                   "type":  "array",
+                   "uniqueItems": true,
+                   "items": {
+                       "type": "object",
+                       "uniqueItems": false,
+                       "title": "String options",
+                       "description": "User selected string value",
+                       "additionalProperties": false,
+                       "properties":{
+                           "name": {
+                               "type": "string",
+                               "title": "UI Option",
+                               "description": "UI name for selection",
+                               "minLength": 1
+                           },
+                           "desc": {
+                               "type": "string",
+                               "title": "UI tooltip",
+                               "description": "UI description for selection"
+                           },
+                           "default":{
+                               "type": "string",
+                               "title": "Initial string",
+                               "description": "Default 'string' for variable"
+                           }
+                       },
+                       "required": ["name", "desc", "default"]
+                   }
+               },
+               "list_parameters": {
+                   "type":  "array",
+                   "uniqueItems": true,
+                   "items": {
+                       "type": "object",
+                       "uniqueItems": false,
+                       "title": "List options",
+                       "description": "User selected list values",
+                       "additionalProperties": false,
+                       "properties":{
+                           "name": {
+                               "type": "string",
+                               "title": "UI Option",
+                               "description": "UI name for selection",
+                               "minLength": 1
+                           },
+                           "desc": {
+                               "type": "string",
+                               "title": "UI tooltip",
+                               "description": "UI description for selection"
+                           },
+                           "default":{
+                               "type": "array",
+                               "title": "Default List value",
+                               "description": "Default 'list' set for variable",
+                               "items":{
+                                   "type": "string" 
+                               }
+                           }
+                       },
+                       "required": ["name", "desc", "default"]
+                   }
+               },
+               "dictionary_parameters": {
+                   "type":  "array",
+                   "uniqueItems": true,
+                   "items": {
+                       "type": "object",
+                       "uniqueItems": false,
+                       "title": "Dictionary option",
+                       "description": "User selected dictionarys",
+                       "additionalProperties": false,
+                       "properties":{
+                           "name": {
+                               "type": "string",
+                               "title": "UI Option",
+                               "description": "UI name for selection",
+                               "minLength": 1
+                           },
+                           "desc": {
+                               "type": "string",
+                               "title": "UI tooltip",
+                               "description": "UI description for selection"
+                           },
+                           "default":{
+                               "type": "object",
+                               "title": "Default dictionary",
+                               "description": "Defaults set for variable"
+                           }
+                       },
+                       "required": ["name", "desc", "default"]
+                   }
+               },
                "boolean_parameters": {
                    "type":  "array",
                    "uniqueItems": true,
@@ -121,7 +214,7 @@
                        "type": "object",
                        "uniqueItems": false,
                        "title": "Boolean option",
-                       "description": "Select boolean value",
+                       "description": "User selected boolean option",
                        "additionalProperties": false,
                        "properties":{
                            "name": {

--- a/src/server/oasisapi/schemas/model_settings.json
+++ b/src/server/oasisapi/schemas/model_settings.json
@@ -106,6 +106,12 @@
                                        "title": "Occurrence set description",
                                        "description": "Short string description for an occurrence set file",
                                        "minLength": 1
+                                   },
+                                   "max_periods": {
+                                       "type": "integer",
+                                       "title": "Max periods",
+                                       "description": "Maximum periods for this occurrence set",
+                                       "minimum": 1
                                    }
                                },
                                "required": ["id", "desc"]


### PR DESCRIPTION
example new sections:
```
   "string_parameters":[
        {   
            "name": "option_name",
            "desc": "Option for X, Y or Z",
            "default": "some_string"
        }   
      ],  
      "list_parameters":[
        {   
            "name": "option_list",
            "desc": "list is for A or B",
            "default": ["str1", "str2"]
        }   
      ],  
      "dictionary_parameters":[ 
        {   
            "name": "dictionary_option",
            "desc": "this Stores .. for ... etc",
            "default": {"k1":"v1", "k2":"v2"}
        }   
      ],  
```