### PR TITLE
Fix/tasks not failing on disconnect

### DIFF
--- a/src/conf/celeryconf.py
+++ b/src/conf/celeryconf.py
@@ -48,3 +48,7 @@ CELERY_ENABLE_UTC = True
 
 #: Celery config - concurrency
 CELERYD_CONCURRENCY = 1
+
+#: Celery config - Send task fail signal on lost worker
+CELERY_TASK_REJECT_ON_WORKER_LOST = False
+CELERY_SEND_EVENTS = True

--- a/src/conf/celeryconf.py
+++ b/src/conf/celeryconf.py
@@ -48,7 +48,3 @@ CELERY_ENABLE_UTC = True
 
 #: Celery config - concurrency
 CELERYD_CONCURRENCY = 1
-
-#: Celery config - Send task fail signal on lost worker
-CELERY_TASK_REJECT_ON_WORKER_LOST = False
-CELERY_SEND_EVENTS = True

--- a/src/model_execution_worker/tasks.py
+++ b/src/model_execution_worker/tasks.py
@@ -17,6 +17,7 @@ from contextlib import contextmanager, suppress
 from celery import Celery, signature
 from celery.task import task
 from celery.signals import worker_ready
+from celery.exceptions import WorkerLostError
 from oasislmf.utils import status
 from oasislmf.utils.exceptions import OasisException
 from oasislmf.utils.log import oasis_log
@@ -41,7 +42,6 @@ CELERY.config_from_object(celery_conf)
 logging.info("Started worker")
 
 filestore = StorageSelector(settings)
-
 
 class TemporaryDir(object):
     """Context manager for mkdtemp() with option to persist"""
@@ -203,7 +203,7 @@ def notify_api_status(analysis_pk, task_status):
     ).delay()
 
 
-@task(name='run_analysis', bind=True)
+@task(name='run_analysis', bind=True, acks_late=True)
 def start_analysis_task(self, analysis_pk, input_location, analysis_settings, complex_data_files=None):
     """Task wrapper for running an analysis.
 
@@ -217,10 +217,34 @@ def start_analysis_task(self, analysis_pk, input_location, analysis_settings, co
     Returns:
         (string) The location of the outputs.
     """
-
     logging.info("LOCK_FILE: {}".format(settings.get('worker', 'LOCK_FILE')))
     logging.info("LOCK_RETRY_COUNTDOWN_IN_SECS: {}".format(
         settings.get('worker', 'LOCK_RETRY_COUNTDOWN_IN_SECS')))
+
+
+    """
+    SAFE GUARD: - Fail any tasks received from dead workers 
+    -------------------------------------------------------
+    Setting the option `acks_late` means tasks will remain on the Queue until after 
+    a tasks has completed. If the worker goes down during the execution of `generate_input` 
+    or `start_analysis_task` then if another work is available the task will be picked up
+    on an active worker. 
+
+    When the task is picked up for a 2nd time, the new worker will reject it will 
+    'WorkerLostError' and mark the execution as failed.
+
+    Note that this is not the ideal approach, since at least one alive worker is required to
+    fail as crash workers task. 
+
+    A better method is to use either tasks signals or celery events to fail the task immediately,
+    so this should be viewed as a fallback option.
+    """
+    current_state = self.AsyncResult(self.request.id).state
+    logging.info(current_state)
+    if current_state == RUNNING_TASK_STATUS:
+        raise WorkerLostError('Received task from dead worker')
+    self.update_state(state=RUNNING_TASK_STATUS, meta={'analysis_pk': analysis_pk})
+
 
     with get_lock() as gotten:
         if not gotten:
@@ -356,8 +380,9 @@ def start_analysis(analysis_settings, input_location, complex_data_files=None):
     return output_location, traceback_location, log_location, result.returncode
 
 
-@task(name='generate_input')
-def generate_input(analysis_pk,
+@task(name='generate_input', bind=True, acks_late=True)
+def generate_input(self,
+                   analysis_pk,
                    loc_file,
                    acc_file=None,
                    info_file=None,
@@ -385,8 +410,33 @@ def generate_input(analysis_pk,
     """
     logging.info("args: {}".format(str(locals())))
     logging.info(str(get_worker_versions()))
-    notify_api_status(analysis_pk, 'INPUTS_GENERATION_STARTED')
 
+
+    """
+    SAFE GUARD: - Fail any tasks received from dead workers 
+    -------------------------------------------------------
+    Setting the option `acks_late` means tasks will remain on the Queue until after 
+    a tasks has completed. If the worker goes down during the execution of `generate_input` 
+    or `start_analysis_task` then if another work is available the task will be picked up
+    on an active worker. 
+
+    When the task is picked up for a 2nd time, the new worker will reject it will 
+    'WorkerLostError' and mark the execution as failed.
+
+    Note that this is not the ideal approach, since at least one alive worker is required to
+    fail as crash workers task. 
+
+    A better method is to use either tasks signals or celery events to fail the task immediately,
+    so this should be viewed as a fallback option.
+    """
+    current_state = self.AsyncResult(self.request.id).state
+    logging.info(current_state)
+    if current_state == RUNNING_TASK_STATUS:
+        raise WorkerLostError('Received task from dead worker')
+    self.update_state(state=RUNNING_TASK_STATUS, meta={'analysis_pk': analysis_pk})
+
+
+    notify_api_status(analysis_pk, 'INPUTS_GENERATION_STARTED')
     filestore.media_root = settings.get('worker', 'MEDIA_ROOT')
     config_path = get_oasislmf_config_path()
     tmpdir_persist = settings.getboolean('worker', 'KEEP_RUN_DIR', fallback=False)

--- a/src/server/oasisapi/analyses/tasks.py
+++ b/src/server/oasisapi/analyses/tasks.py
@@ -30,17 +30,6 @@ from ..celery import celery_app
 logger = get_task_logger(__name__)
 
 
-## Stub for task signal handler
-@signals.task_retry.connect
-@signals.task_failure.connect
-@signals.task_success.connect
-@signals.task_revoked.connect
-@signals.task_unknown.connect
-@signals.task_received.connect
-def task_signal_handler(**kwargs):
-    logger.debug('TASK SIGNAL: {}'.format(kwargs))
-
-
 def is_valid_url(url):
     if url:
         result = urlparse(url)

--- a/src/server/oasisapi/analyses/tasks.py
+++ b/src/server/oasisapi/analyses/tasks.py
@@ -5,7 +5,7 @@ import os
 
 from celery.utils.log import get_task_logger
 from celery import Task
-from celery.signals import worker_ready
+from celery import signals
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.files import File
@@ -30,6 +30,17 @@ from ..celery import celery_app
 logger = get_task_logger(__name__)
 
 
+## Stub for task signal handler
+@signals.task_retry.connect
+@signals.task_failure.connect
+@signals.task_success.connect
+@signals.task_revoked.connect
+@signals.task_unknown.connect
+@signals.task_received.connect
+def task_signal_handler(**kwargs):
+    logger.debug('TASK SIGNAL: {}'.format(kwargs))
+
+
 def is_valid_url(url):
     if url:
         result = urlparse(url)
@@ -40,7 +51,7 @@ def is_valid_url(url):
 def is_in_bucket(object_key):
     if not hasattr(default_storage, 'bucket'):
         return False
-    else:    
+    else:
         try:
             default_storage.bucket.Object(object_key).load()
             return True
@@ -52,7 +63,7 @@ def is_in_bucket(object_key):
 
 
 def store_file(reference, content_type, creator, required=True):
-    """ Returns a `RelatedFile` obejct to store 
+    """ Returns a `RelatedFile` obejct to store
 
     :param reference: Storage reference of file (url or file path)
     :type  reference: string
@@ -66,7 +77,7 @@ def store_file(reference, content_type, creator, required=True):
     :param required: Allow for None returns if set to false
     :type  required: boolean
 
-    :return: Model Object holding a Django file 
+    :return: Model Object holding a Django file
     :rtype RelatedFile
     """
 
@@ -91,8 +102,8 @@ def store_file(reference, content_type, creator, required=True):
                 creator=creator,
             )
 
-    # Download data from S3 Bucket 
-    if is_in_bucket(reference): 
+    # Download data from S3 Bucket
+    if is_in_bucket(reference):
         with TemporaryFile() as tmp_file:
             default_storage.bucket.download_fileobj(reference, tmp_file)
             fname = os.path.basename(reference)
@@ -109,7 +120,7 @@ def store_file(reference, content_type, creator, required=True):
         file_path = os.path.join(
            settings.MEDIA_ROOT,
            file_name,
-        )    
+        )
         return RelatedFile.objects.create(
             file=file_path,
             filename=file_name,
@@ -118,7 +129,7 @@ def store_file(reference, content_type, creator, required=True):
         )
     except TypeError as e:
         if not required:
-            logger.warning(f'Failed to store file reference: {reference} - {e}') 
+            logger.warning(f'Failed to store file reference: {reference} - {e}')
             return None
         else:
             raise e
@@ -188,20 +199,20 @@ class LogTaskError(Task):
                 raise e
 
 
-@worker_ready.connect
+@signals.worker_ready.connect
 def log_worker_monitor(sender, **k):
-    logger.info('DEBUG: {}'.format(settings.DEBUG))    
-    logger.info('DB_ENGINE: {}'.format(settings.DB_ENGINE))    
-    logger.info('STORAGE_TYPE: {}'.format(settings.STORAGE_TYPE))    
-    logger.info('DEFAULT_FILE_STORAGE: {}'.format(settings.DEFAULT_FILE_STORAGE))    
-    logger.info('MEDIA_ROOT: {}'.format(settings.MEDIA_ROOT))    
-    logger.info('AWS_STORAGE_BUCKET_NAME: {}'.format(settings.AWS_STORAGE_BUCKET_NAME))    
-    logger.info('AWS_LOCATION: {}'.format(settings.AWS_LOCATION))    
-    logger.info('AWS_S3_REGION_NAME: {}'.format(settings.AWS_S3_REGION_NAME))    
-    logger.info('AWS_QUERYSTRING_AUTH: {}'.format(settings.AWS_QUERYSTRING_AUTH))    
-    logger.info('AWS_QUERYSTRING_EXPIRE: {}'.format(settings.AWS_QUERYSTRING_EXPIRE))    
-    logger.info('AWS_SHARED_BUCKET: {}'.format(settings.AWS_SHARED_BUCKET))    
-    logger.info('AWS_IS_GZIPPED: {}'.format(settings.AWS_IS_GZIPPED))    
+    logger.info('DEBUG: {}'.format(settings.DEBUG))
+    logger.info('DB_ENGINE: {}'.format(settings.DB_ENGINE))
+    logger.info('STORAGE_TYPE: {}'.format(settings.STORAGE_TYPE))
+    logger.info('DEFAULT_FILE_STORAGE: {}'.format(settings.DEFAULT_FILE_STORAGE))
+    logger.info('MEDIA_ROOT: {}'.format(settings.MEDIA_ROOT))
+    logger.info('AWS_STORAGE_BUCKET_NAME: {}'.format(settings.AWS_STORAGE_BUCKET_NAME))
+    logger.info('AWS_LOCATION: {}'.format(settings.AWS_LOCATION))
+    logger.info('AWS_S3_REGION_NAME: {}'.format(settings.AWS_S3_REGION_NAME))
+    logger.info('AWS_QUERYSTRING_AUTH: {}'.format(settings.AWS_QUERYSTRING_AUTH))
+    logger.info('AWS_QUERYSTRING_EXPIRE: {}'.format(settings.AWS_QUERYSTRING_EXPIRE))
+    logger.info('AWS_SHARED_BUCKET: {}'.format(settings.AWS_SHARED_BUCKET))
+    logger.info('AWS_IS_GZIPPED: {}'.format(settings.AWS_IS_GZIPPED))
 
 @celery_app.task(name='run_register_worker')
 def run_register_worker(m_supplier, m_name, m_id, m_settings, m_version):

--- a/src/startup_worker.sh
+++ b/src/startup_worker.sh
@@ -14,8 +14,4 @@ rm -f /home/worker/celeryd.pid
 ./src/utils/wait-for-it.sh "$OASIS_CELERY_DB_HOST:$OASIS_CELERY_DB_PORT" -t 60
 
 # Start worker on init
-celery worker -A src.model_execution_worker.tasks --detach --loglevel=INFO --logfile="/var/log/oasis/worker.log" -Q "${OASIS_MODEL_SUPPLIER_ID}-${OASIS_MODEL_ID}-${OASIS_MODEL_VERSION_ID}"
-
-sleep 5
-
-tail -f /var/log/oasis/worker.log
+celery worker -A src.model_execution_worker.tasks --loglevel=INFO -Q "${OASIS_MODEL_SUPPLIER_ID}-${OASIS_MODEL_ID}-${OASIS_MODEL_VERSION_ID}" |& tee -a /var/log/oasis/worker.log

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -70,8 +70,8 @@ class StartAnalysis(TestCase):
             with SettingsPatcher(MEDIA_ROOT=media_root):
                 Path(media_root, 'not-tar-file.tar').touch()
                 Path(media_root, 'analysis_settings.json').touch()
-                self.assertRaises(InvalidInputsException, start_analysis, 
-                    os.path.join(media_root, 'analysis_settings.json'), 
+                self.assertRaises(InvalidInputsException, start_analysis,
+                    os.path.join(media_root, 'analysis_settings.json'),
                     os.path.join(media_root, 'not-tar-file.tar')
                 )
 
@@ -127,14 +127,18 @@ class StartAnalysisTask(TestCase):
     @given(pk=integers(), location=text(), analysis_settings_path=text())
     def test_lock_is_not_acquireable___retry_esception_is_raised(self, pk, location, analysis_settings_path):
         with patch('fasteners.InterProcessLock.acquire', Mock(return_value=False)), \
+             patch('src.model_execution_worker.tasks.check_worker_lost', Mock(return_value='')), \
              patch('src.model_execution_worker.tasks.notify_api_status') as api_notify:
+
             with self.assertRaises(Retry):
                 start_analysis_task(pk, location, analysis_settings_path)
 
     @given(pk=integers(), location=text(), analysis_settings_path=text())
     def test_lock_is_acquireable___start_analysis_is_ran(self, pk, location, analysis_settings_path):
         with patch('src.model_execution_worker.tasks.start_analysis', Mock(return_value=('', '', '', 0))) as start_analysis_mock, \
-        patch('src.model_execution_worker.tasks.notify_api_status') as api_notify:
+             patch('src.model_execution_worker.tasks.check_worker_lost', Mock(return_value='')), \
+             patch('src.model_execution_worker.tasks.notify_api_status') as api_notify:
+
             start_analysis_task.update_state = Mock()
             start_analysis_task(pk, location, analysis_settings_path)
 


### PR DESCRIPTION
* Added `acks_late` option to input generation and analyses run tasks
* Added `WorkerLostError` check when reading tasks 
* Set the worker containers to exit if the celery processes die


## How it works
If a worker is killed while processing a task it will now still exist on the queue, where as before it would be lost. 
That task will then get picked up for a 2nd time, either when the worker restarts or from another consumer on the queue. 
If a task is from a crashed worker, then that analyses is marked as failed with the following stack trace.

```
~/repos/models/piwind$ oasislmf api run 
Creating portfolio
File uploaded: tests/inputs/SourceLocOEDPiWind10.csv
File uploaded: tests/inputs/SourceAccOEDPiWind.csv
File uploaded: tests/inputs/SourceReinsInfoOEDPiWind.csv
File uploaded: tests/inputs/SourceReinsScopeOEDPiWind.csv
Running model:
   ...
 
Input Generation: Executing (id=135)
Inputs Generation: Complete (id=135)
Analysis Run: Starting (id=135)
Analysis Run: Queued (id=135)
Analysis Run: Executing (id=135)
Analysis Run: Failed (id=135)
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/celery/app/trace.py", line 385, in trace_task
    R = retval = fun(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/celery/app/trace.py", line 650, in __protected_call__
    return self.run(*args, **kwargs)
  File "/home/worker/src/model_execution_worker/tasks.py", line 264, in start_analysis_task
    check_worker_lost(self, analysis_pk)
  File "/home/worker/src/model_execution_worker/tasks.py", line 123, in check_worker_lost
    'Task received from dead worker - A worker container crashed when executing a task from analysis_id={}'.format(analysis_pk)
billiard.exceptions.WorkerLostError: Task received from dead worker - A worker container crashed when executing a task from analysis_id=135
```