### PR TITLE
Disable task prefetch in worker - blocks idle workers from executing

### DIFF
--- a/src/conf/celeryconf.py
+++ b/src/conf/celeryconf.py
@@ -40,8 +40,8 @@ CELERY_RESULT_SERIALIZER = 'json'
 #: Celery config - accept content type
 CELERY_ACCEPT_CONTENT = ['json']
 
-#: Celery config - timezone
-CELERY_TIMEZONE = 'Europe/London'
+#: Celery config - timezone (default == UTC)
+# CELERY_TIMEZONE = 'Europe/London'
 
 #: Celery config - enable UTC
 CELERY_ENABLE_UTC = True

--- a/src/conf/celeryconf.py
+++ b/src/conf/celeryconf.py
@@ -48,3 +48,7 @@ CELERY_ENABLE_UTC = True
 
 #: Celery config - concurrency
 CELERYD_CONCURRENCY = 1
+
+#: Disable celery task prefetch
+#: https://docs.celeryproject.org/en/stable/userguide/configuration.html#std-setting-worker_prefetch_multiplier
+CELERYD_PREFETCH_MULTIPLIER = 1

--- a/src/startup_worker.sh
+++ b/src/startup_worker.sh
@@ -14,4 +14,4 @@ rm -f /home/worker/celeryd.pid
 ./src/utils/wait-for-it.sh "$OASIS_CELERY_DB_HOST:$OASIS_CELERY_DB_PORT" -t 60
 
 # Start worker on init
-celery --app src.model_execution_worker.tasks worker --loglevel=INFO -Q "${OASIS_MODEL_SUPPLIER_ID}-${OASIS_MODEL_ID}-${OASIS_MODEL_VERSION_ID}" |& tee -a /var/log/oasis/worker.log
+celery --app src.model_execution_worker.tasks worker --concurrency=1 --loglevel=INFO -Q "${OASIS_MODEL_SUPPLIER_ID}-${OASIS_MODEL_ID}-${OASIS_MODEL_VERSION_ID}" |& tee -a /var/log/oasis/worker.log


### PR DESCRIPTION
Fix for issue #387  - Prevent workers from reserving more than 1 task in advance: 
https://docs.celeryproject.org/en/latest/userguide/optimizing.html#reserve-one-task-at-a-time