### PR TITLE
Feature/413 docker container scanning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
+language: python
+python:
+  - 3.6
+  - "pypy3"  
 install:
   - pip install safety
-
 script:
   - safety check -r requirements-server.txt
   - safety check -r requirements-worker.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+install:
+  - pip install safety
+
+script:
+  - safety check -r requirements-server.txt
+  - safety check -r requirements-worker.txt

--- a/Dockerfile.model_worker
+++ b/Dockerfile.model_worker
@@ -1,27 +1,32 @@
-# ---- STAGE 1 ----- Build python packages
+# ---- STAGE 1 -----
 FROM ubuntu:20.04 AS build-packages
 
+# Build python packages
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y libspatialindex-dev git curl g++ build-essential libtool autoconf automake python3 python3-pip
 COPY ./requirements-worker.txt ./requirements.txt
 RUN pip3 install --user --no-warn-script-location -r ./requirements.txt
 
 
-# ---- STAGE 2 ---- Create worker image
+# ---- STAGE 2 ----
 FROM ubuntu:20.04
 RUN apt-get update && apt-get install -y --no-install-recommends vim python3 python3-pip libspatialindex-dev curl procps && \
     rm -rf /var/lib/apt/lists/*
 
+# Copy built python packages 
+COPY --from=build-packages /root/.local /root/.local
+ENV PATH=/root/.local/bin:$PATH
+
 # Enviroment setup
-ENV PATH=/home/worker/.local/bin:$PATH
 ENV DEBIAN_FRONTEND=noninteractive
 ENV OASIS_MEDIA_ROOT=/shared-fs
 ENV OASIS_ENV_OVERRIDE=true
 
+# Setup worker dir and user
 RUN adduser --shell /bin/bash --disabled-password --gecos "" worker
 WORKDIR /home/worker
 
-COPY --from=build-packages /root/.local /root/.local
+# Copy in worker files 
 COPY ./src/startup_worker.sh ./startup.sh
 COPY ./src/startup_tester.sh ./runtest
 COPY ./src/startup_tester_S3.sh ./runtest_S3
@@ -35,11 +40,11 @@ COPY ./src/utils/worker_bashrc /root/.bashrc
 COPY ./tests/integration /home/worker/tests/integration
 COPY ./VERSION ./
 
+# Add required directories 
 RUN mkdir -p /var/oasis && \
     mkdir -p /var/log/oasis && \
     touch /var/log/oasis/worker.log && \
     chmod 777 /var/log/oasis/worker.log
-
 RUN chmod -R 777 /home/worker /var/log/oasis /var/oasis && \
     chown -R worker /home/worker && \
     chown -R worker /var/oasis && \

--- a/Dockerfile.model_worker
+++ b/Dockerfile.model_worker
@@ -21,7 +21,7 @@ ENV OASIS_ENV_OVERRIDE=true
 RUN adduser --shell /bin/bash --disabled-password --gecos "" worker
 WORKDIR /home/worker
 
-COPY --from=build-packages /root/.local /home/worker/.local
+COPY --from=build-packages /root/.local /root/.local
 COPY ./src/startup_worker.sh ./startup.sh
 COPY ./src/startup_tester.sh ./runtest
 COPY ./src/startup_tester_S3.sh ./runtest_S3

--- a/Dockerfile.model_worker
+++ b/Dockerfile.model_worker
@@ -1,27 +1,27 @@
-# ---- STAGE 1 -----
+# ---- STAGE 1 ----- Build python packages
 FROM ubuntu:20.04 AS build-packages
 
-# set noninteractive installation
 ENV DEBIAN_FRONTEND=noninteractive
-
 RUN apt-get update && apt-get install -y libspatialindex-dev git curl g++ build-essential libtool autoconf automake python3 python3-pip
 COPY ./requirements-worker.txt ./requirements.txt
 RUN pip3 install --user --no-warn-script-location -r ./requirements.txt
 
 
-# ---- STAGE 2 ---- DEBIAN
+# ---- STAGE 2 ---- Create worker image
 FROM ubuntu:20.04
-RUN apt-get update && apt-get install -y --no-install-recommends python3 python3-pip libspatialindex-dev curl procps && \ 
+RUN apt-get update && apt-get install -y --no-install-recommends vim python3 python3-pip libspatialindex-dev curl procps && \
     rm -rf /var/lib/apt/lists/*
 
-COPY --from=build-packages /root/.local /root/.local
-ENV PATH=/root/.local/bin:$PATH
-
+# Enviroment setup
+ENV PATH=/home/worker/.local/bin:$PATH
+ENV DEBIAN_FRONTEND=noninteractive
 ENV OASIS_MEDIA_ROOT=/shared-fs
 ENV OASIS_ENV_OVERRIDE=true
+
 RUN adduser --shell /bin/bash --disabled-password --gecos "" worker
 WORKDIR /home/worker
 
+COPY --from=build-packages /root/.local /home/worker/.local
 COPY ./src/startup_worker.sh ./startup.sh
 COPY ./src/startup_tester.sh ./runtest
 COPY ./src/startup_tester_S3.sh ./runtest_S3
@@ -43,6 +43,6 @@ RUN mkdir -p /var/oasis && \
 RUN chmod -R 777 /home/worker /var/log/oasis /var/oasis && \
     chown -R worker /home/worker && \
     chown -R worker /var/oasis && \
-	chown -R worker /var/log
+    chown -R worker /var/log
 
 ENTRYPOINT ./startup.sh

--- a/Dockerfile.model_worker_debug
+++ b/Dockerfile.model_worker_debug
@@ -1,31 +1,23 @@
-# ---- STAGE 1 -----
-FROM ubuntu:20.04 AS build-packages
-
-# set noninteractive installation
-ENV DEBIAN_FRONTEND=noninteractive
-
-RUN apt-get update && apt-get install -y libspatialindex-dev git curl g++ build-essential libtool autoconf automake python3 python3-pip
-COPY ./requirements-worker.txt ./requirements.txt
-RUN pip3 install --user --no-warn-script-location -r ./requirements.txt
-
-
-# ---- STAGE 2 ---- DEBIAN
-FROM ubuntu:20.04
-RUN apt-get update && apt-get install -y --no-install-recommends python3 python3-pip libspatialindex-dev curl procps && \ 
-    rm -rf /var/lib/apt/lists/*
-
-COPY --from=build-packages /root/.local /root/.local
-ENV PATH=/root/.local/bin:$PATH
+FROM python:3.8
 
 ENV OASIS_MEDIA_ROOT=/shared-fs
 ENV OASIS_ENV_OVERRIDE=true
+
+RUN apt-get update && apt-get install -y --no-install-recommends git vim libspatialindex-dev && rm -rf /var/lib/apt/lists/*
+
 RUN adduser --shell /bin/bash --disabled-password --gecos "" worker
 WORKDIR /home/worker
 
+# Install requirements
+COPY ./requirements-worker.txt ./requirements.txt
+RUN pip install -r ./requirements.txt
+
+# Copy startup script + server config
 COPY ./src/startup_worker.sh ./startup.sh
 COPY ./src/startup_tester.sh ./runtest
 COPY ./src/startup_tester_S3.sh ./runtest_S3
 COPY ./conf.ini ./
+
 COPY ./src/__init__.py ./src/
 COPY ./src/common ./src/common/
 COPY ./src/conf ./src/conf/

--- a/jenkins/oasis_platform.groovy
+++ b/jenkins/oasis_platform.groovy
@@ -181,7 +181,7 @@ node {
                         sh PIPELINE + " build_image ${docker_api} ${image_api} ${env.TAG_RELEASE}"
 
                     }
-                },
+                }
                 stage('Scan: API server'){
                     dir(oasis_workspace) {
                         // Genrate a report
@@ -203,7 +203,7 @@ node {
                         }
                         sh PIPELINE + " build_image ${docker_worker} ${image_worker} ${env.TAG_RELEASE}"
                     }
-                },
+                }
                 stage('Scan: Model worker'){
                     dir(oasis_workspace) {
                         // Genrate a report


### PR DESCRIPTION
## CVE container checks
Uses [Trivy](https://github.com/aquasecurity/trivy), an Open Source container scanning tool by Aqua Secure. 

The test failure threshold can be set when running a build in Jenkins using `SCAN_IMAGE_VULNERABILITIES`
![scan_set](https://user-images.githubusercontent.com/9889973/100442725-660d9980-30a0-11eb-90f7-1267192daa36.png)

If set to a blank string the scan stage is skipped, otherwise the build will fail if a CVE is found at the selected levels. The valid options are `UNKNOWN`, `LOW`, `MEDIUM`, `HIGH` and  `CRITICAL`.


Reports are archived in CI, each build has a CVE report for the base server and worker containers: 
* **artifact/cve_reports/api-server.txt**
```
+------------+------------------+----------+-------------------+---------------+--------------------------------+
|  LIBRARY   | VULNERABILITY ID | SEVERITY | INSTALLED VERSION | FIXED VERSION |             TITLE              |
+------------+------------------+----------+-------------------+---------------+--------------------------------+
| musl-utils | CVE-2020-28928   | UNKNOWN  | 1.1.24-r2         | 1.1.24-r3     | In musl libc through 1.2.1,    |
|            |                  |          |                   |               | wcsnrtombs mishandles          |
|            |                  |          |                   |               | particular combinations of     |
|            |                  |          |                   |               | destination buffer...          |
+------------+------------------+----------+-------------------+---------------+--------------------------------+
```

*  **artifact/cve_reports/model-worker.txt**
```
+------------------+------------------+----------+------------------------+---------------+--------------------------------+
|     LIBRARY      | VULNERABILITY ID | SEVERITY |   INSTALLED VERSION    | FIXED VERSION |             TITLE              |
+------------------+------------------+----------+------------------------+---------------+--------------------------------+
| bash             | CVE-2019-18276   | LOW      | 5.0-6ubuntu1.1         |               | bash: when effective UID is    |
|                  |                  |          |                        |               | not equal to its real UID      |
|                  |                  |          |                        |               | the...                         |
+------------------+------------------+          +------------------------+---------------+--------------------------------+
| coreutils        | CVE-2016-2781    |          | 8.30-3ubuntu2          |               | coreutils: Non-privileged      |
|                  |                  |          |                        |               | session can escape to the      |
|                  |                  |          |                        |               | parent session in chroot       |
+------------------+------------------+          +------------------------+---------------+--------------------------------+
| gpgv             | CVE-2019-13050   |          | 2.2.19-3ubuntu2        |               | GnuPG: interaction between the |
|                  |                  |          |                        |               | sks-keyserver code and GnuPG   |
|                  |                  |          |                        |               | allows for a Certificate...    |
  ...
```

## Switched model_worker base to ubuntu
The Debian based python images had multiple  `HIGH` and  `CRITICAL` CVE. Solved by moving to a 'lighter' ubuntu base image 

### Debain CVE summary
```
coreoasis/model_worker:413-docker-container-scanning-11 (debian 10.6)

=====================================================================

Total: 1411 (UNKNOWN: 5, LOW: 1053, MEDIUM: 224, HIGH: 128, CRITICAL: 1)
```

### ubuntu CVE summary
```
coreoasis/model_worker:413-docker-container-scanning-20 (ubuntu 20.04)

======================================================================

Total: 24 (UNKNOWN: 0, LOW: 19, MEDIUM: 5, HIGH: 0, CRITICAL: 0)
``` 