### PR TITLE
Set JSON schema's to be inline with oasislmf

### DIFF
--- a/src/server/oasisapi/schemas/analysis_settings.json
+++ b/src/server/oasisapi/schemas/analysis_settings.json
@@ -39,6 +39,16 @@
             "description": "The threshold at which groun-up losses will be capped.",
             "default": 0
         },
+        "return_periods": {
+            "type": "array",
+            "minItems": 1,
+            "title": "User set return periods",
+            "description": "List of return periods as integers '[10, 100, 1000 .. etc]'",
+            "items": {
+                "type": "integer",
+                "minimum": 1
+            }
+        },    
         "model_settings": {
             "type": "object",
             "title": "Model settings",

--- a/src/server/oasisapi/schemas/model_settings.json
+++ b/src/server/oasisapi/schemas/model_settings.json
@@ -140,6 +140,7 @@
                                     "lec",
                                     "aep",
                                     "oep",
+                                    "summarycalc",
                                     "full_uncertainty_aep",
                                     "full_uncertainty_oep",
                                     "sample_mean_aep",


### PR DESCRIPTION
Missed JSON schema update for Oasislmf changes: 
* Added return periods option to `analysis_settings.json` [updated-schema.zip](https://github.com/OasisLMF/OasisPlatform/files/5830997/updated-schema.zip)
