### PR TITLE
Fix/454 boto3 logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,12 @@ admin interface or the api setting:
         version_id: "1",
     }
 
+### Running outside of a container 
+
+The server can be run directly in python by `./manage.py runserver`, note that if the server has `debug=false` set (the default value)
+then the command `./manage.py collectstatic` must be executed first
+
+
 ### Testing
 
 To test the code style run::

--- a/conf.ini
+++ b/conf.ini
@@ -11,7 +11,7 @@ MEDIA_ROOT = /shared-fs/
 LOG_FILENAME = oasis_api_worker.log
 STORAGE_TYPE = shared-fs
 KEEP_RUN_DIR = False
-AWS_LOG_LEVEL = CRITICAL
+AWS_LOG_LEVEL = WARNING
 
 [server]
 ALLOWED_HOSTS=*

--- a/conf.ini
+++ b/conf.ini
@@ -11,6 +11,7 @@ MEDIA_ROOT = /shared-fs/
 LOG_FILENAME = oasis_api_worker.log
 STORAGE_TYPE = shared-fs
 KEEP_RUN_DIR = False
+AWS_LOG_LEVEL = CRITICAL
 
 [server]
 ALLOWED_HOSTS=*
@@ -18,16 +19,13 @@ DO_GZIP_RESPONSE = True
 SECRET_KEY=OmuudYrSFVxcIVIWf6YlYdkP6NXApP
 TOKEN_SIGINING_KEY=JsVzvtWw2EwksaYCZsMmd2zmm
 TOKEN_REFRESH_ROTATE = True
-AWS_SHARED_BUCKET=True
-AWS_LOCATION=server
 
-#   --- Example settings ---  #
-#TOKEN_ACCESS_LIFETIME = minutes=0, hours=0, days=0, weeks=0
 #TOKEN_REFRESH_LIFETIME = minutes=0, hours=0, days=0, weeks=0
-#STORAGE_TYPE = S3
+STORAGE_TYPE = S3
 #AWS_BUCKET_NAME=example-bucket
-#AWS_ACCESS_KEY_ID=<server-key-id>
-#AWS_SECRET_ACCESS_KEY=<worker-bucket-name>
+#AWS_S3_ENDPOINT_URL=http://localhost:4572
+#AWS_ACCESS_KEY_ID=foo
+#AWS_SECRET_ACCESS_KEY=bar
 #AWS_QUERYSTRING_EXPIRE=180
 #AWS_QUERYSTRING_AUTH=True
 

--- a/conf.ini
+++ b/conf.ini
@@ -21,7 +21,7 @@ TOKEN_SIGINING_KEY=JsVzvtWw2EwksaYCZsMmd2zmm
 TOKEN_REFRESH_ROTATE = True
 
 #TOKEN_REFRESH_LIFETIME = minutes=0, hours=0, days=0, weeks=0
-STORAGE_TYPE = S3
+#STORAGE_TYPE = S3
 #AWS_BUCKET_NAME=example-bucket
 #AWS_S3_ENDPOINT_URL=http://localhost:4572
 #AWS_ACCESS_KEY_ID=foo

--- a/src/common/shared.py
+++ b/src/common/shared.py
@@ -1,0 +1,14 @@
+import logging
+
+def set_aws_log_level(log_level):
+    # Set log level for s3boto3
+    try:
+        LOG_LEVEL = getattr(logging, log_level.upper())    
+    except AttributeError:
+        LOG_LEVEL = logging.CRITICAL    
+    
+    logging.getLogger('boto3').setLevel(LOG_LEVEL)
+    logging.getLogger('botocore').setLevel(LOG_LEVEL)
+    logging.getLogger('nose').setLevel(LOG_LEVEL)
+    logging.getLogger('s3transfer').setLevel(LOG_LEVEL)
+    logging.getLogger('urllib3').setLevel(LOG_LEVEL)

--- a/src/common/shared.py
+++ b/src/common/shared.py
@@ -3,10 +3,10 @@ import logging
 def set_aws_log_level(log_level):
     # Set log level for s3boto3
     try:
-        LOG_LEVEL = getattr(logging, log_level.upper())    
+        LOG_LEVEL = getattr(logging, log_level.upper())
     except AttributeError:
-        LOG_LEVEL = logging.CRITICAL    
-    
+        LOG_LEVEL = logging.WARNING
+
     logging.getLogger('boto3').setLevel(LOG_LEVEL)
     logging.getLogger('botocore').setLevel(LOG_LEVEL)
     logging.getLogger('nose').setLevel(LOG_LEVEL)

--- a/src/model_execution_worker/storage_manager.py
+++ b/src/model_execution_worker/storage_manager.py
@@ -11,8 +11,9 @@ from urllib.parse import urlparse, urlsplit, parse_qsl
 from urllib.request import urlopen
 
 from oasislmf.utils.exceptions import OasisException
-
 from botocore.exceptions import ClientError as S3_ClientError
+
+from ..common.shared import set_aws_log_level
 
 LOG_FILE_SUFFIX = 'txt'
 ARCHIVE_FILE_SUFFIX = 'tar.gz'
@@ -34,6 +35,7 @@ def StorageSelector(settings_conf):
     if selected_storage in ['local-fs', 'shared-fs']:
         return BaseStorageConnector(settings_conf)
     elif selected_storage in ['aws-s3', 'aws', 's3']:
+        
         return AwsObjectStore(settings_conf)
     else:
         raise OasisException('Invalid value for STORAGE_TYPE: {}'.format(selected_storage))
@@ -347,6 +349,7 @@ class AwsObjectStore(BaseStorageConnector):
         self.verify = settings.get('worker', 'AWS_S3_VERIFY', fallback=None)
         self.max_memory_size = settings.get('worker', 'AWS_S3_MAX_MEMORY_SIZE', fallback=0)
         self.shared_bucket = settings.getboolean('worker', 'AWS_SHARED_BUCKET', fallback=False)
+        self.aws_log_level = settings.get('worker', 'AWS_LOG_LEVEL', fallback='')
         self.gzip_content_types = settings.get('worker', 'GZIP_CONTENT_TYPES', fallback=(
             'text/css',
             'text/javascript',
@@ -354,6 +357,7 @@ class AwsObjectStore(BaseStorageConnector):
             'application/x-javascript',
             'image/svg+xml',
         ))
+        set_aws_log_level(self.aws_log_level)
         super(AwsObjectStore, self).__init__(settings)
 
 

--- a/src/model_execution_worker/tasks.py
+++ b/src/model_execution_worker/tasks.py
@@ -201,6 +201,7 @@ def register_worker(sender, **k):
         logging.info("AWS_ACCESS_KEY_ID: {}".format(settings.get('worker', 'AWS_ACCESS_KEY_ID', fallback='None')))
         logging.info("AWS_QUERYSTRING_EXPIRE: {}".format(settings.get('worker', 'AWS_QUERYSTRING_EXPIRE', fallback='None')))
         logging.info("AWS_QUERYSTRING_AUTH: {}".format(settings.get('worker', 'AWS_QUERYSTRING_AUTH', fallback='None')))
+        logging.info('AWS_LOG_LEVEL: {}'.format(settings.get('worker', 'AWS_LOG_LEVEL', fallback='None')))
 
     # Optional ENV
     logging.info("MODEL_DATA_DIRECTORY: {}".format(settings.get('worker', 'MODEL_DATA_DIRECTORY', fallback='/home/worker/model')))

--- a/src/server/oasisapi/analyses/tasks.py
+++ b/src/server/oasisapi/analyses/tasks.py
@@ -220,6 +220,7 @@ def log_worker_monitor(sender, **k):
     logger.info('MEDIA_ROOT: {}'.format(settings.MEDIA_ROOT))
     logger.info('AWS_STORAGE_BUCKET_NAME: {}'.format(settings.AWS_STORAGE_BUCKET_NAME))
     logger.info('AWS_LOCATION: {}'.format(settings.AWS_LOCATION))
+    logger.info('AWS_LOG_LEVEL: {}'.format(settings.AWS_LOG_LEVEL))
     logger.info('AWS_S3_REGION_NAME: {}'.format(settings.AWS_S3_REGION_NAME))
     logger.info('AWS_QUERYSTRING_AUTH: {}'.format(settings.AWS_QUERYSTRING_AUTH))
     logger.info('AWS_QUERYSTRING_EXPIRE: {}'.format(settings.AWS_QUERYSTRING_EXPIRE))

--- a/src/server/oasisapi/settings.py
+++ b/src/server/oasisapi/settings.py
@@ -18,6 +18,7 @@ from django.core.exceptions import ImproperlyConfigured
 
 from ...conf import iniconf  # noqa
 from ...conf.celeryconf import *  # noqa
+from ...common.shared import set_aws_log_level
 
 IN_TEST = 'test' in sys.argv
 
@@ -161,6 +162,7 @@ AWS_S3_CUSTOM_DOMAIN = iniconf.settings.get('server', 'AWS_S3_CUSTOM_DOMAIN', fa
 AWS_S3_ENDPOINT_URL = iniconf.settings.get('server', 'AWS_S3_ENDPOINT_URL', fallback=None)
 AWS_LOCATION = iniconf.settings.get('server', 'AWS_LOCATION', fallback='')
 AWS_S3_REGION_NAME = iniconf.settings.get('server', 'AWS_S3_REGION_NAME', fallback=None)
+AWS_LOG_EVEL = iniconf.settings.get('server', 'aws_log_level', fallback="")
 
 # Presigned generated URLs for private buckets
 AWS_QUERYSTRING_AUTH = iniconf.settings.getboolean('server', 'AWS_QUERYSTRING_AUTH', fallback=False)
@@ -188,6 +190,8 @@ if STORAGE_TYPE in LOCAL_FS:
 elif STORAGE_TYPE in AWS_S3:
     # AWS S3 Object Store via `Django-Storages`
     DEFAULT_FILE_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
+    set_aws_log_level(AWS_LOG_EVEL)
+    
 else:
     raise ImproperlyConfigured('Invalid value for STORAGE_TYPE: {}'.format(STORAGE_TYPE))
 


### PR DESCRIPTION
Added new config option `AWS_LOG_LEVEL`  which sets the boto3 loggers independently of the general logging level. 

* setting `AWS_LOG_LEVEL=CRITICAL` will hide problematic output from issue #454  (new default)
* using `AWS_LOG_LEVEL=DEBUG` will return logging to previous behaviour  