### PR TITLE
call S3 object waiter after invoking copy

### DIFF
--- a/src/server/oasisapi/portfolios/serializers.py
+++ b/src/server/oasisapi/portfolios/serializers.py
@@ -198,6 +198,7 @@ class PortfolioStorageSerializer(serializers.ModelSerializer):
                 bucket = default_storage.bucket
                 stored_file = default_storage.open(new_related_file.file.name)
                 stored_file.obj.copy({"Bucket": bucket.name, "Key": validated_data[field]})
+                stored_file.obj.wait_until_exists()
 
             # Shared-fs
             else:


### PR DESCRIPTION
Possible fix for #455 using: [S3.Object.wait_until_exists()](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html?highlight=query#S3.Object.wait_until_exists)