### PR TITLE
Add cancel any endpoint

### DIFF
--- a/src/server/oasisapi/analyses/models.py
+++ b/src/server/oasisapi/analyses/models.py
@@ -79,6 +79,9 @@ class Analysis(TimeStampedModel):
     def get_absolute_cancel_url(self, request=None):
         return reverse('analysis-cancel', kwargs={'version': 'v1', 'pk': self.pk}, request=request)
 
+    def get_absolute_cancel_analysis_url(self, request=None):
+        return reverse('analysis-cancel-analysis-run', kwargs={'version': 'v1', 'pk': self.pk}, request=request)
+
     def get_absolute_generate_inputs_url(self, request=None):
         return reverse('analysis-generate-inputs', kwargs={'version': 'v1', 'pk': self.pk}, request=request)
 

--- a/src/server/oasisapi/analyses/tests/test_analysis_api.py
+++ b/src/server/oasisapi/analyses/tests/test_analysis_api.py
@@ -279,7 +279,7 @@ class AnalysisCancel(WebTestMixin, TestCase):
     def test_user_is_not_authenticated___response_is_forbidden(self):
         analysis = fake_analysis()
 
-        response = self.app.post(analysis.get_absolute_cancel_url(), expect_errors=True)
+        response = self.app.post(analysis.get_absolute_cancel_analysis_url(), expect_errors=True)
         self.assertIn(response.status_code, [401,403])
 
     def test_user_is_authenticated_object_does_not_exist___response_is_404(self):
@@ -297,12 +297,12 @@ class AnalysisCancel(WebTestMixin, TestCase):
         self.assertEqual(404, response.status_code)
 
     def test_user_is_authenticated_object_exists___cancel_is_called(self):
-        with patch('src.server.oasisapi.analyses.models.Analysis.cancel', autospec=True) as cancel_mock:
+        with patch('src.server.oasisapi.analyses.models.Analysis.cancel_analysis', autospec=True) as cancel_mock:
             user = fake_user()
             analysis = fake_analysis()
 
             self.app.post(
-                analysis.get_absolute_cancel_url(),
+                analysis.get_absolute_cancel_analysis_url(),
                 headers={
                     'Authorization': 'Bearer {}'.format(AccessToken.for_user(user))
                 }

--- a/src/server/oasisapi/analyses/tests/test_analysis_model.py
+++ b/src/server/oasisapi/analyses/tests/test_analysis_model.py
@@ -29,7 +29,7 @@ class AnalysisCancel(WebTestMixin, TestCase):
         analysis = fake_analysis(status=Analysis.status_choices.RUN_STARTED, run_task_id=task_id)
 
         with patch('src.server.oasisapi.analyses.models.AsyncResult', res_factory):
-            analysis.cancel()
+            analysis.cancel_analysis()
 
             self.assertEqual(Analysis.status_choices.RUN_CANCELLED, analysis.status)
             self.assertTrue(res_factory.revoke_called)
@@ -49,9 +49,9 @@ class AnalysisCancel(WebTestMixin, TestCase):
             analysis = fake_analysis(status=status, run_task_id=task_id)
 
             with self.assertRaises(ValidationError) as ex:
-                analysis.cancel()
+                analysis.cancel_analysis()
 
-            self.assertEqual({'status': ['Analysis is not running or queued']}, ex.exception.detail)
+            self.assertEqual({'status': ['Analysis execution is not running or queued']}, ex.exception.detail)
             self.assertEqual(status, analysis.status)
             self.assertFalse(res_factory.revoke_called)
 
@@ -159,8 +159,8 @@ class AnalysisCancelInputGeneration(WebTestMixin, TestCase):
 class AnalysisGenerateInputs(WebTestMixin, TestCase):
     @given(
         status=sampled_from([c for c in Analysis.status_choices._db_values if c not in [
-            Analysis.status_choices.INPUTS_GENERATION_QUEUED, 
-            Analysis.status_choices.INPUTS_GENERATION_STARTED, 
+            Analysis.status_choices.INPUTS_GENERATION_QUEUED,
+            Analysis.status_choices.INPUTS_GENERATION_STARTED,
             Analysis.status_choices.RUN_QUEUED,
             Analysis.status_choices.RUN_STARTED
         ]]),

--- a/src/server/oasisapi/analyses/viewsets.py
+++ b/src/server/oasisapi/analyses/viewsets.py
@@ -183,16 +183,27 @@ class AnalysisViewSet(viewsets.ModelViewSet):
         obj.run(request.user)
         return Response(AnalysisSerializer(instance=obj, context=self.get_serializer_context()).data)
 
+
     @swagger_auto_schema(responses={200: AnalysisSerializer})
     @action(methods=['post'], detail=True)
     def cancel(self, request, pk=None, version=None):
         """
-        Cancels a currently running analysis. The analysis must have one of the following statuses, `NEW`, `INPUTS_GENERATION_ERROR`,
-        `INPUTS_GENERATION_CANCELED`, `READY`, `RUN_COMPLETED`, `RUN_CANCELLED` or
-        `RUN_ERROR`.
+        Cancels either input generation or analysis execution depending on the active stage. 
+        The analysis must have one of the following statuses, `INPUTS_GENERATION_QUEUED`, `INPUTS_GENERATION_STARTED`, `RUN_QUEUED` or `RUN_STARTED`
         """
         obj = self.get_object()
-        obj.cancel()
+        obj.cancel_any()
+        return Response(AnalysisSerializer(instance=obj, context=self.get_serializer_context()).data)
+
+
+    @swagger_auto_schema(responses={200: AnalysisSerializer})
+    @action(methods=['post'], detail=True)
+    def cancel_analysis_run(self, request, pk=None, version=None):
+        """
+        Cancels a running analysis execution. The analysis must have one of the following statuses, `RUN_QUEUED` or `RUN_STARTED`
+        """
+        obj = self.get_object()
+        obj.cancel_analysis()
         return Response(AnalysisSerializer(instance=obj, context=self.get_serializer_context()).data)
 
     @swagger_auto_schema(responses={200: AnalysisSerializer})
@@ -200,9 +211,7 @@ class AnalysisViewSet(viewsets.ModelViewSet):
     def generate_inputs(self, request, pk=None, version=None):
         """
         Generates the inputs for the analysis based on the portfolio.
-        The analysis must have one of the following statuses, `NEW`, `INPUTS_GENERATION_ERROR`,
-        `INPUTS_GENERATION_CANCELED`, `READY`, `RUN_COMPLETED`, `RUN_CANCELLED` or
-        `RUN_ERROR`.
+        The analysis must have one of the following statuses, `INPUTS_GENERATION_QUEUED` or `INPUTS_GENERATION_STARTED`
         """
         obj = self.get_object()
         obj.generate_inputs(request.user)


### PR DESCRIPTION
Feature for #467

## Updated endpoints: 

* `​/v1​/analyses​/{id}​/cancel​/` - Cancels either input generation or analysis run depending on the active stage.
* `/v1/analyses/{id}/cancel_analysis_run/` - Cancels a running analysis execution. 
* `/v1/analyses/{id}/cancel_generate_inputs/` - (no change) Cancels inputs generation.