### PR TITLE
Update bash promp to show oasis version number

### DIFF
--- a/src/utils/server_bashrc
+++ b/src/utils/server_bashrc
@@ -3,7 +3,8 @@
 # Note: PS1 and umask are already set in /etc/profile. You should not
 # need this unless you want different defaults for root.
 # umask 022
-PS1='\[\033[01;31m\]oasis-api(\h)\[\033[01;34m\] \w \$\[\033[00m\] '
+VER=$(cat /var/www/oasis/VERSION | sed -nre 's/^[^0-9]*(([0-9]+\.)*[0-9]+).*/\1/p')
+PS1='\[\033[01;31m\]oasis-api($VER)\[\033[01;34m\] \h \w \$\[\033[00m\] '
 
 # You may uncomment the following lines if you want `ls' to be colorized:
 export LS_OPTIONS='--color=auto'

--- a/src/utils/worker_bashrc
+++ b/src/utils/worker_bashrc
@@ -3,7 +3,8 @@
 # Note: PS1 and umask are already set in /etc/profile. You should not
 # need this unless you want different defaults for root.
 # umask 022
-PS1='\[\033[01;31m\]oasis-worker(\h)\[\033[01;34m\] \w \$\[\033[00m\] '
+VER=$(cat /home/worker/VERSION | sed -nre 's/^[^0-9]*(([0-9]+\.)*[0-9]+).*/\1/p')
+PS1='\[\033[01;31m\]oasis-worker($VER)\[\033[01;34m\] \h \w \$\[\033[00m\] '
 
 # You may uncomment the following lines if you want `ls' to be colorized:
 export LS_OPTIONS='--color=auto'


### PR DESCRIPTION
Small update to show the Oasis version number in bash: 
```
oasis-worker(1.16.0) 61103fa3fe30 /home/worker #
oasis-api(1.16.0) 21e303ed9d89 /var/www/oasis #
```