### PR TITLE
Fix issue #498 - error linking S3 object keys

### DIFF
--- a/src/server/oasisapi/portfolios/serializers.py
+++ b/src/server/oasisapi/portfolios/serializers.py
@@ -186,7 +186,7 @@ class PortfolioStorageSerializer(serializers.ModelSerializer):
             # S3 storage - File copy needed
             if hasattr(default_storage, 'bucket'):
                 fname = path.basename(validated_data[field])
-                new_file = ContentFile('')
+                new_file = ContentFile(b'')
                 new_file.name = default_storage.get_alternative_name(fname, '')
                 new_related_file = RelatedFile.objects.create(
                     file=new_file,


### PR DESCRIPTION
<!--start_release_notes-->
### Fixed S3 object linking endpoint 
Fix for connecting S3 files to a new portfolio using the endpoint POST `/v1/portfolios/{id}/storage_links` 
Similar issue as #472 , Affected version (1.16.0)
<!--end_release_notes-->