### PR TITLE
Update urllib3 for CVE-2021-33503

### DIFF
--- a/requirements-server.txt
+++ b/requirements-server.txt
@@ -74,7 +74,7 @@ sqlparse==0.4.1           # via django
 twisted[tls]==21.2.0      # via daphne
 txaio==21.2.1             # via autobahn
 uritemplate==3.0.1        # via coreapi, drf-yasg
-urllib3==1.26.4           # via botocore, requests
+urllib3==1.26.5           # via botocore, requests
 vine==5.0.0               # via amqp, celery
 wcwidth==0.2.5            # via prompt-toolkit
 whitenoise==5.2.0         # via -r requirements-server.in

--- a/requirements-worker.txt
+++ b/requirements-worker.txt
@@ -69,7 +69,7 @@ tabulate==0.8.9           # via oasislmf
 text-unidecode==1.3       # via python-slugify
 toml==0.10.2              # via pytest
 tqdm==4.59.0              # via oasislmf
-urllib3==1.26.4           # via botocore, requests
+urllib3==1.26.5           # via botocore, requests
 vine==5.0.0               # via amqp, celery
 wcwidth==0.2.5            # via prompt-toolkit
 


### PR DESCRIPTION
<!--start_release_notes-->
### Update urllib3 for CVE-2021-33503
Fixed [CVE-2021-33503](https://github.com/advisories/GHSA-q2q7-5pp4-w6pg) - Catastrophic backtracking in URL authority parser when passed URL containing many @ characters

From: https://github.com/OasisLMF/OasisPlatform/pull/506 
<!--end_release_notes-->
