### PR TITLE
Fix/509 portfolio list performance

### DIFF
--- a/requirements-server.in
+++ b/requirements-server.in
@@ -18,6 +18,7 @@ django-storages
 django-cleanup
 djangorestframework_simplejwt
 django-model-utils>=4.0.0
+django-debug-toolbar
 coreapi
 whitenoise
 drf-yasg>=1.17.1

--- a/requirements.in
+++ b/requirements.in
@@ -17,3 +17,4 @@ pytest-cov
 pytest-django
 model_mommy
 django-webtest
+django-debug-toolbar

--- a/requirements.txt
+++ b/requirements.txt
@@ -149,6 +149,8 @@ djangorestframework==3.12.4
     #   drf-yasg
 drf-yasg==1.20.0
     # via -r ./requirements-server.in
+django-debug-toolbar==3.2.1 
+    # ia -r requirements-server.in
 fasteners==0.16
     # via
     #   -r ./requirements-worker.in

--- a/src/server/oasisapi/analyses/serializers.py
+++ b/src/server/oasisapi/analyses/serializers.py
@@ -6,6 +6,131 @@ from .models import Analysis
 from ..files.models import file_storage_link
 
 
+from ..data_files.models import DataFile
+from ..data_files.serializers import DataFileSerializer
+
+class AnalysisListSerializer(serializers.Serializer):
+    """ Read Only Analyses Deserializer for efficiently returning a list of all
+        Analyses in DB
+    """
+
+    """
+    {
+      "created": "2021-06-17T08:21:59.315040Z",
+      "modified": "2021-06-17T08:21:59.315040Z",
+      "name": "Analysis_17062021-092159",
+      "id": 1,
+      "portfolio": 1506,
+      "model": 3,
+      "status": "NEW",
+      "task_started": null,
+      "task_finished": null,
+      "complex_model_data_files": [],
+      "input_file": null,
+      "settings_file": "http://localhost:8000/v1/analyses/1/settings_file/",
+      "settings": "http://localhost:8000/v1/analyses/1/settings/",
+      "lookup_errors_file": null,
+      "lookup_success_file": null,
+      "lookup_validation_file": null,
+      "summary_levels_file": null,
+      "input_generation_traceback_file": null,
+      "output_file": null,
+      "run_traceback_file": null,
+      "run_log_file": null,
+      "storage_links": "http://localhost:8000/v1/analyses/1/storage_links/"
+    }
+    """
+
+    # model fields
+    created = serializers.DateTimeField(read_only=True)
+    modified = serializers.DateTimeField(read_only=True)
+    name = serializers.CharField(read_only=True)
+    id = serializers.IntegerField(read_only=True)
+    portfolio = serializers.IntegerField(source='portfolio_id', read_only=True)
+    model = serializers.IntegerField(source='model_id', read_only=True)
+    status = serializers.CharField(read_only=True)
+    task_started = serializers.DateTimeField(read_only=True)
+    task_finished = serializers.DateTimeField(read_only=True)
+    complex_model_data_files = serializers.PrimaryKeyRelatedField(many=True, read_only=True)
+
+
+    # file fields
+    input_file = serializers.SerializerMethodField(read_only=True)
+    settings_file = serializers.SerializerMethodField(read_only=True)
+    settings = serializers.SerializerMethodField(read_only=True)
+    lookup_errors_file = serializers.SerializerMethodField(read_only=True)
+    lookup_success_file = serializers.SerializerMethodField(read_only=True)
+    lookup_validation_file = serializers.SerializerMethodField(read_only=True)
+    summary_levels_file = serializers.SerializerMethodField(read_only=True)
+    input_generation_traceback_file = serializers.SerializerMethodField(read_only=True)
+    output_file = serializers.SerializerMethodField(read_only=True)
+    run_traceback_file = serializers.SerializerMethodField(read_only=True)
+    run_log_file = serializers.SerializerMethodField(read_only=True)
+    storage_links = serializers.SerializerMethodField(read_only=True)
+
+
+    @swagger_serializer_method(serializer_or_field=serializers.URLField)
+    def get_input_file(self, instance):
+        request = self.context.get('request')
+        return instance.get_absolute_input_file_url(request=request) if instance.input_file_id else None
+
+    @swagger_serializer_method(serializer_or_field=serializers.URLField)
+    def get_settings_file(self, instance):
+        request = self.context.get('request')
+        return instance.get_absolute_settings_file_url(request=request) if instance.settings_file_id else None
+
+    @swagger_serializer_method(serializer_or_field=serializers.URLField)
+    def get_settings(self, instance):
+        request = self.context.get('request')
+        return instance.get_absolute_settings_url(request=request) if instance.settings_file_id else None
+
+    @swagger_serializer_method(serializer_or_field=serializers.URLField)
+    def get_lookup_errors_file(self, instance):
+        request = self.context.get('request')
+        return instance.get_absolute_lookup_errors_file_url(request=request) if instance.lookup_errors_file_id else None
+
+    @swagger_serializer_method(serializer_or_field=serializers.URLField)
+    def get_lookup_success_file(self, instance):
+        request = self.context.get('request')
+        return instance.get_absolute_lookup_success_file_url(request=request) if instance.lookup_success_file_id else None
+
+    @swagger_serializer_method(serializer_or_field=serializers.URLField)
+    def get_lookup_validation_file(self, instance):
+        request = self.context.get('request')
+        return instance.get_absolute_lookup_validation_file_url(request=request) if instance.lookup_validation_file_id else None
+
+    @swagger_serializer_method(serializer_or_field=serializers.URLField)
+    def get_summary_levels_file(self, instance):
+        request = self.context.get('request')
+        return instance.get_absolute_summary_levels_file_url(request=request) if instance.summary_levels_file_id else None
+
+    @swagger_serializer_method(serializer_or_field=serializers.URLField)
+    def get_input_generation_traceback_file(self, instance):
+        request = self.context.get('request')
+        return instance.get_absolute_input_generation_traceback_file_url(request=request) if instance.input_generation_traceback_file_id else None
+
+    @swagger_serializer_method(serializer_or_field=serializers.URLField)
+    def get_output_file(self, instance):
+        request = self.context.get('request')
+        return instance.get_absolute_output_file_url(request=request) if instance.output_file_id else None
+
+    @swagger_serializer_method(serializer_or_field=serializers.URLField)
+    def get_run_traceback_file(self, instance):
+        request = self.context.get('request')
+        return instance.get_absolute_run_traceback_file_url(request=request) if instance.run_traceback_file_id else None
+
+    @swagger_serializer_method(serializer_or_field=serializers.URLField)
+    def get_run_log_file(self, instance):
+        request = self.context.get('request')
+        return instance.get_absolute_run_log_file_url(request=request) if instance.run_log_file_id else None
+
+    @swagger_serializer_method(serializer_or_field=serializers.URLField)
+    def get_storage_links(self, instance):
+        request = self.context.get('request')
+        return instance.get_absolute_storage_url(request=request)
+
+
+
 class AnalysisSerializer(serializers.ModelSerializer):
     input_file = serializers.SerializerMethodField()
     settings_file = serializers.SerializerMethodField()
@@ -50,57 +175,57 @@ class AnalysisSerializer(serializers.ModelSerializer):
     @swagger_serializer_method(serializer_or_field=serializers.URLField)
     def get_input_file(self, instance):
         request = self.context.get('request')
-        return instance.get_absolute_input_file_url(request=request) if instance.input_file else None
+        return instance.get_absolute_input_file_url(request=request) if instance.input_file_id else None
 
     @swagger_serializer_method(serializer_or_field=serializers.URLField)
     def get_settings_file(self, instance):
         request = self.context.get('request')
-        return instance.get_absolute_settings_file_url(request=request) if instance.settings_file else None
+        return instance.get_absolute_settings_file_url(request=request) if instance.settings_file_id else None
 
     @swagger_serializer_method(serializer_or_field=serializers.URLField)
     def get_settings(self, instance):
         request = self.context.get('request')
-        return instance.get_absolute_settings_url(request=request) if instance.settings_file else None
+        return instance.get_absolute_settings_url(request=request) if instance.settings_file_id else None
 
     @swagger_serializer_method(serializer_or_field=serializers.URLField)
     def get_lookup_errors_file(self, instance):
         request = self.context.get('request')
-        return instance.get_absolute_lookup_errors_file_url(request=request) if instance.lookup_errors_file else None
+        return instance.get_absolute_lookup_errors_file_url(request=request) if instance.lookup_errors_file_id else None
 
     @swagger_serializer_method(serializer_or_field=serializers.URLField)
     def get_lookup_success_file(self, instance):
         request = self.context.get('request')
-        return instance.get_absolute_lookup_success_file_url(request=request) if instance.lookup_success_file else None
+        return instance.get_absolute_lookup_success_file_url(request=request) if instance.lookup_success_file_id else None
 
     @swagger_serializer_method(serializer_or_field=serializers.URLField)
     def get_lookup_validation_file(self, instance):
         request = self.context.get('request')
-        return instance.get_absolute_lookup_validation_file_url(request=request) if instance.lookup_validation_file else None
+        return instance.get_absolute_lookup_validation_file_url(request=request) if instance.lookup_validation_file_id else None
 
     @swagger_serializer_method(serializer_or_field=serializers.URLField)
     def get_summary_levels_file(self, instance):
         request = self.context.get('request')
-        return instance.get_absolute_summary_levels_file_url(request=request) if instance.summary_levels_file else None
+        return instance.get_absolute_summary_levels_file_url(request=request) if instance.summary_levels_file_id else None
 
     @swagger_serializer_method(serializer_or_field=serializers.URLField)
     def get_input_generation_traceback_file(self, instance):
         request = self.context.get('request')
-        return instance.get_absolute_input_generation_traceback_file_url(request=request) if instance.input_generation_traceback_file else None
+        return instance.get_absolute_input_generation_traceback_file_url(request=request) if instance.input_generation_traceback_file_id else None
 
     @swagger_serializer_method(serializer_or_field=serializers.URLField)
     def get_output_file(self, instance):
         request = self.context.get('request')
-        return instance.get_absolute_output_file_url(request=request) if instance.output_file else None
+        return instance.get_absolute_output_file_url(request=request) if instance.output_file_id else None
 
     @swagger_serializer_method(serializer_or_field=serializers.URLField)
     def get_run_traceback_file(self, instance):
         request = self.context.get('request')
-        return instance.get_absolute_run_traceback_file_url(request=request) if instance.run_traceback_file else None
+        return instance.get_absolute_run_traceback_file_url(request=request) if instance.run_traceback_file_id else None
 
     @swagger_serializer_method(serializer_or_field=serializers.URLField)
     def get_run_log_file(self, instance):
         request = self.context.get('request')
-        return instance.get_absolute_run_log_file_url(request=request) if instance.run_log_file else None
+        return instance.get_absolute_run_log_file_url(request=request) if instance.run_log_file_id else None
 
     @swagger_serializer_method(serializer_or_field=serializers.URLField)
     def get_storage_links(self, instance):
@@ -118,7 +243,7 @@ class AnalysisSerializer(serializers.ModelSerializer):
                 raise ValidationError({'portfolio': '"location_file" must not be null'})
 
         # check that model isn't soft-deleted
-        if attrs.get('model'):    
+        if attrs.get('model'):
             if attrs['model'].deleted:
                 error = {'model': ["Model pk \"{}\" - has been deleted.".format(attrs['model'].id)]}
                 raise ValidationError(detail=error)
@@ -139,7 +264,7 @@ class AnalysisStorageSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Analysis
-        fields = ( 
+        fields = (
             'settings_file',
             'input_file',
             'input_generation_traceback_file',

--- a/src/server/oasisapi/analyses/serializers.py
+++ b/src/server/oasisapi/analyses/serializers.py
@@ -5,40 +5,9 @@ from rest_framework.exceptions import ValidationError
 from .models import Analysis
 from ..files.models import file_storage_link
 
-
-from ..data_files.models import DataFile
-from ..data_files.serializers import DataFileSerializer
-
 class AnalysisListSerializer(serializers.Serializer):
     """ Read Only Analyses Deserializer for efficiently returning a list of all
-        Analyses in DB
-    """
-
-    """
-    {
-      "created": "2021-06-17T08:21:59.315040Z",
-      "modified": "2021-06-17T08:21:59.315040Z",
-      "name": "Analysis_17062021-092159",
-      "id": 1,
-      "portfolio": 1506,
-      "model": 3,
-      "status": "NEW",
-      "task_started": null,
-      "task_finished": null,
-      "complex_model_data_files": [],
-      "input_file": null,
-      "settings_file": "http://localhost:8000/v1/analyses/1/settings_file/",
-      "settings": "http://localhost:8000/v1/analyses/1/settings/",
-      "lookup_errors_file": null,
-      "lookup_success_file": null,
-      "lookup_validation_file": null,
-      "summary_levels_file": null,
-      "input_generation_traceback_file": null,
-      "output_file": null,
-      "run_traceback_file": null,
-      "run_log_file": null,
-      "storage_links": "http://localhost:8000/v1/analyses/1/storage_links/"
-    }
+        Analyses from DB
     """
 
     # model fields
@@ -52,7 +21,6 @@ class AnalysisListSerializer(serializers.Serializer):
     task_started = serializers.DateTimeField(read_only=True)
     task_finished = serializers.DateTimeField(read_only=True)
     complex_model_data_files = serializers.PrimaryKeyRelatedField(many=True, read_only=True)
-
 
     # file fields
     input_file = serializers.SerializerMethodField(read_only=True)

--- a/src/server/oasisapi/analyses/viewsets.py
+++ b/src/server/oasisapi/analyses/viewsets.py
@@ -12,7 +12,7 @@ from django_filters import rest_framework as filters
 from django_filters import NumberFilter
 
 from .models import Analysis
-from .serializers import AnalysisSerializer, AnalysisCopySerializer, AnalysisStorageSerializer
+from .serializers import AnalysisSerializer, AnalysisCopySerializer, AnalysisStorageSerializer, AnalysisListSerializer
 
 from ..analysis_models.models import AnalysisModel
 from ..data_files.serializers import DataFileSerializer
@@ -20,7 +20,7 @@ from ..filters import TimeStampedFilter, CsvMultipleChoiceFilter, CsvModelMultip
 from ..files.views import handle_related_file, handle_json_data
 from ..files.serializers import RelatedFileSerializer
 from ..schemas.custom_swagger import FILE_RESPONSE
-from ..schemas.serializers import AnalysisSettingsSerializer 
+from ..schemas.serializers import AnalysisSettingsSerializer
 
 
 class AnalysisFilter(TimeStampedFilter):
@@ -128,13 +128,7 @@ class AnalysisViewSet(viewsets.ModelViewSet):
     partial_update:
     Partially updates the specified analysis (only provided fields are updated)
     """
-
-    queryset = Analysis.objects.all()
-    serializer_class = AnalysisSerializer
-    filterset_class = AnalysisFilter
-
     file_action_types = ['settings_file',
-                         'set_settings_file',
                          'input_file',
                          'lookup_errors_file',
                          'lookup_success_file',
@@ -150,9 +144,17 @@ class AnalysisViewSet(viewsets.ModelViewSet):
                          'generate_inputs',
                          'cancel_generate_inputs']
 
+    queryset = Analysis.objects.all().select_related(*file_action_types).prefetch_related('complex_model_data_files')
+    serializer_class = AnalysisSerializer
+    filterset_class = AnalysisFilter
+
+    file_action_types.append('set_settings_file')
+
     def get_serializer_class(self):
-        if self.action in ['retrieve', 'create', 'list', 'options', 'update', 'partial_update']:
+        if self.action in ['create', 'options', 'update', 'partial_update']:
             return super(AnalysisViewSet, self).get_serializer_class()
+        elif self.action in ['list', 'retrieve']:
+            return AnalysisListSerializer
         elif self.action == 'copy':
             return AnalysisCopySerializer
         elif self.action == 'data_files':
@@ -188,7 +190,7 @@ class AnalysisViewSet(viewsets.ModelViewSet):
     @action(methods=['post'], detail=True)
     def cancel(self, request, pk=None, version=None):
         """
-        Cancels either input generation or analysis execution depending on the active stage. 
+        Cancels either input generation or analysis execution depending on the active stage.
         The analysis must have one of the following statuses, `INPUTS_GENERATION_QUEUED`, `INPUTS_GENERATION_STARTED`, `RUN_QUEUED` or `RUN_STARTED`
         """
         obj = self.get_object()
@@ -395,11 +397,11 @@ class AnalysisViewSet(viewsets.ModelViewSet):
         return Response(df_serializer.data)
 
 
-    
+
     @action(methods=['get'], detail=True)
     def storage_links(self, request, pk=None, version=None):
         """
-        get:                                                                                                                                                 
+        get:
         Gets the analyses storage backed link references, `object keys` or `file paths`
         """
         serializer = self.get_serializer(self.get_object())

--- a/src/server/oasisapi/analyses/viewsets.py
+++ b/src/server/oasisapi/analyses/viewsets.py
@@ -151,9 +151,9 @@ class AnalysisViewSet(viewsets.ModelViewSet):
     file_action_types.append('set_settings_file')
 
     def get_serializer_class(self):
-        if self.action in ['create', 'options', 'update', 'partial_update']:
+        if self.action in ['create', 'options', 'update', 'partial_update', 'retrieve']:
             return super(AnalysisViewSet, self).get_serializer_class()
-        elif self.action in ['list', 'retrieve']:
+        elif self.action in ['list']:
             return AnalysisListSerializer
         elif self.action == 'copy':
             return AnalysisCopySerializer

--- a/src/server/oasisapi/data_files/serializers.py
+++ b/src/server/oasisapi/data_files/serializers.py
@@ -4,6 +4,64 @@ from rest_framework import serializers
 from .models import DataFile
 
 
+class DataFileListSerializer(serializers.Serializer):
+    """ Read Only DataFile Deserializer for efficiently returning a list of all
+        DataFile from DB
+    """
+
+    # model fields 
+    id = serializers.IntegerField(read_only=True)
+    file_description = serializers.CharField(read_only=True)
+    file_category = serializers.CharField(read_only=True)
+    created = serializers.DateTimeField(read_only=True)
+    modified = serializers.DateTimeField(read_only=True)
+
+    # File fields 
+    file = serializers.SerializerMethodField(read_only=True)
+    filename = serializers.SerializerMethodField(read_only=True)
+    stored = serializers.SerializerMethodField(read_only=True)
+    content_type = serializers.SerializerMethodField(read_only=True)
+
+    @swagger_serializer_method(serializer_or_field=serializers.URLField)
+    def get_file(self, instance):
+        request = self.context.get('request')
+        return instance.get_absolute_data_file_url(request=request) if instance.file_id else None
+
+    def get_filename(self, instance):
+        return instance.get_filename()
+
+    def get_stored(self, instance):
+        return instance.get_filestore()
+
+    def get_content_type(self, instance):
+        return instance.get_content_type()
+
+
+"""
+ {
+    "id": 1,
+    "file_description": "1",
+    "file_category": "string",
+    "created": "2021-06-17T08:39:18.326853Z",
+    "modified": "2021-06-17T08:39:18.326853Z",
+    "file": "http://localhost:8000/v1/data_files/1/content/",
+    "filename": "analysis_1_output.tar",
+    "stored": "f3ab4e2714af4a11b992f94c243dfc86.tar",
+    "content_type": "application/x-tar"
+  },
+  {
+    "id": 2,
+    "file_description": "2",
+    "file_category": "string",
+    "created": "2021-06-17T08:39:22.688895Z",
+    "modified": "2021-06-17T08:39:22.688895Z",
+    "file": "http://localhost:8000/v1/data_files/2/content/",
+    "filename": "analysis_2_output.tar",
+    "stored": "1c4ae3bae756433cb45b6c4e50849c44.tar",
+    "content_type": "application/x-tar"
+  },
+"""
+
 class DataFileSerializer(serializers.ModelSerializer):
     file = serializers.SerializerMethodField()
     filename = serializers.SerializerMethodField()

--- a/src/server/oasisapi/data_files/serializers.py
+++ b/src/server/oasisapi/data_files/serializers.py
@@ -9,14 +9,14 @@ class DataFileListSerializer(serializers.Serializer):
         DataFile from DB
     """
 
-    # model fields 
+    # model fields
     id = serializers.IntegerField(read_only=True)
     file_description = serializers.CharField(read_only=True)
     file_category = serializers.CharField(read_only=True)
     created = serializers.DateTimeField(read_only=True)
     modified = serializers.DateTimeField(read_only=True)
 
-    # File fields 
+    # File fields
     file = serializers.SerializerMethodField(read_only=True)
     filename = serializers.SerializerMethodField(read_only=True)
     stored = serializers.SerializerMethodField(read_only=True)
@@ -36,31 +36,6 @@ class DataFileListSerializer(serializers.Serializer):
     def get_content_type(self, instance):
         return instance.get_content_type()
 
-
-"""
- {
-    "id": 1,
-    "file_description": "1",
-    "file_category": "string",
-    "created": "2021-06-17T08:39:18.326853Z",
-    "modified": "2021-06-17T08:39:18.326853Z",
-    "file": "http://localhost:8000/v1/data_files/1/content/",
-    "filename": "analysis_1_output.tar",
-    "stored": "f3ab4e2714af4a11b992f94c243dfc86.tar",
-    "content_type": "application/x-tar"
-  },
-  {
-    "id": 2,
-    "file_description": "2",
-    "file_category": "string",
-    "created": "2021-06-17T08:39:22.688895Z",
-    "modified": "2021-06-17T08:39:22.688895Z",
-    "file": "http://localhost:8000/v1/data_files/2/content/",
-    "filename": "analysis_2_output.tar",
-    "stored": "1c4ae3bae756433cb45b6c4e50849c44.tar",
-    "content_type": "application/x-tar"
-  },
-"""
 
 class DataFileSerializer(serializers.ModelSerializer):
     file = serializers.SerializerMethodField()

--- a/src/server/oasisapi/data_files/viewsets.py
+++ b/src/server/oasisapi/data_files/viewsets.py
@@ -11,7 +11,7 @@ from ..files.views import handle_related_file
 from ..filters import TimeStampedFilter
 from .models import DataFile
 from ..schemas.custom_swagger import FILE_RESPONSE
-from .serializers import DataFileSerializer
+from .serializers import DataFileSerializer, DataFileListSerializer
 
 
 class DataFileFilter(TimeStampedFilter):
@@ -75,13 +75,15 @@ class DataFileFilter(TimeStampedFilter):
 
 
 class DataFileViewset(viewsets.ModelViewSet):
-    queryset = DataFile.objects.all()
+    queryset = DataFile.objects.all().select_related('file')
     serializer_class = DataFileSerializer
     filterset_class = DataFileFilter
 
     def get_serializer_class(self):
         if self.action in ['content', 'set_content']:
             return RelatedFileSerializer
+        elif self.action in  ['list', 'retrieve']:   
+            return DataFileListSerializer
         else:
             return super(DataFileViewset, self).get_serializer_class()
 

--- a/src/server/oasisapi/data_files/viewsets.py
+++ b/src/server/oasisapi/data_files/viewsets.py
@@ -82,7 +82,7 @@ class DataFileViewset(viewsets.ModelViewSet):
     def get_serializer_class(self):
         if self.action in ['content', 'set_content']:
             return RelatedFileSerializer
-        elif self.action in  ['list', 'retrieve']:   
+        elif self.action in  ['list']:   
             return DataFileListSerializer
         else:
             return super(DataFileViewset, self).get_serializer_class()

--- a/src/server/oasisapi/portfolios/serializers.py
+++ b/src/server/oasisapi/portfolios/serializers.py
@@ -12,13 +12,78 @@ from ..files.models import file_storage_link
 from ..files.models import RelatedFile
 from .models import Portfolio
 
-
 from ..schemas.serializers import (
     LocFileSerializer,
     AccFileSerializer,
     ReinsInfoFileSerializer,
     ReinsScopeFileSerializer,
 )
+
+
+""" Read Only Portfolio Deserializer for returning list of all 
+    Portfolios in DB 
+"""
+class PortfolioListSerializer(serializers.Serializer):
+
+    id = serializers.IntegerField(read_only=True)
+    name = serializers.CharField(read_only=True)
+    created = serializers.DateTimeField(read_only=True)
+    modified = serializers.DateTimeField(read_only=True)
+    accounts_file = serializers.SerializerMethodField(read_only=True)
+    location_file = serializers.SerializerMethodField(read_only=True)
+    reinsurance_info_file = serializers.SerializerMethodField(read_only=True)
+    reinsurance_scope_file = serializers.SerializerMethodField(read_only=True)
+    storage_links = serializers.SerializerMethodField(read_only=True)
+
+    @swagger_serializer_method(serializer_or_field=serializers.URLField)
+    def get_storage_links(self, instance):
+        request = self.context.get('request')
+        return instance.get_absolute_storage_url(request=request)
+
+    @swagger_serializer_method(serializer_or_field=LocFileSerializer)
+    def get_location_file(self, instance):
+        if instance.location_file_id is None:
+            return None
+        request = self.context.get('request')
+        return {
+            "uri": instance.get_absolute_location_file_url(request=request),
+            "name": instance.location_file.filename,
+            "stored": str(instance.location_file.file)
+        }
+
+    @swagger_serializer_method(serializer_or_field=AccFileSerializer)
+    def get_accounts_file(self, instance):
+        if instance.accounts_file_id is None:
+            return None
+        request = self.context.get('request')
+        return {
+            "uri": instance.get_absolute_accounts_file_url(request=request),
+            "name": instance.accounts_file.filename,
+            "stored": str(instance.accounts_file.file)
+        }
+
+    @swagger_serializer_method(serializer_or_field=ReinsInfoFileSerializer)
+    def get_reinsurance_info_file(self, instance):
+        if instance.reinsurance_info_file_id is None:
+            return None
+
+        request = self.context.get('request')
+        return {
+            "uri": instance.get_absolute_reinsurance_info_file_url(request=request),
+            "name": instance.reinsurance_info_file.filename,
+            "stored": str(instance.reinsurance_info_file.file)
+        }
+
+    @swagger_serializer_method(serializer_or_field=ReinsScopeFileSerializer)
+    def get_reinsurance_scope_file(self, instance):
+        if instance.reinsurance_scope_file_id is None:
+            return None
+        request = self.context.get('request')
+        return {
+            "uri": instance.get_absolute_reinsurance_scope_file_url(request=request),
+            "name": instance.reinsurance_scope_file.filename,
+            "stored": str(instance.reinsurance_scope_file.file)
+        }
 
 
 class PortfolioSerializer(serializers.ModelSerializer):

--- a/src/server/oasisapi/portfolios/serializers.py
+++ b/src/server/oasisapi/portfolios/serializers.py
@@ -20,10 +20,10 @@ from ..schemas.serializers import (
 )
 
 
-""" Read Only Portfolio Deserializer for returning list of all 
-    Portfolios in DB 
-"""
 class PortfolioListSerializer(serializers.Serializer):
+    """ Read Only Portfolio Deserializer for efficiently returning a list of all 
+        Portfolios in DB 
+    """
 
     id = serializers.IntegerField(read_only=True)
     name = serializers.CharField(read_only=True)

--- a/src/server/oasisapi/portfolios/viewsets.py
+++ b/src/server/oasisapi/portfolios/viewsets.py
@@ -95,7 +95,7 @@ class PortfolioViewSet(viewsets.ModelViewSet):
     def get_serializer_class(self):
         if self.action == 'create_analysis':
             return CreateAnalysisSerializer
-        elif self.action in ['list', 'retrieve']:
+        elif self.action in ['list']:
             return PortfolioListSerializer
         elif self.action in ['set_storage_links', 'storage_links']:
             return PortfolioStorageSerializer

--- a/src/server/oasisapi/portfolios/viewsets.py
+++ b/src/server/oasisapi/portfolios/viewsets.py
@@ -96,6 +96,63 @@ class PortfolioViewSet(viewsets.ModelViewSet):
         else:
             return super(PortfolioViewSet, self).get_serializer_class()
 
+    def list(self, request, pk=None, version=None):
+        import time 
+        #import ipdb; ipdb.set_trace()
+        #queryset = self.filter_queryset(self.get_queryset()).select_related(
+        #    'accounts_file',
+        #    'location_file',
+        #    'reinsurance_info_file',
+        #    'reinsurance_scope_file',
+        #)    
+
+
+        queryset = self.get_queryset().select_related('location_file', 'accounts_file', 'reinsurance_scope_file', 'reinsurance_info_file')
+        #queryset = self.get_queryset().raw('SELECT * from portfolios_portfolio;')
+
+
+        #queryset = self.get_queryset().raw('SELECT * from portfolios_portfolio;')
+
+
+        #queryset = self.get_queryset().values(
+        #    'id',
+        #    'name',
+        #    'created',
+        #    'modified',
+        #    'accounts_file_id',
+        #    'location_file_id',
+        #    'reinsurance_info_file_id',
+        #    'reinsurance_scope_file_id',
+        #)
+
+        from .serializers import PortfolioListSerializer
+        serializer_new =  PortfolioListSerializer(queryset, many=True)
+        #serializer_current = self.get_serializer(queryset, many=True)
+
+
+        # try new serializer
+        #start = time.time() 
+        result_data = serializer_new.data
+        #end = time.time()
+        #print("Portfolio fetch Time NEW: {}".format(end-start))
+        #import ipdb; ipdb.set_trace()
+        
+        #from django.db import connection
+        #print(connection.queries)
+
+
+
+        
+
+        ## compare to prev serializer    
+        #start = time.time() 
+        #result_data = serializer_current.data
+        #end = time.time()
+        #print("Portfolio fetch Time CURRENT: {}".format(end-start))
+
+        return Response(result_data)
+        
+
     @property
     def parser_classes(self):
         if getattr(self, 'action', None) in ['set_accounts_file', 'set_location_file', 'set_reinsurance_info_file', 'set_reinsurance_scope_file']:

--- a/src/server/oasisapi/portfolios/viewsets.py
+++ b/src/server/oasisapi/portfolios/viewsets.py
@@ -18,9 +18,9 @@ from .models import Portfolio
 from ..schemas.custom_swagger import FILE_RESPONSE
 from ..schemas.serializers import StorageLinkSerializer
 from .serializers import (
-    PortfolioSerializer, 
-    CreateAnalysisSerializer, 
-    PortfolioStorageSerializer, 
+    PortfolioSerializer,
+    CreateAnalysisSerializer,
+    PortfolioStorageSerializer,
     PortfolioListSerializer
 )
 
@@ -74,11 +74,10 @@ class PortfolioViewSet(viewsets.ModelViewSet):
     Partially updates the specified portfolio (only provided fields are updated)
     """
 
-    #queryset = Portfolio.objects.all()
     queryset = Portfolio.objects.all().select_related(
-        'location_file', 
-        'accounts_file', 
-        'reinsurance_scope_file', 
+        'location_file',
+        'accounts_file',
+        'reinsurance_scope_file',
         'reinsurance_info_file'
     )
     serializer_class = PortfolioSerializer
@@ -96,8 +95,8 @@ class PortfolioViewSet(viewsets.ModelViewSet):
     def get_serializer_class(self):
         if self.action == 'create_analysis':
             return CreateAnalysisSerializer
-        elif self.action in ['list']:
-            return PortfolioListSerializer  
+        elif self.action in ['list', 'retrieve']:
+            return PortfolioListSerializer
         elif self.action in ['set_storage_links', 'storage_links']:
             return PortfolioStorageSerializer
         elif self.action in [
@@ -108,19 +107,6 @@ class PortfolioViewSet(viewsets.ModelViewSet):
         else:
             return super(PortfolioViewSet, self).get_serializer_class()
 
-
-    # Override default 'list' method to call queryset with `select_related`
-    def list(self, request, pk=None, version=None):
-        import ipdb; ipdb.set_trace()
-        queryset = self.filter_queryset(self.get_queryset()).select_related(
-            'accounts_file',
-            'location_file',
-            'reinsurance_info_file',
-            'reinsurance_scope_file',
-        )    
-        serializer = self.get_serializer(queryset, many=True)
-        return Response(serializer.data)
-        
 
     @property
     def parser_classes(self):

--- a/src/server/oasisapi/settings.py
+++ b/src/server/oasisapi/settings.py
@@ -56,6 +56,8 @@ INSTALLED_APPS = [
     'drf_yasg',
     'rest_framework_simplejwt.token_blacklist',
     'storages',
+    ## DEBUG TOOLBAR 
+#    'debug_toolbar',
 
     'src.server.oasisapi.files',
     'src.server.oasisapi.portfolios',
@@ -76,6 +78,8 @@ MIDDLEWARE = [
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'whitenoise.middleware.WhiteNoiseMiddleware',
+    ## DEBUG TOOLBAR 
+#    'debug_toolbar.middleware.DebugToolbarMiddleware',
 ]
 
 ROOT_URLCONF = 'src.server.oasisapi.urls'
@@ -258,3 +262,7 @@ SWAGGER_SETTINGS = {
     'LOGOUT_URL': reverse_lazy('rest_framework:logout'),
 }
 
+## DEBUG TOOLBAR 
+#INTERNAL_IPS = [
+#    '127.0.0.1',
+#]

--- a/src/server/oasisapi/settings.py
+++ b/src/server/oasisapi/settings.py
@@ -20,6 +20,8 @@ from ...conf import iniconf  # noqa
 from ...conf.celeryconf import *  # noqa
 from ...common.shared import set_aws_log_level
 
+
+
 IN_TEST = 'test' in sys.argv
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
@@ -31,6 +33,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = iniconf.settings.getboolean('server', 'debug', fallback=False)
+DEBUG_TOOLBAR = iniconf.settings.getboolean('server', 'debug_toolbar', fallback=False)
 
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = iniconf.settings.get('server', 'secret_key', fallback='' if not DEBUG else 'supersecret')
@@ -56,8 +59,6 @@ INSTALLED_APPS = [
     'drf_yasg',
     'rest_framework_simplejwt.token_blacklist',
     'storages',
-    ## DEBUG TOOLBAR 
-#    'debug_toolbar',
 
     'src.server.oasisapi.files',
     'src.server.oasisapi.portfolios',
@@ -78,9 +79,13 @@ MIDDLEWARE = [
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'whitenoise.middleware.WhiteNoiseMiddleware',
-    ## DEBUG TOOLBAR 
-#    'debug_toolbar.middleware.DebugToolbarMiddleware',
 ]
+
+
+if DEBUG_TOOLBAR:
+    INSTALLED_APPS.append('debug_toolbar')
+    MIDDLEWARE.append('debug_toolbar.middleware.DebugToolbarMiddleware')
+
 
 ROOT_URLCONF = 'src.server.oasisapi.urls'
 
@@ -262,7 +267,7 @@ SWAGGER_SETTINGS = {
     'LOGOUT_URL': reverse_lazy('rest_framework:logout'),
 }
 
-## DEBUG TOOLBAR 
-#INTERNAL_IPS = [
-#    '127.0.0.1',
-#]
+if DEBUG_TOOLBAR:
+    INTERNAL_IPS = [
+        '127.0.0.1',
+    ]

--- a/src/server/oasisapi/urls.py
+++ b/src/server/oasisapi/urls.py
@@ -6,6 +6,10 @@ from drf_yasg import openapi
 from drf_yasg.views import get_schema_view
 from rest_framework import routers, permissions
 
+## DEBUG TOOLBAR 
+#from django.urls import path
+#import debug_toolbar
+
 from .analysis_models.viewsets import AnalysisModelViewSet, ModelSettingsView
 from .analyses.viewsets import AnalysisViewSet, AnalysisSettingsView
 from .portfolios.viewsets import PortfolioViewSet
@@ -15,7 +19,6 @@ from .info.views import PerilcodesView
 from .info.views import ServerInfoView
 
 admin.autodiscover()
-#app_name = 'oasisapi'
 
 api_router = routers.DefaultRouter()
 api_router.include_root_view = False
@@ -88,3 +91,5 @@ urlpatterns = [
 
 if settings.DEBUG:
     urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+    ## DEBUG TOOLBAR 
+    #urlpatterns.append(path('__debug__/', include(debug_toolbar.urls)))

--- a/src/server/oasisapi/urls.py
+++ b/src/server/oasisapi/urls.py
@@ -6,10 +6,6 @@ from drf_yasg import openapi
 from drf_yasg.views import get_schema_view
 from rest_framework import routers, permissions
 
-## DEBUG TOOLBAR 
-#from django.urls import path
-#import debug_toolbar
-
 from .analysis_models.viewsets import AnalysisModelViewSet, ModelSettingsView
 from .analyses.viewsets import AnalysisViewSet, AnalysisSettingsView
 from .portfolios.viewsets import PortfolioViewSet
@@ -17,6 +13,10 @@ from .healthcheck.views import HealthcheckView
 from .data_files.viewsets import DataFileViewset
 from .info.views import PerilcodesView
 from .info.views import ServerInfoView
+
+if settings.DEBUG_TOOLBAR:
+    from django.urls import path
+    import debug_toolbar
 
 admin.autodiscover()
 
@@ -91,5 +91,6 @@ urlpatterns = [
 
 if settings.DEBUG:
     urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
-    ## DEBUG TOOLBAR 
-    #urlpatterns.append(path('__debug__/', include(debug_toolbar.urls)))
+
+if settings.DEBUG_TOOLBAR:
+    urlpatterns.append(path('__debug__/', include(debug_toolbar.urls)))


### PR DESCRIPTION
<!--start_release_notes-->
### Fixed API endpoint performance for list all requests 
The following endpoints had slow performance when fetching all records from the server database. This was due to each object serialisation request making multiple SQL queries which scales badly as the number of records increases. 

* `/v1/portfolios/`
* `/v1/analyses/`
* `/v1/data_files/`

```
[server]
DEBUG = True
DEBUG_TOOLBAR = True

```

#### Before Fix: SQL calls made for a single portfolio get request (5 per portfolio)
![Example_slow_portfolio](https://user-images.githubusercontent.com/9889973/122393133-77e75900-cf6c-11eb-9c46-6d93c398f93c.png)


This fix makes use of `select_related` and `prefetch_related` Django calls to fetch the QuerySet. All database calls are now combined into a single complex SQL query which greatly improves performance.    

#### Before Fix: SQL calls for fetching all portfolios (6k in total)
![Example_portfolio_many_slow](https://user-images.githubusercontent.com/9889973/122393529-df9da400-cf6c-11eb-8176-0283f54ce484.png)

#### After Fix: SQL calls for fetching all portfolios (3 in total)
![Example_portfolio_many_fast](https://user-images.githubusercontent.com/9889973/122393649-00fe9000-cf6d-11eb-8cd5-4ab9a8eefa77.png)

#### Added Django debug toolbar
Added a [Debugging toolbar](https://django-debug-toolbar.readthedocs.io/en/latest/installation.html) to view request background information. (Development environment only) This can be enabled by installing the package `pip install django-debug-toolbar`
and adding the following settings to `conf.ini`

<!--end_release_notes-->
