### PR TITLE
Build model worker with optional packages

### DIFF
--- a/jenkins/oasis_platform.groovy
+++ b/jenkins/oasis_platform.groovy
@@ -178,8 +178,8 @@ node {
             stage('Git install MDK'){
                 dir(oasis_workspace) {
                     // update worker and server install lists
-                    sh "sed -i 's|^oasislmf.*| git+git://github.com/OasisLMF/OasisLMF.git@${mdk_branch}#egg=oasislmf|g' requirements-worker.txt"
-                    sh "sed -i 's|^oasislmf.*| git+git://github.com/OasisLMF/OasisLMF.git@${mdk_branch}#egg=oasislmf|g' requirements.txt"
+                    sh "sed -i 's|^oasislmf.*| git+git://github.com/OasisLMF/OasisLMF.git@${mdk_branch}#egg=oasislmf[extra]|g' requirements-worker.txt"
+                    sh "sed -i 's|^oasislmf.*| git+git://github.com/OasisLMF/OasisLMF.git@${mdk_branch}#egg=oasislmf[extra]|g' requirements.txt"
                 }
             }
         }

--- a/jenkins/oasis_platform.groovy
+++ b/jenkins/oasis_platform.groovy
@@ -219,7 +219,7 @@ node {
                     sh "docker build -f docker/Dockerfile.release-notes -t release-builder ."
                 }
             }
-        }    
+        }
 
         if (params.SCAN_IMAGE_VULNERABILITIES.replaceAll(" \\s","")){
             parallel(
@@ -265,14 +265,18 @@ node {
                 }
             }
         }
-       if (params.CHECK_COMPATIBILITY) {
 
-            // Build PiWind worker from new worker
-            stage('Build: PiWind worker') {
-                dir(model_workspace) {
-                    sh "docker build --build-arg worker_ver=${env.TAG_RELEASE} -f ${docker_piwind} -t ${image_piwind}:${env.TAG_RELEASE} ."
-                }
-            }
+        if (params.CHECK_S3 || params.CHECK_COMPATIBILITY) {
+              // Build PiWind worker from new worker
+              stage('Build: PiWind worker') {
+                  dir(model_workspace) {
+                      sh "docker build --build-arg worker_ver=${env.TAG_RELEASE} -f ${docker_piwind} -t ${image_piwind}:${env.TAG_RELEASE} ."
+                  }
+              }
+
+         }
+
+         if (params.CHECK_COMPATIBILITY) {
 
             // START API for base model tests
             stage('Run: API Server') {

--- a/requirements-worker.in
+++ b/requirements-worker.in
@@ -1,4 +1,4 @@
-oasislmf>=1.8.3
+oasislmf[extra]>=1.8.3
 celery
 boto3
 configparser

--- a/requirements-worker.txt
+++ b/requirements-worker.txt
@@ -41,7 +41,7 @@ msgpack==1.0.2            # via oasislmf
 numba==0.53.1             # via oasislmf
 numexpr==2.7.3            # via oasislmf
 numpy==1.20.2             # via numba, numexpr, pandas
-oasislmf==1.17.0          # via -r requirements-worker.in
+oasislmf[extra]==1.18.0   # via -r requirements-worker.in
 packaging==20.9           # via pytest
 pandas==1.2.3             # via oasislmf
 pathlib2==2.3.5           # via -r requirements-worker.in, oasislmf


### PR DESCRIPTION
<!--start_release_notes-->
### Build model workers (1.18.0+) with optional oasislmf dependencies 
In package version `1.18.0` the following python packages for running the builtin lookup are now an optional install. 
```
shapely
geopandas
sklearn
pyarrow
rtree 
cookiecutter
```
Model workers will have these extra packages installed by default (See https://github.com/OasisLMF/OasisLMF/pull/847)


<!--end_release_notes-->
