### PR TITLE
Allow binary data as portfolio uploads + fix content_type setting on …

### DIFF
--- a/src/server/oasisapi/portfolios/serializers.py
+++ b/src/server/oasisapi/portfolios/serializers.py
@@ -243,11 +243,14 @@ class PortfolioStorageSerializer(serializers.ModelSerializer):
             raise serializers.ValidationError(errors)
         return super(PortfolioStorageSerializer, self).validate(attrs)
 
+    def get_content_type(self, stored_filename):
+        return RelatedFile.objects.get(file=stored_filename).content_type
+
     def update(self, instance, validated_data):
         files_for_removal = list()
-        content_type = 'text/csv'
-        for field in validated_data:
 
+        for field in validated_data:
+            content_type = self.get_content_type(validated_data[field])
             # S3 storage - File copy needed
             if hasattr(default_storage, 'bucket'):
                 fname = path.basename(validated_data[field])

--- a/src/server/oasisapi/portfolios/viewsets.py
+++ b/src/server/oasisapi/portfolios/viewsets.py
@@ -90,6 +90,7 @@ class PortfolioViewSet(viewsets.ModelViewSet):
         'application/x-bzip2',
         'application/zip',
         'application/x-bzip2',
+        'application/octet-stream',
     ]
 
     def get_serializer_class(self):


### PR DESCRIPTION
<!--start_release_notes-->
### Enable parquet file uploads for portfolios
* Parquet can be uploaded by allowing the content type 'application/octet-stream' as a valid MIME type
<!--end_release_notes-->
