### PR TITLE
Sprint 6 - Failure recovery - rebased

### DIFF
--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -12,12 +12,12 @@ Read [RELEASES.md](RELEASES.md) for an overview of what has delivered.
 A priority is set on each analysis either by the default value of 6 or by giving the `priority' attribute. Allowed
 values are from 1-10:
 
-| Priority | Comment
-|----------|--------
-| 10       | The highest priority
-| 8-10     | Can only be set by administrators
-| 4        | Default if no priority is specified
-| 1        | The lowest priority
+| Priority | Comment                             |
+|----------|-------------------------------------|
+| 10       | The highest priority                |
+| 8-10     | Can only be set by administrators   |
+| 4        | Default if no priority is specified |
+| 1        | The lowest priority                 |
 
 When an analysis is started (input gen or run) tasks put on celery queues will get the same priority as the analysis
 has.

--- a/kubernetes/RELEASES.md
+++ b/kubernetes/RELEASES.md
@@ -146,3 +146,23 @@ Released on 2021-11-26
 
 * Job prioritization (1.5):
 * Finished health checks and mysql support (not fully implemented in 1.1 / sprint 1)
+
+## Sprint 6
+
+Released on 2021-12-10
+
+**Features included:**
+
+* Platform chart improvements:
+  * RabbitMQ ack timeout disabled (introduced in 3.8.15)
+* Platform improvements:
+  * Enabled retry for worker tasks - A failed task will be run again 2 times.
+* Verified that the platform recovers from:
+  * Randomly failed worker tasks - Each task will be retried 2 times before it is marked as failed.
+  * Lost database connection - celery will reconnect and retry the task.
+  * Disk error - Each task will be retried 2 times before it is marked as failed.
+  * Lost worker - task is picked up by other worker.
+
+**This covers the following in the functional summary:**
+
+* Improved worker resilience to disconnection/failure (1.6)

--- a/kubernetes/RELEASES.md
+++ b/kubernetes/RELEASES.md
@@ -157,11 +157,70 @@ Released on 2021-12-10
   * RabbitMQ ack timeout disabled (introduced in 3.8.15)
 * Platform improvements:
   * Enabled retry for worker tasks - A failed task will be run again 2 times.
+
+
+**Performed tests**
+
 * Verified that the platform recovers from:
-  * Randomly failed worker tasks - Each task will be retried 2 times before it is marked as failed.
-  * Lost database connection - celery will reconnect and retry the task.
-  * Disk error - Each task will be retried 2 times before it is marked as failed.
-  * Lost worker - task is picked up by other worker.
+    * Randomly failed worker tasks - Each task will be retried 2 times before it is marked as failed.
+
+      ```
+      Test #1:
+      1. Make a specific task fail all the time by throsing an exception.
+      2. Start an analysis.
+      3. Verify the task is retried 2 times before failing.
+      
+      Test #2:
+      1. Make random worker task fail randomly by using a function randmly
+         throw an exception up on call (for example every 3th call).
+      2. Start an analysis.
+      3. Verify the task that fail is retried, but the run should finish successfully
+         unless any of the tasks fails 3 times.
+      ```
+
+    * Lost database connection - celery will reconnect and retry the task.
+
+      ```
+      Test #1:
+      1. By using kubectl port-forward open a connection to celery.
+      2. Start one ore more workers locally and make it connect to celery over a
+         port-forward to the cluster.
+      3. Start an analysis and close the port-forward while the worker executes a task.
+      4. Verify the worker starts to try to reconnect.
+      5. Bring the port-forward up.
+      6. Verify the worker gets reconnected and finishes.
+      ```
+
+    * Disk error - Each task will be retried 2 times before it is marked as failed.
+
+      ```
+      Test #1:
+      1. Run a worker locally and set a breakpoint within a task.
+      2. Start an analysis.
+      3. Make sure the breakpoint is reached and pause the execution.
+      4. Delete or break files or directories necessary to complete the task.
+      5. Continue the execution, make sure it fails and verify that the task is
+         run again.
+      ```
+      
+    * Lost worker - task is picked up by other worker.
+
+      ```
+      # Test #1:
+      1. Start a worker.
+      2. Start an analysis.
+      3. Stop worker while executing task.
+      4. Start the worker again.
+      5. Verify it continues the execution of the task.
+      
+      # Test #2:
+      1. Start 2 worker.
+      2. Start an analysis.
+      3. Stop one worker while executing task.
+      5. Verify all tasks are executed by the second worker including the one currently
+         processed by the other worker that was shut down.
+      ```
+
 
 **This covers the following in the functional summary:**
 

--- a/kubernetes/charts/README.md
+++ b/kubernetes/charts/README.md
@@ -151,10 +151,10 @@ running.
 
 Here is a short summary of two klusters:
 
-Type                      | IP
---------------------------|--------
-Docker desktop on Windows | 127.0.0.1
-Minikube                  | <ol><li>Run `minikube tunnel` to expose cluster IP</li><li>Run `kubectl get svc --template="{{range .items}}{{range .status.loadBalancer.ingress}}{{.ip}}{{end}}{{end}}"` to get the IP.</li></ol>
+| Type                      | IP                                                                                                                                                                                                 |
+|---------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Docker desktop on Windows | 127.0.0.1                                                                                                                                                                                          |
+| Minikube                  | <ol><li>Run `minikube tunnel` to expose cluster IP</li><li>Run `kubectl get svc --template="{{range .items}}{{range .status.loadBalancer.ingress}}{{.ip}}{{end}}{{end}}"` to get the IP.</li></ol> |
 
 ### Add hostnames
 

--- a/kubernetes/charts/oasis-models/templates/workers.yaml
+++ b/kubernetes/charts/oasis-models/templates/workers.yaml
@@ -40,12 +40,12 @@ spec:
             {{- include "h.modelEnvs" . | indent 12 }}
             {{- include "h.brokerVars" $root | indent 12 }}
             {{- include "h.celeryDbVars" $root | indent 12}}
-          readinessProbe:
+          startupProbe:
             exec:
               command: ["celery", "-A", "src.model_execution_worker.distributed_tasks", "inspect", "ping"]
-            initialDelaySeconds: 5
+            timeoutSeconds: 5
             periodSeconds: 10
-            timeoutSeconds: 30
+            failureThreshold: 30
           livenessProbe:
             exec:
               command: ["celery", "-A", "src.model_execution_worker.distributed_tasks", "inspect", "ping"]

--- a/kubernetes/charts/oasis-monitoring/values.yaml
+++ b/kubernetes/charts/oasis-monitoring/values.yaml
@@ -67,3 +67,4 @@ kube-prometheus-stack:
       hosts:
         - ui.oasis.local
       path: /grafana/
+

--- a/kubernetes/charts/oasis-platform/templates/databases.yaml
+++ b/kubernetes/charts/oasis-platform/templates/databases.yaml
@@ -40,7 +40,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ $v.name }}
-  namespace: default
+  namespace: {{ $root.Release.Namespace }}
   labels:
   {{- include "h.labels" $root | nindent 4 }}
 type: Opaque

--- a/kubernetes/charts/oasis-platform/templates/databases.yaml
+++ b/kubernetes/charts/oasis-platform/templates/databases.yaml
@@ -127,12 +127,12 @@ spec:
           volumeMounts:
             - name: db-persistent-storage
               mountPath: /var/lib/postgresql/data
-          readinessProbe:
+          startupProbe:
             exec:
               command: ["bash", "-c", "psql -w -U $POSTGRES_USER -d $POSTGRES_DB -c 'SELECT 1'"]
-            initialDelaySeconds: 10
-            periodSeconds: 2
             timeoutSeconds: 5
+            periodSeconds: 10
+            failureThreshold: 30
           livenessProbe:
             exec:
               command: ["bash", "-c", "psql -w -U $POSTGRES_USER -d $POSTGRES_DB -c 'SELECT 1'"]
@@ -162,12 +162,12 @@ spec:
           volumeMounts:
             - name: db-persistent-storage
               mountPath: /var/lib/mysql
-          readinessProbe:
+          startupProbe:
             exec:
               command: ["bash", "-c", "echo -en \"[client]\nuser=$MYSQL_USER\npassword=$MYSQL_PASSWORD\n\" > /tmp/file && cat /tmp/file && chmod go-rw /tmp/file && mysql --defaults-extra-file=/tmp/file -h 127.0.0.1 -e \"SELECT 1\"" ]
-            initialDelaySeconds: 3
-            periodSeconds: 2
-            timeoutSeconds: 3
+            timeoutSeconds: 5
+            periodSeconds: 10
+            failureThreshold: 30
           livenessProbe:
             exec:
               command: ["mysqladmin", "ping"]
@@ -176,12 +176,12 @@ spec:
             timeoutSeconds: 5
 {{- else if eq $v.type "redis" }}
           image: {{ $root.Values.images.redis.image }}:{{ $root.Values.images.redis.version }}
-          readinessProbe:
+          startupProbe:
             exec:
               command: ["/usr/local/bin/redis-cli", "ping"]
-            initialDelaySeconds: 5
-            periodSeconds: 2
             timeoutSeconds: 5
+            periodSeconds: 10
+            failureThreshold: 30
           livenessProbe:
             exec:
               command: ["/usr/local/bin/redis-cli", "ping"]
@@ -206,12 +206,12 @@ spec:
           volumeMounts:
             - name: rabbitmq-advanced-config
               mountPath: /etc/rabbitmq/advanced/
-          readinessProbe:
+          startupProbe:
             exec:
               command: ["rabbitmq-diagnostics", "ping"]
-            initialDelaySeconds: 20
-            periodSeconds: 20
-            timeoutSeconds: 10
+            timeoutSeconds: 5
+            periodSeconds: 10
+            failureThreshold: 30
           livenessProbe:
             exec:
               command: ["rabbitmq-diagnostics", "status"]

--- a/kubernetes/charts/oasis-platform/templates/databases.yaml
+++ b/kubernetes/charts/oasis-platform/templates/databases.yaml
@@ -49,6 +49,22 @@ data:
   password: {{ include "h.password" (list .name "password" $root $v.password (printf "A valid password for %s is required" $v.name)) }}
 {{- end }}
 ---
+{{- if eq $v.type "rabbitmq" }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ printf "%s-config" $v.name }}
+  labels:
+  {{- include "h.labels" $root | nindent 4 }}
+data:
+  advanced.config: |
+    [
+      {rabbit, [
+        {consumer_timeout, undefined}
+      ]}
+    ].
+{{- end }}
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -67,11 +83,21 @@ spec:
       annotations:
         checksum/{{ $v.name }}: {{ toJson $v | sha256sum }}
     spec:
-{{- if $v.volumeSize }}
       volumes:
+{{- if or $v.volumeSize (eq $v.type "rabbitmq") }}
+        {{- if or $v.volumeSize }}
         - name: db-persistent-storage
           persistentVolumeClaim:
             claimName: {{ $v.name }}
+        {{- end }}
+        {{- if eq $v.type "rabbitmq" }}
+        - name: rabbitmq-advanced-config
+          configMap:
+            name: {{ printf "%s-config" $v.name }}
+            items:
+            - key: advanced.config
+              path: advanced.config
+        {{- end }}
 {{- end }}
       {{- include "h.affinity" $root | nindent 6 }}
       containers:
@@ -175,18 +201,23 @@ spec:
                 secretKeyRef:
                   name: {{ .name }}
                   key: password
+            - name: RABBITMQ_ADVANCED_CONFIG_FILE
+              value: /etc/rabbitmq/advanced/advanced.config
+          volumeMounts:
+            - name: rabbitmq-advanced-config
+              mountPath: /etc/rabbitmq/advanced/
           readinessProbe:
             exec:
               command: ["rabbitmq-diagnostics", "ping"]
             initialDelaySeconds: 20
-            periodSeconds: 60
+            periodSeconds: 20
             timeoutSeconds: 10
           livenessProbe:
             exec:
               command: ["rabbitmq-diagnostics", "status"]
-            initialDelaySeconds: 60
-            periodSeconds: 60
-            timeoutSeconds: 15
+            initialDelaySeconds: 20
+            periodSeconds: 30
+            timeoutSeconds: 10
 {{- end }}
 ---
 {{- if $v.volumeSize }}

--- a/kubernetes/charts/oasis-platform/templates/keycloak.yaml
+++ b/kubernetes/charts/oasis-platform/templates/keycloak.yaml
@@ -13,7 +13,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Values.keycloak.name }}
-  namespace: default
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "h.labels" . | nindent 4}}
 type: Opaque

--- a/kubernetes/charts/oasis-platform/templates/keycloak.yaml
+++ b/kubernetes/charts/oasis-platform/templates/keycloak.yaml
@@ -144,14 +144,13 @@ spec:
               value: "true"
             - name: KEYCLOAK_IMPORT
               value: "/opt/oasis-realm.json"
-          readinessProbe:
+          startupProbe:
             httpGet:
               path: /auth/realms/master
               port: 8080
-            initialDelaySeconds: 10
+            timeoutSeconds: 5
             periodSeconds: 10
-            timeoutSeconds: 10
-            failureThreshold: 50
+            failureThreshold: 30
           livenessProbe:
             httpGet:
               path: /auth/

--- a/kubernetes/charts/oasis-platform/templates/oasis.yaml
+++ b/kubernetes/charts/oasis-platform/templates/oasis.yaml
@@ -74,7 +74,7 @@ spec:
             exec:
               command: ["celery", "-A", "src.server.oasisapi.celery_app", "inspect", "ping"]
             initialDelaySeconds: 5
-            periodSeconds: 5
+            periodSeconds: 50
             timeoutSeconds: 10
           livenessProbe:
             exec:
@@ -181,7 +181,7 @@ spec:
             exec:
               command: ["celery", "-A", "src.server.oasisapi.celery_app", "inspect", "ping"]
             initialDelaySeconds: 5
-            periodSeconds: 5
+            periodSeconds: 50
             timeoutSeconds: 10
           livenessProbe:
             exec:
@@ -225,7 +225,7 @@ spec:
             exec:
               command: ["celery", "-A", "src.server.oasisapi.celery_app", "inspect", "ping"]
             initialDelaySeconds: 5
-            periodSeconds: 5
+            periodSeconds: 50
             timeoutSeconds: 10
           livenessProbe:
             exec:

--- a/kubernetes/charts/oasis-platform/templates/oasis.yaml
+++ b/kubernetes/charts/oasis-platform/templates/oasis.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: oasis-rest-service-account
-  namespace: default
+  namespace: {{ .Release.Namespace }}
   labels:
   {{- include "h.labels" . | nindent 4 }}
 type: Opaque

--- a/kubernetes/charts/oasis-platform/templates/oasis.yaml
+++ b/kubernetes/charts/oasis-platform/templates/oasis.yaml
@@ -70,12 +70,12 @@ spec:
           volumeMounts:
             - name: shared-fs-persistent-storage
               mountPath: /shared-fs
-          readinessProbe:
+          startupProbe:
             exec:
               command: ["celery", "-A", "src.server.oasisapi.celery_app", "inspect", "ping"]
-            initialDelaySeconds: 5
-            periodSeconds: 50
             timeoutSeconds: 10
+            periodSeconds: 10
+            failureThreshold: 30
           livenessProbe:
             exec:
               command: ["celery", "-A", "src.server.oasisapi.celery_app", "inspect", "ping"]
@@ -124,14 +124,14 @@ spec:
           ports:
             - containerPort: 3838
               name: {{ .Values.oasisUI.name }}
-          readinessProbe:
+          startupProbe:
             httpGet:
               path: /
               port: 3838
               scheme: HTTP
-            initialDelaySeconds: 5
-            periodSeconds: 5
-            timeoutSeconds: 2
+            timeoutSeconds: 10
+            periodSeconds: 10
+            failureThreshold: 30
           livenessProbe:
             httpGet:
               path: /
@@ -177,12 +177,12 @@ spec:
             {{- include "h.celeryDbVars" . | indent 12}}
             {{- include "h.brokerVars" . | indent 12 }}
             {{- include "h.channelLayerVars" . | indent 12 }}
-          readinessProbe:
+          startupProbe:
             exec:
               command: ["celery", "-A", "src.server.oasisapi.celery_app", "inspect", "ping"]
-            initialDelaySeconds: 5
-            periodSeconds: 50
             timeoutSeconds: 10
+            periodSeconds: 10
+            failureThreshold: 30
           livenessProbe:
             exec:
               command: ["celery", "-A", "src.server.oasisapi.celery_app", "inspect", "ping"]
@@ -221,12 +221,12 @@ spec:
           imagePullPolicy: {{ .Values.images.oasis.platform.imagePullPolicy }}
           name: main
           command: ["celery", "-A", "src.server.oasisapi.celery_app", "worker", "--loglevel=INFO", "-Q", "task-controller"]
-          readinessProbe:
+          startupProbe:
             exec:
               command: ["celery", "-A", "src.server.oasisapi.celery_app", "inspect", "ping"]
-            initialDelaySeconds: 5
-            periodSeconds: 50
             timeoutSeconds: 10
+            periodSeconds: 10
+            failureThreshold: 30
           livenessProbe:
             exec:
               command: ["celery", "-A", "src.server.oasisapi.celery_app", "inspect", "ping"]

--- a/kubernetes/charts/oasis-platform/templates/oasis_server.yaml
+++ b/kubernetes/charts/oasis-platform/templates/oasis_server.yaml
@@ -101,14 +101,14 @@ spec:
           volumeMounts:
             - name: shared-fs-persistent-storage
               mountPath: /shared-fs
-          readinessProbe:
+          startupProbe:
             httpGet:
               path: /api/healthcheck/
               port: {{.Values.oasisServer.port}}
               scheme: HTTP
-            initialDelaySeconds: 5
-            periodSeconds: 5
-            timeoutSeconds: 5
+            timeoutSeconds: 10
+            periodSeconds: 10
+            failureThreshold: 30
           livenessProbe:
             httpGet:
               path: /api/healthcheck/

--- a/kubernetes/charts/oasis-platform/templates/oasis_server.yaml
+++ b/kubernetes/charts/oasis-platform/templates/oasis_server.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Values.oasisServer.name }}
-  namespace: default
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "h.labels" . | nindent 4}}
 type: Opaque

--- a/kubernetes/charts/oasis-platform/templates/oasis_worker_controller.yaml
+++ b/kubernetes/charts/oasis-platform/templates/oasis_worker_controller.yaml
@@ -74,6 +74,8 @@ spec:
               value: {{ .Values.oasisServer.name }}
             - name: OASIS_API_PORT
               value: {{ .Values.oasisServer.port | quote }}
+            - name: OASIS_CLUSTER_NAMESPACE
+              value: {{ .Release.Namespace | quote }}
             {{- with .Values.workerController.totalWorkerLimit }}
             - name: OASIS_TOTAL_WORKER_LIMIT
               value: {{ . | quote }}

--- a/kubernetes/scripts/README.md
+++ b/kubernetes/scripts/README.md
@@ -19,3 +19,14 @@ A few helpful scripts for development
 | k8s/clean_host_volume.sh        | Mounts the host nodes volume path and erases everything within - handy to clean the environment, but make sure to uninstall it first. |
 | k8s/port-forward.sh             | Sets up port forwarding to access UI, API, Prometheus and Grafana.                                                                    |
 | k8s/set_ingress_ip.sh           | For `minikube` on linux - updates your /etc/hosts file with the ingress IP used by `minikube tunnel`                                  |
+
+### Settings
+
+Supported environment variables:
+
+| Name                    | Default  | Description                                                                             |
+|-------------------------|----------|-----------------------------------------------------------------------------------------|
+| OASIS_USERNAME          | admin    | Oasis username                                                                          |
+| OASIS_PASSWORD          | password | Oasis password                                                                          |
+| OASIS_AUTH_API          | 1        | How to authenticate. 1=directly against keycloak on ui.oasis.local, 0=through oasis API |
+| OASIS_CLUSTER_NAMESPACE | default  | Namespace to use for kubernetes operations                                              |

--- a/kubernetes/scripts/README.md
+++ b/kubernetes/scripts/README.md
@@ -8,13 +8,14 @@ A few helpful scripts for development
 
 ### Overview
 
-Path                            | Description
-------------------------------- |------------
-api/                            | Scripts for the Oasis API
-api/api.sh                      | A few basic commands to query the Oasis API and list, run and cancel runs
-api/setup_env.sh                | Creates a portfolio and an analysis
-k8s/                            | Scripts for the kubernetes API
-k8s/upload_piwind_model_data.sh | Upload PiWind model data to the k8s host node (in case it is virtual and difficult to reach)
-k8s/host_volume_shell.sh       | Creates a pod with a bash shell and mounts the host node /data path. Convenient for reaching the kubernetes host node filesystem.
-k8s/clean_host_volume.sh        | Mounts the host nodes volume path and erases everything within - handy to clean the environment, but make sure to uninstall it first.
-k8s/port-forward.sh             | Sets up port forwarding to access UI, API, Prometheus and Grafana.
+| Path                            | Description                                                                                                                           |
+|---------------------------------|---------------------------------------------------------------------------------------------------------------------------------------|
+| api/                            | Scripts for the Oasis API                                                                                                             |
+| api/api.sh                      | A few basic commands to query the Oasis API and list, run and cancel runs                                                             |
+| api/setup_env.sh                | Creates a portfolio and an analysis                                                                                                   |
+| k8s/                            | Scripts for the kubernetes API                                                                                                        |
+| k8s/upload_piwind_model_data.sh | Upload PiWind model data to the k8s host node (in case it is virtual and difficult to reach)                                          |
+| k8s/host_volume_shell.sh        | Creates a pod with a bash shell and mounts the host node /data path. Convenient for reaching the kubernetes host node filesystem.     |
+| k8s/clean_host_volume.sh        | Mounts the host nodes volume path and erases everything within - handy to clean the environment, but make sure to uninstall it first. |
+| k8s/port-forward.sh             | Sets up port forwarding to access UI, API, Prometheus and Grafana.                                                                    |
+| k8s/set_ingress_ip.sh           | For `minikube` on linux - updates your /etc/hosts file with the ingress IP used by `minikube tunnel`                                  |

--- a/kubernetes/scripts/api/common.sh
+++ b/kubernetes/scripts/api/common.sh
@@ -3,7 +3,7 @@ set -o pipefail
 
 
 API_URL="https://ui.oasis.local/api"
-#API_URL="http://localhost:8001/api"
+#API_URL="http://localhost:8002"
 SCRIPT_DIR=$(dirname $0)
 CURL="curl -sk"
 TMP_PATH="/tmp/"
@@ -25,7 +25,7 @@ if [ -z "$OASIS_USERNAME" ] || [ -z "$OASIS_PASSWORD" ]; then
   exit
 fi
 
-USE_OASIS_API=1
+USE_OASIS_API=0
 
 if [ "$USE_OASIS_API" == "1" ]; then
   R="$($CURL -X POST "${API_URL}/access_token/" -H "accept: application/json" -H "Content-Type: application/json" \

--- a/kubernetes/scripts/api/common.sh
+++ b/kubernetes/scripts/api/common.sh
@@ -12,22 +12,17 @@ KEYCLOAK_TOKEN_URL="https://ui.oasis.local/auth/realms/oasis/protocol/openid-con
 CLIENT_ID=oasis-server
 CLIENT_SECRET=e4f4fb25-2250-4210-a7d6-9b16c3d2ab77
 
+
 if [ -f "/mnt/c/WINDOWS/system32/curl.exe" ]; then
   CURL="${CURL//curl/curl.exe}"
   TMP_PATH="/mnt/c/tmp/"
 fi
 
-if [ -z "$OASIS_USERNAME" ] || [ -z "$OASIS_PASSWORD" ]; then
-  echo "Set username and password as environment variables:"
-  echo ""
-  echo "export OASIS_USERNAME=admin"
-  echo "export OASIS_PASSWORD=password"
-  exit
-fi
+OASIS_USERNAME="${OASIS_USERNAME:-admin}"
+OASIS_PASSWORD="${OASIS_PASSWORD:-password}"
+OASIS_AUTH_API="${OASIS_AUTH_API:-0}"
 
-USE_OASIS_API=0
-
-if [ "$USE_OASIS_API" == "1" ]; then
+if [ "$OASIS_AUTH_API" == "1" ]; then
   R="$($CURL -X POST "${API_URL}/access_token/" -H "accept: application/json" -H "Content-Type: application/json" \
          -d "{ \"username\": \"${OASIS_USERNAME}\", \"password\": \"${OASIS_PASSWORD}\"}")"
   ACCESS_TOKEN=$(echo "$R" | jq -r '.access_token // empty')

--- a/kubernetes/scripts/api/setup_env.sh
+++ b/kubernetes/scripts/api/setup_env.sh
@@ -29,8 +29,8 @@ cat << EOF | curlf -X POST "${API_URL}/v1/models/${PIWIND_VERSION}/chunking_conf
   "strategy": "FIXED_CHUNKS",
   "dynamic_locations_per_lookup": 10000,
   "dynamic_events_per_analysis": 1,
-  "fixed_analysis_chunks": 2,
-  "fixed_lookup_chunks": 2
+  "fixed_analysis_chunks": 10,
+  "fixed_lookup_chunks": 10
 }
 EOF
 

--- a/kubernetes/scripts/k8s/host_volume_shell.sh
+++ b/kubernetes/scripts/k8s/host_volume_shell.sh
@@ -2,7 +2,9 @@
 
 set -e
 
-cat << EOF | kubectl apply -f -
+OASIS_CLUSTER_NAMESPACE="${OASIS_CLUSTER_NAMESPACE:-default}"
+
+cat << EOF | kubectl apply -n "$OASIS_CLUSTER_NAMESPACE" -f -
 apiVersion: v1
 kind: PersistentVolume
 metadata:
@@ -47,7 +49,7 @@ spec:
 ---
 EOF
 
-while ! kubectl get pods host-volume-shell | grep Running | grep "1/1"; do
+while ! kubectl get pods -n "$OASIS_CLUSTER_NAMESPACE" host-volume-shell | grep Running | grep "1/1"; do
   sleep 1
   echo -n .
 done
@@ -56,7 +58,7 @@ echo
 echo "Host volume mount point is /mnt/host/"
 echo
 
-kubectl exec -it host-volume-shell -- bash
-kubectl delete pod --grace-period=2 host-volume-shell
-kubectl delete pvc host-pv-claim
-kubectl delete pv host-pv
+kubectl exec -it -n "$OASIS_CLUSTER_NAMESPACE" host-volume-shell -- bash
+kubectl delete pod -n "$OASIS_CLUSTER_NAMESPACE" --grace-period=2 host-volume-shell
+kubectl delete pvc -n "$OASIS_CLUSTER_NAMESPACE" host-pv-claim
+kubectl delete pv -n "$OASIS_CLUSTER_NAMESPACE" host-pv

--- a/kubernetes/scripts/k8s/port-forward.sh
+++ b/kubernetes/scripts/k8s/port-forward.sh
@@ -48,9 +48,11 @@ for arg in "${@}"; do
 
 done
 
+OASIS_CLUSTER_NAMESPACE="${OASIS_CLUSTER_NAMESPACE:-default}"
+
 for fw in "${forwards[@]}"; do
   echo $fw
-  kubectl port-forward $fw &
+  kubectl port-forward -n "$OASIS_CLUSTER_NAMESPACE" $fw &
   pids="$pids $!"
 done
 

--- a/kubernetes/scripts/k8s/set_ingress_ip.sh
+++ b/kubernetes/scripts/k8s/set_ingress_ip.sh
@@ -2,7 +2,9 @@
 
 set -e
 
-IP="$(kubectl get svc --template="{{range .items}}{{range .status.loadBalancer.ingress}}{{.ip}}{{end}}{{end}}")"
+OASIS_CLUSTER_NAMESPACE="${OASIS_CLUSTER_NAMESPACE:-default}"
+
+IP="$(kubectl get svc -n "$OASIS_CLUSTER_NAMESPACE" --template="{{range .items}}{{range .status.loadBalancer.ingress}}{{.ip}}{{end}}{{end}}")"
 
 echo "Found IP: $IP"
 

--- a/kubernetes/worker-controller/src/worker_controller.py
+++ b/kubernetes/worker-controller/src/worker_controller.py
@@ -45,6 +45,7 @@ def parse_args():
     parser.add_argument('--secure', help='Flag if https and wss should be used', default=bool(getenv('OASIS_API_SECURE')), action='store_true')
     parser.add_argument('--username', help='The username of the worker controller user', default=getenv('OASIS_USERNAME') or 'admin')
     parser.add_argument('--password', help='The password of the worker controller user', default=getenv('OASIS_PASSWORD') or 'password')
+    parser.add_argument('--namespace', help='Namespace of cluster where oasis is deployed to', default=getenv('OASIS_CLUSTER_NAMESPACE') or 'default')
     parser.add_argument('--limit', help='Hard limit for the total number of workers created', default=getenv('OASIS_TOTAL_WORKER_LIMIT'))
     parser.add_argument('--prioritized-models-limit', help='When prioritized runs are used - create workers for the models with the highest priority', default=getenv('OASIS_PRIORITIZED_MODELS_LIMIT'))
     parser.add_argument('--cluster', help='Type of kubernetes cluster to connect to, either "local" (~/.kube/config)\
@@ -78,14 +79,14 @@ def main():
     event_loop = asyncio.get_event_loop()
 
     # Create cluster client and load configuration
-    cluster_client = ClusterClient()
+    cluster_client = ClusterClient(args.namespace)
     event_loop.run_until_complete(cluster_client.load_config(args.cluster))
 
     # Create the autoscaler to bind everything together
     autoscaler = AutoScaler(deployments, cluster_client, oasis_client, args.prioritized_models_limit, args.limit)
 
     # Create the deployment watcher and load all available deployments
-    deployments_watcher = DeploymentWatcher(deployments)
+    deployments_watcher = DeploymentWatcher(args.namespace, deployments)
     event_loop.run_until_complete(deployments_watcher.load_deployments())
     deployments.print_list()
 

--- a/src/server/oasisapi/settings.py
+++ b/src/server/oasisapi/settings.py
@@ -305,7 +305,7 @@ if IN_TEST:
 CHANNEL_LAYER_HOST = iniconf.settings.get('server', 'channel_layer_host', fallback='localhost')
 CHANNEL_LAYER_PASS = iniconf.settings.get('server', 'channel_layer_pass', fallback='')
 CHANNEL_LAYER_USER = iniconf.settings.get('server', 'channel_layer_user', fallback='')
-CHANNEL_LAYER_PORT = iniconf.settings.get('server', 'channel_layer_user', fallback='6379')
+CHANNEL_LAYER_PORT = iniconf.settings.get('server', 'channel_layer_port', fallback='6379')
 CHANNEL_LAYERS = {
     'default': {
         'BACKEND': 'channels_redis.core.RedisChannelLayer',

--- a/src/server/oasisapi/settings.py
+++ b/src/server/oasisapi/settings.py
@@ -221,6 +221,9 @@ USE_I18N = True
 USE_L10N = True
 USE_TZ = True
 
+# Place the app in a sub path (swagger still available in /)
+FORCE_SCRIPT_NAME = '/api'
+
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/2.0/howto/static-files/
 MEDIA_URL = '/api/media/'


### PR DESCRIPTION
Update the `platform-2.0-analysis-priority_failure-recovery` with the updated change from sprint 5

<!--start_release_notes-->
##  Sprint 6

This spring included mostly testing to make sure it could recover from different failures, for example:
 - Randomly failed worker tasks.
 - Lost database connection.
 - Filesystem error.
 - Lost worker for unknown reason.

**Features included:**

* Platform chart improvements:
  * RabbitMQ ack timeout disabled (introduced in 3.8.15)
* Platform improvements:
  * Enabled retry for worker tasks - A failed task will be run again 2 times.
* Verified that the platform recovers from:
  * Randomly failed worker tasks - Each task will be retried 2 times before it is marked as failed.
  * Lost database connection - celery will reconnect and retry the task.
  * Disk error - Each task will be retried 2 times before it is marked as failed.
  * Lost worker - task is picked up by other worker.

**This covers the following in the functional summary:**

* Improved worker resilience to disconnection/failure (1.6)
Improved worker resilience to disconnection/failure (1.6)
<!--end_release_notes-->
