### PR TITLE
Fix/576 limit worker logging

### DIFF
--- a/conf.ini
+++ b/conf.ini
@@ -32,6 +32,7 @@ TOKEN_REFRESH_ROTATE = True
 
 [worker]
 DISABLE_WORKER_REG = False
+DEBUG = False
 AWS_SHARED_BUCKET=True
 AWS_LOCATION=worker
 MODEL_SETTINGS_FILE = /home/worker/model/meta-data/model_settings.json

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export OASIS_MODEL_DATA_DIR=<..path to piwind ..>
+export OASIS_MODEL_DATA_DIR=/home/sam/repos/models/piwind
 
 docker rmi coreoasis/api_server:latest
 docker rmi coreoasis/model_worker:latest

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export OASIS_MODEL_DATA_DIR=/home/sam/repos/models/piwind
+export OASIS_MODEL_DATA_DIR=<..path to piwind ..>
 
 docker rmi coreoasis/api_server:latest
 docker rmi coreoasis/model_worker:latest

--- a/src/model_execution_worker/tasks.py
+++ b/src/model_execution_worker/tasks.py
@@ -42,6 +42,7 @@ app = Celery()
 app.config_from_object(celery_conf)
 logging.info("Started worker")
 filestore = StorageSelector(settings)
+debug_worker = settings.getboolean('worker', 'DEBUG', fallback=False)
 
 
 class TemporaryDir(object):
@@ -194,20 +195,21 @@ def register_worker(sender, **k):
     logging.info("STORAGE_MANAGER: {}".format(type(filestore)))
     logging.info("STORAGE_TYPE: {}".format(settings.get('worker', 'STORAGE_TYPE', fallback='None')))
 
-    if selected_storage in ['local-fs', 'shared-fs']:
-        logging.info("MEDIA_ROOT: {}".format(settings.get('worker', 'MEDIA_ROOT')))
+    if debug_worker:
+        logging.info("MODEL_DATA_DIRECTORY: {}".format(settings.get('worker', 'MODEL_DATA_DIRECTORY', fallback='/home/worker/model')))
+        if selected_storage in ['local-fs', 'shared-fs']:
+            logging.info("MEDIA_ROOT: {}".format(settings.get('worker', 'MEDIA_ROOT')))
 
-    elif selected_storage in ['aws-s3', 'aws', 's3']:
-        logging.info("AWS_BUCKET_NAME: {}".format(settings.get('worker', 'AWS_BUCKET_NAME', fallback='None')))
-        logging.info("AWS_SHARED_BUCKET: {}".format(settings.get('worker', 'AWS_SHARED_BUCKET', fallback='None')))
-        logging.info("AWS_LOCATION: {}".format(settings.get('worker', 'AWS_LOCATION', fallback='None')))
-        logging.info("AWS_ACCESS_KEY_ID: {}".format(settings.get('worker', 'AWS_ACCESS_KEY_ID', fallback='None')))
-        logging.info("AWS_QUERYSTRING_EXPIRE: {}".format(settings.get('worker', 'AWS_QUERYSTRING_EXPIRE', fallback='None')))
-        logging.info("AWS_QUERYSTRING_AUTH: {}".format(settings.get('worker', 'AWS_QUERYSTRING_AUTH', fallback='None')))
-        logging.info('AWS_LOG_LEVEL: {}'.format(settings.get('worker', 'AWS_LOG_LEVEL', fallback='None')))
+        elif selected_storage in ['aws-s3', 'aws', 's3']:
+            logging.info("AWS_BUCKET_NAME: {}".format(settings.get('worker', 'AWS_BUCKET_NAME', fallback='None')))
+            logging.info("AWS_SHARED_BUCKET: {}".format(settings.get('worker', 'AWS_SHARED_BUCKET', fallback='None')))
+            logging.info("AWS_LOCATION: {}".format(settings.get('worker', 'AWS_LOCATION', fallback='None')))
+            logging.info("AWS_ACCESS_KEY_ID: {}".format(settings.get('worker', 'AWS_ACCESS_KEY_ID', fallback='None')))
+            logging.info("AWS_QUERYSTRING_EXPIRE: {}".format(settings.get('worker', 'AWS_QUERYSTRING_EXPIRE', fallback='None')))
+            logging.info("AWS_QUERYSTRING_AUTH: {}".format(settings.get('worker', 'AWS_QUERYSTRING_AUTH', fallback='None')))
+            logging.info('AWS_LOG_LEVEL: {}'.format(settings.get('worker', 'AWS_LOG_LEVEL', fallback='None')))
 
     # Optional ENV
-    logging.info("MODEL_DATA_DIRECTORY: {}".format(settings.get('worker', 'MODEL_DATA_DIRECTORY', fallback='/home/worker/model')))
     logging.info("MODEL_SETTINGS_FILE: {}".format(settings.get('worker', 'MODEL_SETTINGS_FILE', fallback='None')))
     logging.info("DISABLE_WORKER_REG: {}".format(settings.getboolean('worker', 'DISABLE_WORKER_REG', fallback='False')))
     logging.info("KEEP_RUN_DIR: {}".format(settings.get('worker', 'KEEP_RUN_DIR', fallback='False')))
@@ -216,24 +218,25 @@ def register_worker(sender, **k):
     logging.info("OASISLMF_CONFIG: {}".format(settings.get('worker', 'oasislmf_config', fallback='None')))
 
     # Log Env variables
-    if settings.getboolean('worker', 'DEBUG', fallback=False):
-        # show all env variables
+    if debug_worker:
+        # show all env variables and  override root log level
         logging.info('ALL_OASIS_ENV_VARS:' + json.dumps({k: v for (k, v) in os.environ.items() if k.startswith('OASIS_')}, indent=4))
-    else: 
-        # Limit Env variables to run only variables 
+    else:
+        # Limit Env variables to run only variables
         logging.info('OASIS_ENV_VARS:' + json.dumps({
             k: v for (k, v) in os.environ.items() if k.startswith('OASIS_') and not any(
                 substring in k for substring in [
-                    'SERVER', 
-                    'CELERY', 
-                    'RABBIT', 
+                    'SERVER',
+                    'CELERY',
+                    'RABBIT',
                     'BROKER',
-                    'USER', 
+                    'USER',
                     'PASS',
                     'PORT',
                     'HOST',
+                    'ROOT',
+                    'DIR',
                 ])}, indent=4))
-
 
     # Clean up multiprocess tmp dirs on startup
     for tmpdir in glob.glob("/tmp/pymp-*"):
@@ -312,7 +315,7 @@ def start_analysis_task(self, analysis_pk, input_location, analysis_settings, co
                 complex_data_files=complex_data_files
             )
 
-        except Terminated:    
+        except Terminated:
             sys.exit('Task aborted')
         except Exception:
             logging.exception("Model execution task failed.")
@@ -347,7 +350,7 @@ def start_analysis(analysis_settings, input_location, complex_data_files=None):
         logging.info('TASK CANCELLATION')
         if proc is not None:
             os.killpg(os.getpgid(proc.pid), 15)
-        raise Terminated("Cancellation request sent from API")    
+        raise Terminated("Cancellation request sent from API")
 
     proc = None  # Popen object for subpross runner
     signals['SIGTERM'] = analysis_cancel_handler
@@ -389,23 +392,27 @@ def start_analysis(analysis_settings, input_location, complex_data_files=None):
         args_list = run_args + [''] if (len(run_args) % 2) else run_args
         mdk_args = [x for t in list(zip(*[iter(args_list)] * 2)) if (None not in t) and ('--model-run-dir' not in t) for x in t]
         logging.info('run_directory: {}'.format(oasis_files_dir))
-        logging.info('args_list: {}'.format(str(run_args)))
-        logging.info("\nRUNNING: \noasislmf model generate-losses {}".format(
-            " ".join([str(arg) for arg in mdk_args])
-        ))
-        logging.info(run_args)
+        #logging.info('args_list: {}'.format(str(run_args)))
+        logging.info("\nExecuting: generate-losses")
+        if debug_worker:
+            logging.info("\nCLI command: \noasislmf model generate-losses {}".format(
+                " ".join([str(arg) for arg in mdk_args])
+            ))
+            logging.info(run_args)
 
         # Subprocess Execution
         worker_env = os.environ.copy()
+
         proc = subprocess.Popen(
             ['oasislmf', 'model', 'generate-losses'] + run_args,
             stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=worker_env,
             preexec_fn=os.setsid,   # run the program in a new session, assigning a new process group to it and its children.
         )
-
-        # Log output and close 
         stdout, stderr = proc.communicate()
-        logging.info('stdout: {}'.format(stdout.decode()))
+
+        if debug_worker:
+            logging.info('stdout: {}'.format(stdout.decode()))
+
         logging.info('stderr: {}'.format(stderr.decode()))
         proc.terminate()
 
@@ -463,7 +470,7 @@ def generate_input(self,
         logging.info('TASK CANCELLATION')
         if proc is not None:
             os.killpg(os.getpgid(proc.pid), 15)
-        raise Terminated("Cancellation request sent from API")    
+        raise Terminated("Cancellation request sent from API")
 
     proc = None  # Popen object for subpross runner
     signals['SIGTERM'] = generate_input_cancel_handler
@@ -516,14 +523,20 @@ def generate_input(self,
         if model_settings_fp and os.path.isfile(model_settings_fp):
             run_args += ['--model-settings-json', model_settings_fp]
 
+        if debug_worker:
+            run_args += ['--verbose']
+
+
         # Log MDK generate command
         args_list = run_args + [''] if (len(run_args) % 2) else run_args
         mdk_args = [x for t in list(zip(*[iter(args_list)] * 2)) if None not in t for x in t]
         logging.info('run_directory: {}'.format(oasis_files_dir))
-        logging.info('args_list: {}'.format(str(run_args)))
-        logging.info("\nRUNNING: \noasislmf model generate-oasis-files {}".format(
-            " ".join([str(arg) for arg in mdk_args])
-        ))
+        #logging.info('args_list: {}'.format(str(run_args)))
+        logging.info("\nExecuting: generate-oasis-files")
+        if debug_worker:
+            logging.info("\nCLI command: \noasislmf model generate-oasis-files {}".format(
+                " ".join([str(arg) for arg in mdk_args])
+            ))
 
         # Subprocess Execution
         worker_env = os.environ.copy()
@@ -532,10 +545,11 @@ def generate_input(self,
             stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=worker_env,
             preexec_fn=os.setsid, # run in a new session, assigning a new process group to it and its children.
         )
-
-        # Log output and close 
         stdout, stderr = proc.communicate()
-        logging.info('stdout: {}'.format(stdout.decode()))
+
+        # Log output and close
+        if debug_worker:
+            logging.info('stdout: {}'.format(stdout.decode()))
         logging.info('stderr: {}'.format(stderr.decode()))
         proc.terminate()
 
@@ -565,7 +579,7 @@ def on_error(request, ex, traceback, record_task_name, analysis_pk, initiator_pk
     This function takes the error and passes it on back to the server so that it can store
     the info on the analysis.
     """
-    # Ignore exceptions raised from Job cancellations 
+    # Ignore exceptions raised from Job cancellations
     if not isinstance(ex, Terminated):
         signature(
             record_task_name,

--- a/src/model_execution_worker/tasks.py
+++ b/src/model_execution_worker/tasks.py
@@ -214,8 +214,23 @@ def register_worker(sender, **k):
     logging.info("BASE_RUN_DIR: {}".format(settings.get('worker', 'BASE_RUN_DIR', fallback='None')))
     logging.info("OASISLMF_CONFIG: {}".format(settings.get('worker', 'oasislmf_config', fallback='None')))
 
-    # Log All Env variables
-    logging.info('OASIS_ENV_VARS:' + json.dumps({k: v for (k, v) in os.environ.items() if k.startswith('OASIS_')}, indent=4))
+    # Log Env variables
+    if settings.getboolean('worker', 'DEBUG', fallback=False):
+        # show all env variables
+        logging.info('ALL_OASIS_ENV_VARS:' + json.dumps({k: v for (k, v) in os.environ.items() if k.startswith('OASIS_')}, indent=4))
+    else: 
+        # Limit Env variables to run only variables 
+        logging.info('OASIS_ENV_VARS:' + json.dumps({
+            k: v for (k, v) in os.environ.items() if k.startswith('OASIS_') and not any(
+                substring in k for substring in [
+                    'SERVER', 
+                    'CELERY', 
+                    'RABBIT', 
+                    'USER', 
+                    'PASS',
+                    'BROKER',
+                ])}, indent=4))
+
 
     # Clean up multiprocess tmp dirs on startup
     for tmpdir in glob.glob("/tmp/pymp-*"):

--- a/src/model_execution_worker/tasks.py
+++ b/src/model_execution_worker/tasks.py
@@ -211,6 +211,7 @@ def register_worker(sender, **k):
     logging.info("MODEL_SETTINGS_FILE: {}".format(settings.get('worker', 'MODEL_SETTINGS_FILE', fallback='None')))
     logging.info("DISABLE_WORKER_REG: {}".format(settings.getboolean('worker', 'DISABLE_WORKER_REG', fallback='False')))
     logging.info("KEEP_RUN_DIR: {}".format(settings.get('worker', 'KEEP_RUN_DIR', fallback='False')))
+    logging.info("DEBUG: {}".format(settings.get('worker', 'DEBUG', fallback='False')))
     logging.info("BASE_RUN_DIR: {}".format(settings.get('worker', 'BASE_RUN_DIR', fallback='None')))
     logging.info("OASISLMF_CONFIG: {}".format(settings.get('worker', 'oasislmf_config', fallback='None')))
 
@@ -226,9 +227,11 @@ def register_worker(sender, **k):
                     'SERVER', 
                     'CELERY', 
                     'RABBIT', 
+                    'BROKER',
                     'USER', 
                     'PASS',
-                    'BROKER',
+                    'PORT',
+                    'HOST',
                 ])}, indent=4))
 
 


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue after submitting a Pull Request. -->

<!--start_release_notes-->
### Filter worker environment variable logging when not in debug mode 
Before this fix this line might leak sensitive information into the worker logs [tasks.py#L218](https://github.com/OasisLMF/OasisPlatform/blob/9ec485463321b82ff9bd850113517ddc61d5b1ac/src/model_execution_worker/tasks.py#L218)

* Fixed by filtering out any environment variable names which contain the following key words ` [ 'SERVER', 
                    'CELERY', 
                    'RABBIT', 
                    'BROKER',
                    'USER', 
                    'PASS',
                    'PORT',
                    'HOST',
                    'ROOT',
                    'DIR']
` 
* The standard output from oasislmf is now hidden from the worker logs by default. The full output will still be stored as traceback files and saved in the platform's analysis (regardless of the debug mode). 


To view all the variables and oasislmf output set the following env `OASIS_DEBUG=True` or add `DEBUG=True` to the **[worker]** section of the conf.ini file.    

**Non-Debug mode worker logging** 
```
[2021-12-17 14:10:14,156: INFO/MainProcess] OASISLMF_CONFIG: None
[2021-12-17 14:10:14,156: INFO/MainProcess] OASIS_ENV_VARS:{
    "OASIS_MODEL_VERSION_ID": "1",
    "OASIS_MODEL_ID": "PiWind",
    "OASIS_INI_PATH": "/home/worker/conf.ini",
    "OASIS_ENV_OVERRIDE": "true",
    "OASIS_MODEL_SUPPLIER_ID": "OasisLMF"
}
[2021-12-17 14:10:14,156: INFO/MainProcess] celery@920bdd083a2f ready.
[2021-12-17 14:10:15,613: INFO/MainProcess] Events of group {task} enabled by remote.
``` 

[worker_logs_debug_off.txt](https://github.com/OasisLMF/OasisPlatform/files/7736474/worker_logs_debug_off.txt)


<!--end_release_notes-->
