### PR TITLE
Fix CVE-2021-44420 for Django

### DIFF
--- a/requirements-server.txt
+++ b/requirements-server.txt
@@ -74,7 +74,7 @@ daphne==3.0.2
     # via
     #   -r requirements-server.in
     #   channels
-django==3.2.9
+django==3.2.10
     # via
     #   -r requirements-server.in
     #   channels

--- a/requirements.txt
+++ b/requirements.txt
@@ -132,7 +132,7 @@ decorator==5.1.0
     #   ipython
 distlib==0.3.3
     # via virtualenv
-django==3.2.9
+django==3.2.10
     # via
     #   -r ./requirements-server.in
     #   channels


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue after submitting a Pull Request. -->

<!--start_release_notes-->
### Django Security patch 
[CVE-2021-44420](https://nvd.nist.gov/vuln/detail/CVE-2021-44420)  - HTTP requests for URLs with trailing newlines could bypass upstream access control based on URL paths.
<!--end_release_notes-->
