### PR TITLE
Fix/580 per request debugging logs

### DIFF
--- a/requirements-server.in
+++ b/requirements-server.in
@@ -10,6 +10,7 @@ django-cleanup
 django-filter
 django-model-utils>=4.0.0
 django-storages
+django-request-logging
 djangorestframework
 djangorestframework_simplejwt
 drf-yasg>=1.17.1

--- a/requirements-server.txt
+++ b/requirements-server.txt
@@ -80,6 +80,7 @@ django==3.2.10
     #   channels
     #   django-filter
     #   django-model-utils
+    #   django-request-logging
     #   django-storages
     #   djangorestframework
     #   djangorestframework-simplejwt
@@ -89,6 +90,8 @@ django-cleanup==5.2.0
 django-filter==21.1
     # via -r requirements-server.in
 django-model-utils==4.2.0
+    # via -r requirements-server.in
+django-request-logging==0.7.3
     # via -r requirements-server.in
 django-storages==1.12.3
     # via -r requirements-server.in

--- a/src/server/oasisapi/settings.py
+++ b/src/server/oasisapi/settings.py
@@ -79,6 +79,7 @@ MIDDLEWARE = [
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'whitenoise.middleware.WhiteNoiseMiddleware',
+    'request_logging.middleware.LoggingMiddleware',
 ]
 
 
@@ -239,10 +240,17 @@ REST_FRAMEWORK = {
 
 LOGGING = {
     'version': 1,
-    'disable_existing_loggers': True,
+    'disable_existing_loggers': False,
     'root': {
         'level': 'DEBUG',
         'handlers': ['console'],
+    },
+    'loggers': {
+        'django.request': {
+            'handlers': ['console'],
+            'level': 'DEBUG',  # change debug level as appropiate
+            'propagate': False,
+        },
     },
     'formatters': {
         'verbose': {

--- a/src/server/oasisapi/settings.py
+++ b/src/server/oasisapi/settings.py
@@ -31,9 +31,17 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/2.0/howto/deployment/checklist/
 
-# SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = iniconf.settings.getboolean('server', 'debug', fallback=False)
-DEBUG_TOOLBAR = iniconf.settings.getboolean('server', 'debug_toolbar', fallback=False)
+if (len(sys.argv) >= 2 and sys.argv[1] == 'runserver'):
+    # Always set Debug mode when in dev environment
+    MEDIA_ROOT = './shared-fs/'
+    DEBUG = True
+    DEBUG_TOOLBAR = True
+else:
+    # SECURITY WARNING: don't run with debug turned on in production!
+    MEDIA_ROOT = iniconf.settings.get('server', 'media_root', fallback=os.path.join(BASE_DIR, 'media'))
+    DEBUG = iniconf.settings.getboolean('server', 'debug', fallback=False)
+    DEBUG_TOOLBAR = iniconf.settings.getboolean('server', 'debug_toolbar', fallback=False)
+
 
 # Django 3.2 - the default pri-key field changed to 'BigAutoField.',
 # https://docs.djangoproject.com/en/3.2/releases/3.2/#customizing-type-of-auto-created-primary-keys
@@ -161,7 +169,6 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/2.0/howto/static-files/
 MEDIA_URL = '/media/'
-MEDIA_ROOT = iniconf.settings.get('server', 'media_root', fallback=os.path.join(BASE_DIR, 'media'))
 STATIC_URL = '/static/'
 STATIC_ROOT = os.path.join(BASE_DIR, 'static')
 STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'

--- a/src/server/oasisapi/settings.py
+++ b/src/server/oasisapi/settings.py
@@ -35,6 +35,10 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 DEBUG = iniconf.settings.getboolean('server', 'debug', fallback=False)
 DEBUG_TOOLBAR = iniconf.settings.getboolean('server', 'debug_toolbar', fallback=False)
 
+# Django 3.2 - the default pri-key field changed to 'BigAutoField.',
+# https://docs.djangoproject.com/en/3.2/releases/3.2/#customizing-type-of-auto-created-primary-keys
+DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
+
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = iniconf.settings.get('server', 'secret_key', fallback='' if not DEBUG else 'supersecret')
 
@@ -249,6 +253,11 @@ LOGGING = {
     },
     'loggers': {
         'drf_yasg': {
+                'handlers': ['console'],
+                'level': 'WARNING',
+                'propagate': False,
+        },
+        'numexpr': {
                 'handlers': ['console'],
                 'level': 'WARNING',
                 'propagate': False,

--- a/src/server/oasisapi/settings.py
+++ b/src/server/oasisapi/settings.py
@@ -46,6 +46,7 @@ else:
 
 # Application definition
 
+
 INSTALLED_APPS = [
     'django.contrib.admin',
     'django.contrib.auth',
@@ -79,9 +80,11 @@ MIDDLEWARE = [
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'whitenoise.middleware.WhiteNoiseMiddleware',
-    'request_logging.middleware.LoggingMiddleware',
 ]
 
+
+if DEBUG:
+    MIDDLEWARE.append('request_logging.middleware.LoggingMiddleware')
 
 if DEBUG_TOOLBAR:
     INSTALLED_APPS.append('debug_toolbar')
@@ -201,7 +204,7 @@ elif STORAGE_TYPE in AWS_S3:
     # AWS S3 Object Store via `Django-Storages`
     DEFAULT_FILE_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
     set_aws_log_level(AWS_LOG_EVEL)
-    
+
 else:
     raise ImproperlyConfigured('Invalid value for STORAGE_TYPE: {}'.format(STORAGE_TYPE))
 
@@ -237,7 +240,6 @@ REST_FRAMEWORK = {
     'DEFAULT_VERSION': 'v1',
 }
 
-
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,
@@ -246,10 +248,10 @@ LOGGING = {
         'handlers': ['console'],
     },
     'loggers': {
-        'django.request': {
-            'handlers': ['console'],
-            'level': 'DEBUG',  # change debug level as appropiate
-            'propagate': False,
+        'drf_yasg': {
+                'handlers': ['console'],
+                'level': 'WARNING',
+                'propagate': False,
         },
     },
     'formatters': {
@@ -265,6 +267,12 @@ LOGGING = {
         }
     },
 }
+if DEBUG:
+    LOGGING['loggers']['django.request'] = {
+        'handlers': ['console'],
+        'level': 'DEBUG',  # change debug level as appropiate
+        'propagate': False,
+    }
 
 
 if IN_TEST:


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue after submitting a Pull Request. -->

<!--start_release_notes-->
### Added detailed server logging when in Debug mode  

<!--end_release_notes-->


**Debug off**
```
Quit the server with CONTROL-C. 
[22/Dec/2021 11:59:29] "GET / HTTP/1.1" 200 2344
[22/Dec/2021 11:59:29] "GET /static/drf-yasg/swagger-ui-dist/swagger-ui-bundle.ee32fa5b4197.js HTTP/1.1" 304 0
[22/Dec/2021 11:59:29] "GET /static/drf-yasg/swagger-ui-dist/swagger-ui-standalone-preset.f76577cd29dc.js HTTP/1.1" 304 0
[22/Dec/2021 11:59:29] "GET /static/drf-yasg/insQ.min.90ab21607447.js HTTP/1.1" 304 0
[22/Dec/2021 11:59:29] "GET /static/drf-yasg/immutable.min.d985bc61d85c.js HTTP/1.1" 304 0
[22/Dec/2021 11:59:29] "GET /static/drf-yasg/swagger-ui-init.4581b8d51ebc.js HTTP/1.1" 304 0 
[22/Dec/2021 11:59:29] "GET /static/drf-yasg/url-polyfill.min.5ec37fdadbc5.js HTTP/1.1" 304 0
[22/Dec/2021 11:59:29] "GET /?format=openapi HTTP/1.1" 200 112565
[22/Dec/2021 11:59:38] "GET /healthcheck/ HTTP/1.1" 200 15 
[22/Dec/2021 11:59:46] "GET /oed_peril_codes/ HTTP/1.1" 200 1666
WARNING 2021-12-22 11:59:59,766 log 14490 140676383893056 Unauthorized: /v1/analyses/
[22/Dec/2021 11:59:59] "GET /v1/analyses/ HTTP/1.1" 401 58
```
**Debug on**
```
Quit the server with CONTROL-C.
INFO 2021-12-22 12:01:26,150 middleware 14947 139963357230656 GET /
DEBUG 2021-12-22 12:01:26,151 middleware 14947 139963357230656 {'Content-Length': '', 'Content-Type': 'text/plain', 'Host': 'localhost:8000', 'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64; rv:95.0) Gecko/20100101 Firefox/95.0', 'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8', 'Accept-Language': 'en', 'Accept-Encoding': 'gzip, deflate', 'Dnt': '1', 'Connection': 'keep-alive', 'Cookie': 'csrftoken=1n8sek17KGmIIuEHBWaF7WtsMFSFUGaj8JRK4JrQOoUYs9dZHOJvzpK3ElAYNf1J', 'Upgrade-Insecure-Requests': '1', 'Sec-Fetch-Dest': 'document', 'Sec-Fetch-Mode': 'navigate', 'Sec-Fetch-Site': 'cross-site', 'Cache-Control': 'max-age=0'}
DEBUG 2021-12-22 12:01:26,151 middleware 14947 139963357230656 b''
INFO 2021-12-22 12:01:26,151 middleware 14947 139963357230656 GET / - 200
[22/Dec/2021 12:01:26] "GET / HTTP/1.1" 200 2214
[22/Dec/2021 12:01:26] "GET /static/drf-yasg/style.css HTTP/1.1" 200 1047
[22/Dec/2021 12:01:26] "GET /static/drf-yasg/url-polyfill.min.js HTTP/1.1" 200 6092
[22/Dec/2021 12:01:26] "GET /static/drf-yasg/insQ.min.js HTTP/1.1" 200 2093
[22/Dec/2021 12:01:26] "GET /static/drf-yasg/swagger-ui-dist/swagger-ui.css HTTP/1.1" 200 143074
[22/Dec/2021 12:01:26] "GET /static/drf-yasg/swagger-ui-init.js HTTP/1.1" 200 14715
[22/Dec/2021 12:01:26] "GET /static/drf-yasg/immutable.min.js HTTP/1.1" 200 56904
[22/Dec/2021 12:01:26] "GET /static/drf-yasg/swagger-ui-dist/swagger-ui-standalone-preset.js HTTP/1.1" 200 329649
[22/Dec/2021 12:01:26] "GET /static/drf-yasg/swagger-ui-dist/swagger-ui-bundle.js HTTP/1.1" 200 1038857
INFO 2021-12-22 12:01:26,410 middleware 14947 139963339396672 GET /?format=openapi
DEBUG 2021-12-22 12:01:26,410 middleware 14947 139963339396672 {'Content-Length': '', 'Content-Type': 'text/plain', 'Host': 'localhost:8000', 'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64; rv:95.0) Gecko/20100101 Firefox/95.0', 'Accept': 'application/json,*/*', 'Accept-Language': 'en', 'Accept-Encoding': 'gzip, deflate', 'Referer': 'http://localhost:8000/', 'X-Csrftoken': 'pYxW9h6yffnJS3HeXFfuwC72GFi1ygdfwkgeZGwhjXVZCIgw3xOkY5oDyl0krP4F', 'Dnt': '1', 'Connection': 'keep-alive', 'Cookie': 'csrftoken=1n8sek17KGmIIuEHBWaF7WtsMFSFUGaj8JRK4JrQOoUYs9dZHOJvzpK3ElAYNf1J', 'Sec-Fetch-Dest': 'empty', 'Sec-Fetch-Mode': 'cors', 'Sec-Fetch-Site': 'same-origin'}
DEBUG 2021-12-22 12:01:26,410 middleware 14947 139963339396672 b''
INFO 2021-12-22 12:01:26,410 middleware 14947 139963339396672 GET /?format=openapi - 200
[22/Dec/2021 12:01:26] "GET /?format=openapi HTTP/1.1" 200 112565
[22/Dec/2021 12:01:26] "GET /static/drf-yasg/swagger-ui-dist/favicon-32x32.png HTTP/1.1" 200 628
INFO 2021-12-22 12:01:48,462 middleware 14947 139963339396672 GET /healthcheck/
DEBUG 2021-12-22 12:01:48,462 middleware 14947 139963339396672 {'Content-Length': '', 'Content-Type': 'text/plain', 'Host': 'localhost:8000', 'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64; rv:95.0) Gecko/20100101 Firefox/95.0', 'Accept': 'application/json', 'Accept-Language': 'en', 'Accept-Encoding': 'gzip, deflate', 'Referer': 'http://localhost:8000/', 'X-Csrftoken': 'pYxW9h6yffnJS3HeXFfuwC72GFi1ygdfwkgeZGwhjXVZCIgw3xOkY5oDyl0krP4F', 'Dnt': '1', 'Connection': 'keep-alive', 'Cookie': 'csrftoken=1n8sek17KGmIIuEHBWaF7WtsMFSFUGaj8JRK4JrQOoUYs9dZHOJvzpK3ElAYNf1J', 'Sec-Fetch-Dest': 'empty', 'Sec-Fetch-Mode': 'cors', 'Sec-Fetch-Site': 'same-origin'}
DEBUG 2021-12-22 12:01:48,462 middleware 14947 139963339396672 b''
INFO 2021-12-22 12:01:48,462 middleware 14947 139963339396672 GET /healthcheck/ - 200
DEBUG 2021-12-22 12:01:48,462 middleware 14947 139963339396672 {'Content-Type': 'application/json', 'Allow': 'GET'}
DEBUG 2021-12-22 12:01:48,462 middleware 14947 139963339396672 b'{"status":"OK"}'
[22/Dec/2021 12:01:48] "GET /healthcheck/ HTTP/1.1" 200 15
INFO 2021-12-22 12:01:53,951 middleware 14947 139963339396672 GET /oed_peril_codes/
DEBUG 2021-12-22 12:01:53,951 middleware 14947 139963339396672 {'Content-Length': '', 'Content-Type': 'text/plain', 'Host': 'localhost:8000', 'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64; rv:95.0) Gecko/20100101 Firefox/95.0', 'Accept': 'application/json', 'Accept-Language': 'en', 'Accept-Encoding': 'gzip, deflate', 'Referer': 'http://localhost:8000/', 'X-Csrftoken': 'pYxW9h6yffnJS3HeXFfuwC72GFi1ygdfwkgeZGwhjXVZCIgw3xOkY5oDyl0krP4F', 'Dnt': '1', 'Connection': 'keep-alive', 'Cookie': 'csrftoken=1n8sek17KGmIIuEHBWaF7WtsMFSFUGaj8JRK4JrQOoUYs9dZHOJvzpK3ElAYNf1J', 'Sec-Fetch-Dest': 'empty', 'Sec-Fetch-Mode': 'cors', 'Sec-Fetch-Site': 'same-origin'}
DEBUG 2021-12-22 12:01:53,951 middleware 14947 139963339396672 b''
INFO 2021-12-22 12:01:53,951 middleware 14947 139963339396672 GET /oed_peril_codes/ - 200
DEBUG 2021-12-22 12:01:53,951 middleware 14947 139963339396672 {'Content-Type': 'application/json', 'Allow': 'GET'}
DEBUG 2021-12-22 12:01:53,951 middleware 14947 139963339396672 b'{"peril_codes":{"BBF":{"desc":"Wildfire / Bushfire"},"BFR":{"desc":"NonCat"},"BSK":{"desc":"Smoke"},"MNT":{"desc":"NBCR Terrorism"},"MTR":{"desc":"Conventional Terrorism"},"ORF":{"desc":"River / Fluvial Flood"},"OSF":{"desc":"Flash / Surface / Pluvial Flood"},"QEQ":{"desc":"Earthquake - Shake only"},"QFF":{"desc":"Fire Following"},"QLF":{"desc":"Liquefaction"},"QLS":{"desc":"Landslide"},"QSL":{"desc":"Sprinkler Leakage"},"QTS":{"desc":"Tsunami"},"WEC":{"desc":"Extra Tropical Cyclone"},"WSS":{"desc":"Storm Surge"},"WTC":{"desc":"Tropical Cyclone"},"XHL":{"desc":"Hail"},"XLT":{"desc":"Lightning"},"XSL":{"desc":"Straight-line / other convective wind"},"XTD":{"desc":"Tornado"},"ZFZ":{"desc":"Freeze"},"ZIC":{"desc":"Ice"},"ZSN":{"desc":"Snow"},"ZST":{"desc":"Winterstorm Wind"}},"peril_groups":{"AA1":{"desc":"All perils","peril_ids":["QEQ","QFF","QTS","QSL","QLS","QLF","WTC","WEC","WSS","ORF","OSF","XSL","XTD","XHL","ZSN","ZIC","ZFZ","BFR","BBF","MNT","MTR","XLT","ZST","BSK"]},"BB1":{"desc":"Wildfire with smoke","peril_ids":["BBF","BSK"]},"MM1":{"desc":"Terrorism","peril_ids":["MNT","MTR"]},"OO1":{"desc":"Flood w/o storm surge","peril_ids":["ORF","OSF"]},"QQ1":{"desc":"All EQ perils","peril_ids":["QEQ","QFF","QTS","QSL","QLS","QLF"]},"WW1":{"desc":"Windstorm with storm surge","peril_ids":["WTC","WEC","WSS"]},"WW2":{"desc":"Windstorm w/o storm surge","peril_ids":["WTC","WEC"]},"XX1":{"desc":"Convective Storm","peril_ids":["XSL","XTD","XHL","XLT"]},"XZ1":{"desc":"Convective storm (incl winter storm) - for RMS users","peril_ids":["XSL","XTD","XHL","ZSN","ZIC","ZFZ","XLT","ZST"]},"ZZ1":{"desc":"Winter storm","peril_ids":["ZSN","ZIC","ZFZ","ZST"]}}}'
[22/Dec/2021 12:01:53] "GET /oed_peril_codes/ HTTP/1.1" 200 1666
INFO 2021-12-22 12:02:00,794 middleware 14947 139963339396672 GET /v1/analyses/
ERROR 2021-12-22 12:02:00,794 middleware 14947 139963339396672 {'Content-Length': '', 'Content-Type': 'text/plain', 'Host': 'localhost:8000', 'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64; rv:95.0) Gecko/20100101 Firefox/95.0', 'Accept': 'application/json', 'Accept-Language': 'en', 'Accept-Encoding': 'gzip, deflate', 'Referer': 'http://localhost:8000/', 'X-Csrftoken': 'pYxW9h6yffnJS3HeXFfuwC72GFi1ygdfwkgeZGwhjXVZCIgw3xOkY5oDyl0krP4F', 'Dnt': '1', 'Connection': 'keep-alive', 'Cookie': 'csrftoken=1n8sek17KGmIIuEHBWaF7WtsMFSFUGaj8JRK4JrQOoUYs9dZHOJvzpK3ElAYNf1J', 'Sec-Fetch-Dest': 'empty', 'Sec-Fetch-Mode': 'cors', 'Sec-Fetch-Site': 'same-origin'}
ERROR 2021-12-22 12:02:00,794 middleware 14947 139963339396672 b''
INFO 2021-12-22 12:02:00,794 middleware 14947 139963339396672 GET /v1/analyses/ - 401
ERROR 2021-12-22 12:02:00,794 middleware 14947 139963339396672 {'Content-Type': 'application/json', 'WWW-Authenticate': 'Bearer realm="api"', 'Allow': 'GET, POST, HEAD, OPTIONS'}
ERROR 2021-12-22 12:02:00,794 middleware 14947 139963339396672 b'{"detail":"Authentication credentials were not provided."}'
WARNING 2021-12-22 12:02:00,794 log 14947 139963339396672 Unauthorized: /v1/analyses/
[22/Dec/2021 12:02:00] "GET /v1/analyses/ HTTP/1.1" 401 58
```
