### PR TITLE
Fix for API schema generation

### DIFF
--- a/src/server/oasisapi/analyses/viewsets.py
+++ b/src/server/oasisapi/analyses/viewsets.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 from django.utils.translation import gettext_lazy as _
+from django.utils.decorators import method_decorator
 from rest_framework import viewsets
 from rest_framework.decorators import action
 from rest_framework.parsers import MultiPartParser, FormParser
@@ -81,6 +82,7 @@ class AnalysisFilter(TimeStampedFilter):
         super(AnalysisFilter, self).__init__(*args, **kwargs)
 
 
+@method_decorator(name='list', decorator=swagger_auto_schema(responses={200: AnalysisSerializer}))
 class AnalysisViewSet(viewsets.ModelViewSet):
     """
     list:

--- a/src/server/oasisapi/portfolios/viewsets.py
+++ b/src/server/oasisapi/portfolios/viewsets.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 from django.utils.translation import gettext_lazy as _
 from django_filters import rest_framework as filters
 from django.conf import settings as django_settings
+from django.utils.decorators import method_decorator
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework import viewsets
 from rest_framework.decorators import action
@@ -44,6 +45,7 @@ class PortfolioFilter(TimeStampedFilter):
         ]
 
 
+@method_decorator(name='list', decorator=swagger_auto_schema(responses={200: PortfolioSerializer}))
 class PortfolioViewSet(viewsets.ModelViewSet):
     """
     list:


### PR DESCRIPTION
<!--start_release_notes-->
### Fix for API schema generation 
The classes `AnalysisListSerializer` and `PortfolioListSerializer` are ReadOnly versions of the standard serializers used only for the GET list methods. This speeds up the responses time, but adds unnecessary objects to the specification. 
This PR overrides these with the standard  `AnalysisSerializer` and `PortfolioSerializer` in the generated OpenAPI schema.
    

<!--end_release_notes-->
[fixed_openapi-schema.zip](https://github.com/OasisLMF/OasisPlatform/files/7896323/fixed_openapi-schema.zip)

