### PR TITLE
Update to fix celery chain cancellation issue

### DIFF
--- a/src/server/oasisapi/analyses/models.py
+++ b/src/server/oasisapi/analyses/models.py
@@ -27,6 +27,7 @@ from ....common.data import STORED_FILENAME, ORIGINAL_FILENAME
 from ....conf import iniconf
 
 
+
 # from .tasks import record_generate_input_result, record_run_analysis_result
 ###############
 
@@ -322,6 +323,16 @@ class Analysis(TimeStampedModel):
             }
         )
 
+    @property
+    def cancel_subtasks_signature(self):
+        return celery_app.signature(
+            'cancel_subtasks',
+            options={
+                'queue': iniconf.settings.get('worker', 'INPUT_GENERATION_CONTROLLER_QUEUE', fallback='celery')
+            }
+        )
+
+
     def generate_inputs(self, initiator):
         valid_choices = [
             self.status_choices.NEW,
@@ -362,29 +373,10 @@ class Analysis(TimeStampedModel):
             'failure_status': Analysis.status_choices.INPUTS_GENERATION_ERROR,
         }))
         task_id = task.apply_async(args=[self.pk, initiator.pk], priority=self.priority).id
-
         self.generate_inputs_task_id = task_id
         self.task_started = timezone.now()
         self.task_finished = None
         self.save()
-
-
-    def cancel_subtasks(self):
-        # cleanup the the sub tasks
-        _now = timezone.now()
-
-        qs = self.sub_task_statuses.filter(
-            status__in=[
-                AnalysisTaskStatus.status_choices.PENDING,
-                AnalysisTaskStatus.status_choices.QUEUED,
-                AnalysisTaskStatus.status_choices.STARTED]
-        )
-
-        for task_id in qs.values_list('task_id', flat=True):
-            if task_id:
-                AsyncResult(task_id).revoke(signal='SIGTERM', terminate=True)
-
-        qs.update(status=AnalysisTaskStatus.status_choices.CANCELLED, end_time=_now)
 
 
     def cancel_any(self):
@@ -415,13 +407,17 @@ class Analysis(TimeStampedModel):
         if self.status not in valid_choices:
             raise ValidationError({'status': ['Analysis execution is not running or queued']})
 
+        # Kill the task controller job incase its still on queue
         AsyncResult(self.run_task_id).revoke(
-            signal='SIGTERM',
+            signal='SIGKILL',
             terminate=True,
         )
 
+        # Send Kill chain call to worker-controller
+        cancel_tasks = self.cancel_subtasks_signature
+        task_id = cancel_tasks.apply_async(args=[self.pk], priority=10).id
+
         self.status = self.status_choices.RUN_CANCELLED
-        self.cancel_subtasks()
         self.task_finished = timezone.now()
         self.save()
 
@@ -433,12 +429,18 @@ class Analysis(TimeStampedModel):
         if self.status not in valid_choices:
             raise ValidationError({'status': ['Analysis input generation is not running or queued']})
 
+
+        # Kill the task controller job incase its still on queue
         AsyncResult(self.generate_inputs_task_id).revoke(
-            signal='SIGTERM',
+            signal='SIGKILL',
             terminate=True,
         )
+
+        # Send Kill chain call to worker-controller
+        cancel_tasks = self.cancel_subtasks_signature
+        task_id = cancel_tasks.apply_async(args=[self.pk], priority=10).id
+
         self.status = self.status_choices.INPUTS_GENERATION_CANCELLED
-        self.cancel_subtasks()
         self.task_finished = timezone.now()
         self.save()
 

--- a/src/server/oasisapi/analyses/task_controller.py
+++ b/src/server/oasisapi/analyses/task_controller.py
@@ -335,7 +335,7 @@ class Controller:
         analysis.lookup_chunks = num_chunks
         analysis.save()
 
-        task = analysis.generate_inputs_task_id = cls._start(
+        chain = cls._start(
             analysis,
             initiator,
             tasks,
@@ -343,10 +343,8 @@ class Controller:
             run_data_uuid,
             'input_generation_traceback_file',
             Analysis.status_choices.INPUTS_GENERATION_ERROR,
-        ).id or ''  # TODO: is shouldn't return None but is for some reason so for no guard against it
-        analysis.save()
-
-        return task
+        )
+        return chain
 
     @classmethod
     def get_generate_losses_queue(cls, analysis: 'Analysis', initiator: User) -> str:
@@ -470,7 +468,7 @@ class Controller:
         analysis.analysis_chunks = num_chunks
         analysis.save()
 
-        task = analysis.run_task_id = cls._start(
+        chain = cls._start(
             analysis,
             initiator,
             tasks,
@@ -478,9 +476,8 @@ class Controller:
             run_data_uuid,
             'run_traceback_file',
             Analysis.status_choices.RUN_ERROR,
-        ).id or ''  # TODO: is shouldn't return None but is for some reason so for no guard against it
-        analysis.save()
-        return task
+        )
+        return chain
 
 
 def get_analysis_task_controller() -> Type[Controller]:


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue after submitting a Pull Request. -->

<!--start_release_notes-->
### Fix for celery cancellation
The original method for cancelling worker execution doesn't work with the distributed celery task structure because: 

**1. Celery chains don't have a collective task_id**
The line from here will only work if the first `task_controller` job is still pending. Once that completes there is no `task_id` to revoke the set of pending sub-tasks.    
https://github.com/OasisLMF/OasisPlatform/blob/4335c7fc5d851f4c1a114fbf33cf8745af58ade7/src/server/oasisapi/analyses/models.py#L436-L439

**2.  Using AsyncResult to revoke tasks on a model queue aren't picked up** 
When calling `AsyncResult(sub_task_id).revoke()` the workers on a model queue don't receive the revoke message. 
I'm not sure if this is a bug or a routing problem. The fix is to create a new cancellation task in the `task-controller` container.  
https://github.com/OasisLMF/OasisPlatform/blob/aebd5ac1bd516121d8105783f724bb047d7fff34/src/server/oasisapi/analyses/tasks.py#L327-L365

**3. Task_id's are only updated once queued.**
The cancellation request can be time sensitive, since it can be triggered after a sequential task in the chain has completed, but before the next queued task has been picked up by a worker. This is a problem because the celery [Prefetch Limit](https://docs.celeryproject.org/en/stable/userguide/optimizing.html#prefetch-limits) is set to `1` so that worker can't lock each other from executing a pending task. 
https://github.com/OasisLMF/OasisPlatform/blob/aebd5ac1bd516121d8105783f724bb047d7fff34/src/model_execution_worker/distributed_tasks.py#L982-L992

Fixed (ish) by updating all pending tasks on once the first sequential task is processed in the worker.  This might not work well as the number of parallel chunks or worker containers increases. **More testing is needed**.  
 https://github.com/OasisLMF/OasisPlatform/blob/aebd5ac1bd516121d8105783f724bb047d7fff34/src/model_execution_worker/distributed_tasks.py#L333-L358


**4.  Revoking sub-tasks is not enough to break the celery chain callbacks.** 
Killing a sequential task in a chain will not stop the callback mechanism which will still execute in the background. 
The recommended approach is 'walk the chain' and cancel all tasks, unfortunately the original canvas object is lost once the model queue scheduling job has completed. Its created by calling `get_analysis_task_controller().generate_losses(analysis, initiator)` and i don't see  a good way to rebuild or store this object.      
 https://github.com/OasisLMF/OasisPlatform/blob/4335c7fc5d851f4c1a114fbf33cf8745af58ade7/src/server/oasisapi/analyses/tasks.py#L328-L334

The workaround is using a handler function based on the `task_revoked` celery signal. This wipes out the chain header (and callback references) which prevents the chain from continuing onto the next task. 
https://github.com/OasisLMF/OasisPlatform/blob/aebd5ac1bd516121d8105783f724bb047d7fff34/src/model_execution_worker/distributed_tasks.py#L185-L189

<!--end_release_notes-->
