### PR TITLE
Update/worker scaling

### DIFF
--- a/kubernetes/worker-controller/src/autoscaler.py
+++ b/kubernetes/worker-controller/src/autoscaler.py
@@ -102,10 +102,14 @@ class AutoScaler:
         """
 
         desired_replicas = 0
+        is_fixed_strategy = wd.get('scaling_strategy') == 'FIXED_WORKERS'
 
-        if analysis_in_progress:
+        if analysis_in_progress or is_fixed_strategy:
 
-            logging.info('Analysis for model %s is running', wd.name)
+            if analysis_in_progress:
+                logging.info('Analysis for model %s is running', wd.name)
+            if is_fixed_strategy:
+                logging.info('Model %s is set to "FIXED_WORKERS"', wd.name)
 
             try:
                 desired_replicas = autoscaler_rules.get_desired_worker_count(wd.auto_scaling, model_state)
@@ -114,6 +118,7 @@ class AutoScaler:
                     desired_replicas = limit
             except ValueError as e:
                 logging.error('Could not calculate desired replicas count for model %s: %s', wd.id_string(), str(e))
+
 
         if desired_replicas > 0 and wd.name in self.cleanup_deployments:
 

--- a/src/server/oasisapi/analyses/task_controller.py
+++ b/src/server/oasisapi/analyses/task_controller.py
@@ -455,11 +455,33 @@ class Controller:
         """
         from src.server.oasisapi.analyses.models import Analysis
 
+        # DEBUG
+        from celery.contrib import rdb
+        rdb.set_trace()
+
         # fetch number of event chunks
         if analysis.model.chunking_options.loss_strategy == 'FIXED_CHUNKS':
             num_chunks = analysis.model.chunking_options.fixed_analysis_chunks
         elif analysis.model.chunking_options.loss_strategy == 'DYNAMIC_CHUNKS':
-            raise notimplementederror("FEATURE NOT AVALIBLE -- need event set size from worker")
+            events_per_chunk = analysis.model.chunking_options.dynamic_events_per_analysis
+            analysis_settings = analysis.settings_file.read_json()
+            model_settings = analysis.model.resource_file.read_json()
+
+            # User options
+            user_selected_events = analysis_settings.get('event_ids', [])
+            selected_event_set = analysis_settings.get('model_settings', {}).get('event_set', "")
+            # model metadata
+            event_set_options = model_settings.get('model_settings', {}).get('event_set').get('options', [])
+            event_set_sizes = {e['id']: e['number_of_events'] for e in event_set_options if 'number_of_events' in e}
+
+            if len(user_selected_events) > 1:
+                total_events = len(user_selected_events)
+            else:
+                if selected_event_set not in event_set_sizes:
+                    raise ValueError(f'ERROR: model_settings missing "number_of_events" for Selected event_set "{selected_event_set}"')
+                total_events = event_set_sizes.get(selected_event_set)
+
+            num_chunks = ceil(total_events / events_per_chunk)
 
         run_data_uuid = uuid.uuid4().hex
         statuses, tasks = cls.get_loss_generation_tasks(analysis, initiator, run_data_uuid, num_chunks)

--- a/src/server/oasisapi/analyses/task_controller.py
+++ b/src/server/oasisapi/analyses/task_controller.py
@@ -455,10 +455,6 @@ class Controller:
         """
         from src.server.oasisapi.analyses.models import Analysis
 
-        # DEBUG
-        from celery.contrib import rdb
-        rdb.set_trace()
-
         # fetch number of event chunks
         if analysis.model.chunking_options.loss_strategy == 'FIXED_CHUNKS':
             num_chunks = analysis.model.chunking_options.fixed_analysis_chunks

--- a/src/server/oasisapi/files/models.py
+++ b/src/server/oasisapi/files/models.py
@@ -1,4 +1,5 @@
 import os
+import json
 from io import BytesIO
 from uuid import uuid4
 
@@ -81,4 +82,9 @@ class RelatedFile(TimeStampedModel):
         return 'File_{}'.format(self.file)
 
     def read(self, *args, **kwargs):
+        self.file.seek(0)
         return self.file.read(*args, **kwargs)
+
+    def read_json(self, *args, **kwargs):
+        self.file.seek(0)
+        return json.loads(self.file.read(*args, **kwargs).decode("utf-8"))


### PR DESCRIPTION
<!--start_release_notes-->
### Update platform scaling 
* Run multiple ktools pipes if a single chunk is requested (needs and update on MDK side https://github.com/OasisLMF/OasisLMF/issues/876) 
* The worker controller's `FIX_WORKER` scaling option now sets the replicas regardless of if an analysis is queued 
* Dynamic chunking added for loss analysis based on the `number_of_events` value stored in the model_settings   
<!--end_release_notes-->
