### PR TITLE
Unset "user_data_dir" if no files are given

### DIFF
--- a/src/model_execution_worker/distributed_tasks.py
+++ b/src/model_execution_worker/distributed_tasks.py
@@ -442,6 +442,8 @@ def keys_generation_task(fn):
 
         if complex_data_files:
             maybe_prepare_complex_data_files(complex_data_files, params['user_data_dir'])
+        else: 
+            params['user_data_dir'] = None
 
         log_params(params, kwargs)
 


### PR DESCRIPTION
<!--start_release_notes-->
### Fix for custom lookup classes not expecting user data 
Complex model lookup fixes caused this, added check to not pass in this argument if no user datafiles are given
```
gument 'user_data_dir'")
Traceback (most recent call last):
  File "/root/.local/lib/python3.8/site-packages/celery/app/trace.py", line 451, in trace_task
    R = retval = fun(*args, **kwargs)
  File "/root/.local/lib/python3.8/site-packages/celery/app/trace.py", line 734, in __protected_call__
    return self.run(*args, **kwargs)
  File "/root/.local/lib/python3.8/site-packages/celery/app/autoretry.py", line 54, in run
    ret = task.retry(exc=exc, **retry_kwargs)
  File "/root/.local/lib/python3.8/site-packages/celery/app/task.py", line 717, in retry
    raise_with_context(exc)
  File "/root/.local/lib/python3.8/site-packages/celery/app/autoretry.py", line 34, in run
    return task._orig_run(*args, **kwargs)
  File "/home/worker/src/model_execution_worker/distributed_tasks.py", line 457, in run
    return fn(self, params, *args, analysis_id=analysis_id, run_data_uuid=run_data_uuid, **kwargs)
  File "/home/worker/src/model_execution_worker/distributed_tasks.py", line 535, in prepare_keys_file_chunk
    lookup.generate_key_files(
  File "/root/.local/lib/python3.8/site-packages/oasislmf/utils/log.py", line 111, in wrapper
    result = func(*args, **kwargs)
  File "/root/.local/lib/python3.8/site-packages/oasislmf/lookup/factory.py", line 549, in generate_key_files
    return self.generate_key_files_singleproc(locations,
  File "/root/.local/lib/python3.8/site-packages/oasislmf/lookup/factory.py", line 430, in generate_key_files_singleproc
    lookup = self.create_lookup(self.lookup_cls, self.config, config_dir, self.user_data_dir, self.output_dir,
  File "/root/.local/lib/python3.8/site-packages/oasislmf/lookup/factory.py", line 281, in create_lookup
    return lookup_cls(
  File "/root/.local/lib/python3.8/site-packages/oasislmf/utils/log.py", line 111, in wrapper
    result = func(*args, **kwargs)
TypeError: __init__() got an unexpected keyword argument 'user_data_dir'

```
<!--end_release_notes-->
