### PR TITLE
Fix loading and chunking for compressed exposure file

### DIFF
--- a/src/model_execution_worker/distributed_tasks.py
+++ b/src/model_execution_worker/distributed_tasks.py
@@ -4,6 +4,7 @@ import glob
 import json
 import logging
 import os
+import pathlib
 import shutil
 import subprocess
 import tempfile
@@ -405,7 +406,6 @@ def keys_generation_task(fn):
 
         # Set `oasis-file-generation` input files
         params.setdefault('target_dir', params['root_run_dir'])
-        params.setdefault('oed_location_csv', os.path.join(params['root_run_dir'], 'location.csv'))
         params.setdefault('user_data_dir', os.path.join(params['root_run_dir'], f'user-data'))
         params.setdefault('lookup_complex_config_json', os.path.join(params['root_run_dir'], 'analysis_settings.json'))
 
@@ -423,18 +423,23 @@ def keys_generation_task(fn):
 
         # Prepare 'generate-oasis-files' input files
         if loc_file:
+            loc_extention = "".join(pathlib.Path(loc_file).suffixes)
+            params['oed_location_csv'] = os.path.join(params['root_run_dir'], f'location{loc_extention}')
             maybe_fetch_file(loc_file, params['oed_location_csv'])
 
         if acc_file:
-            params['oed_accounts_csv'] = os.path.join(params['root_run_dir'], 'account.csv')
+            acc_extention = "".join(pathlib.Path(acc_file).suffixes)
+            params['oed_accounts_csv'] = os.path.join(params['root_run_dir'], f'account{acc_extention}')
             maybe_fetch_file(acc_file, params['oed_accounts_csv'])
 
         if info_file:
-            params['oed_info_csv'] = os.path.join(params['root_run_dir'], 'reinsinfo.csv')
+            info_extention = "".join(pathlib.Path(info_file).suffixes)
+            params['oed_info_csv'] = os.path.join(params['root_run_dir'], f'reinsinfo{info_extention}')
             maybe_fetch_file(info_file, params['oed_info_csv'])
 
         if scope_file:
-            params['oed_scope_csv'] = os.path.join(params['root_run_dir'], 'reinsscope.csv')
+            scope_extention = "".join(pathlib.Path(scope_file).suffixes)
+            params['oed_scope_csv'] = os.path.join(params['root_run_dir'], f'reinsscope{scope_extention}')
             maybe_fetch_file(scope_file, params['oed_scope_csv'])
 
         if settings_file:
@@ -442,7 +447,7 @@ def keys_generation_task(fn):
 
         if complex_data_files:
             maybe_prepare_complex_data_files(complex_data_files, params['user_data_dir'])
-        else: 
+        else:
             params['user_data_dir'] = None
 
         log_params(params, kwargs)

--- a/src/server/oasisapi/analyses/models.py
+++ b/src/server/oasisapi/analyses/models.py
@@ -253,7 +253,7 @@ class Analysis(TimeStampedModel):
         selected_strat = self.model.chunking_options.loss_strategy
         dynamic_strat = self.model.chunking_options.chunking_types.DYNAMIC_CHUNKS
         if selected_strat != dynamic_strat:
-            return 0
+            return 1
 
         analysis_settings = self.settings_file.read_json()
         model_settings = self.model.resource_file.read_json()

--- a/src/server/oasisapi/analyses/models.py
+++ b/src/server/oasisapi/analyses/models.py
@@ -250,9 +250,13 @@ class Analysis(TimeStampedModel):
         return groups
 
     def get_num_events(self):
+        selected_strat = self.model.chunking_options.loss_strategy
+        dynamic_strat = self.model.chunking_options.chunking_types.DYNAMIC_CHUNKS
+        if selected_strat != dynamic_strat:
+            return 0
+
         analysis_settings = self.settings_file.read_json()
         model_settings = self.model.resource_file.read_json()
-
         user_selected_events = analysis_settings.get('event_ids', [])
         selected_event_set = analysis_settings.get('model_settings', {}).get('event_set', "")
         if len(user_selected_events) > 1:

--- a/src/server/oasisapi/analyses/task_controller.py
+++ b/src/server/oasisapi/analyses/task_controller.py
@@ -443,7 +443,7 @@ class Controller:
         ])
 
     @classmethod
-    def generate_losses(cls, analysis: 'Analysis', initiator: User):
+    def generate_losses(cls, analysis: 'Analysis', initiator: User, events_total: int):
         """
         Starts the loss generation chain
 
@@ -459,24 +459,7 @@ class Controller:
             num_chunks = analysis.model.chunking_options.fixed_analysis_chunks
         elif analysis.model.chunking_options.loss_strategy == 'DYNAMIC_CHUNKS':
             events_per_chunk = analysis.model.chunking_options.dynamic_events_per_analysis
-            analysis_settings = analysis.settings_file.read_json()
-            model_settings = analysis.model.resource_file.read_json()
-
-            # User options
-            user_selected_events = analysis_settings.get('event_ids', [])
-            selected_event_set = analysis_settings.get('model_settings', {}).get('event_set', "")
-            # model metadata
-            event_set_options = model_settings.get('model_settings', {}).get('event_set').get('options', [])
-            event_set_sizes = {e['id']: e['number_of_events'] for e in event_set_options if 'number_of_events' in e}
-
-            if len(user_selected_events) > 1:
-                total_events = len(user_selected_events)
-            else:
-                if selected_event_set not in event_set_sizes:
-                    raise ValueError(f'ERROR: model_settings missing "number_of_events" for Selected event_set "{selected_event_set}"')
-                total_events = event_set_sizes.get(selected_event_set)
-
-            num_chunks = ceil(total_events / events_per_chunk)
+            num_chunks = ceil(events_total / events_per_chunk)
 
         run_data_uuid = uuid.uuid4().hex
         statuses, tasks = cls.get_loss_generation_tasks(analysis, initiator, run_data_uuid, num_chunks)

--- a/src/server/oasisapi/analyses/task_controller.py
+++ b/src/server/oasisapi/analyses/task_controller.py
@@ -308,7 +308,7 @@ class Controller:
         ])
 
     @classmethod
-    def generate_inputs(cls, analysis: 'Analysis', initiator: User) -> chain:
+    def generate_inputs(cls, analysis: 'Analysis', initiator: User, loc_lines: int) -> chain:
         """
         Starts the input generation chain
 
@@ -324,7 +324,6 @@ class Controller:
         if analysis.model.chunking_options.lookup_strategy == 'FIXED_CHUNKS':
             num_chunks = analysis.model.chunking_options.fixed_lookup_chunks
         elif analysis.model.chunking_options.lookup_strategy == 'DYNAMIC_CHUNKS':
-            loc_lines = sum(1 for line in analysis.portfolio.location_file.read())
             loc_lines_per_chunk = analysis.model.chunking_options.dynamic_locations_per_lookup
             num_chunks = ceil(loc_lines / loc_lines_per_chunk)
 

--- a/src/server/oasisapi/analyses/tasks.py
+++ b/src/server/oasisapi/analyses/tasks.py
@@ -419,11 +419,11 @@ def start_input_generation_task(analysis_pk, initiator_pk, loc_lines):
 
 
 @celery_app.task(name='start_loss_generation_task')
-def start_loss_generation_task(analysis_pk, initiator_pk):
+def start_loss_generation_task(analysis_pk, initiator_pk, events_total):
     from .models import Analysis
     analysis = Analysis.objects.get(pk=analysis_pk)
     initiator = get_user_model().objects.get(pk=initiator_pk)
-    get_analysis_task_controller().generate_losses(analysis, initiator)
+    get_analysis_task_controller().generate_losses(analysis, initiator, events_total)
     analysis.save()
 
 

--- a/src/server/oasisapi/analyses/tasks.py
+++ b/src/server/oasisapi/analyses/tasks.py
@@ -414,7 +414,8 @@ def start_input_generation_task(analysis_pk, initiator_pk):
     from .models import Analysis
     analysis = Analysis.objects.get(pk=analysis_pk)
     initiator = get_user_model().objects.get(pk=initiator_pk)
-    get_analysis_task_controller().generate_inputs(analysis, initiator)
+    loc_lines = analysis.portfolio.location_file_len()
+    get_analysis_task_controller().generate_inputs(analysis, initiator, loc_lines)
     analysis.save()
 
 

--- a/src/server/oasisapi/analyses/tasks.py
+++ b/src/server/oasisapi/analyses/tasks.py
@@ -410,11 +410,10 @@ def cancel_subtasks(self, analysis_pk):
 
 
 @celery_app.task(name='start_input_generation_task', **celery_conf.worker_task_kwargs)
-def start_input_generation_task(analysis_pk, initiator_pk):
+def start_input_generation_task(analysis_pk, initiator_pk, loc_lines):
     from .models import Analysis
     analysis = Analysis.objects.get(pk=analysis_pk)
     initiator = get_user_model().objects.get(pk=initiator_pk)
-    loc_lines = analysis.portfolio.location_file_len()
     get_analysis_task_controller().generate_inputs(analysis, initiator, loc_lines)
     analysis.save()
 

--- a/src/server/oasisapi/analysis_models/serializers.py
+++ b/src/server/oasisapi/analysis_models/serializers.py
@@ -113,8 +113,8 @@ class ModelChunkingConfigSerializer(serializers.ModelSerializer):
                     errors[k] = "Value is not type int, found {}".format(type(value))
                     continue
                 # Check value is greater than 0
-                elif value < 0:
-                    errors[k] = "Value is less than zero."
+                elif value < 1:
+                    errors[k] = "Value is less than one."
                     continue
                 # Data is valid
                 attrs[k] = value

--- a/src/server/oasisapi/files/serializers.py
+++ b/src/server/oasisapi/files/serializers.py
@@ -77,7 +77,7 @@ class RelatedFileSerializer(serializers.ModelSerializer):
 
     def validate_file(self, value):
         mapped_content_type = CONTENT_TYPE_MAPPING.get(value.content_type, value.content_type)
-        file_extention = Path(value.name).suffix[1:]
+        file_extention = Path(value.name).suffix[1:].lower()
 
         # check content_types is valid
         if self.content_types and mapped_content_type not in self.content_types:

--- a/src/server/oasisapi/healthcheck/views.py
+++ b/src/server/oasisapi/healthcheck/views.py
@@ -1,6 +1,8 @@
 import logging
 
 from django.db import connection
+from django.conf import settings as django_settings
+
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework import views, status
 from rest_framework.response import Response
@@ -23,17 +25,16 @@ class HealthcheckView(views.APIView):
         """
         Check db and celery connectivity and return a 200 if healthy, 503 if not.
         """
-
         code = status.HTTP_200_OK
+        status_text = 'OK'
 
-        if not self.celery_is_ok():
-            status_text = 'ERROR - celery down'
-            code = status.HTTP_503_SERVICE_UNAVAILABLE
-        elif not self.db_is_ok():
-            status_text = 'ERROR - db down'
-            code = status.HTTP_503_SERVICE_UNAVAILABLE
-        else:
-            status_text = 'OK'
+        if not django_settings.CONSOLE_DEBUG:
+            if not self.celery_is_ok():
+                status_text = 'ERROR - celery down'
+                code = status.HTTP_503_SERVICE_UNAVAILABLE
+            elif not self.db_is_ok():
+                status_text = 'ERROR - db down'
+                code = status.HTTP_503_SERVICE_UNAVAILABLE
 
         return Response({'status': status_text}, code)
 

--- a/src/server/oasisapi/portfolios/models.py
+++ b/src/server/oasisapi/portfolios/models.py
@@ -57,24 +57,15 @@ class Portfolio(TimeStampedModel):
             'application/x-bzip2': 'bz2',
             'application/zip': 'zip'
         }
-
         if not self.location_file:
             return None
 
-        file_ext = pathlib.Path(self.location_file.filename).suffix[1:]
-        if file_ext in ['pq', 'parquet'] or settings.PORTFOLIO_PARQUET_STORAGE:
-            # load length as parquet
+        if self.location_file.content_type == 'application/octet-stream':
             df = ods_tools.read_parquet(io.BytesIO(self.location_file.file.read()))
             return len(df.index)
-
-        # Load as csv / compressed csv
-        if file_ext in ['gzip', 'bz2', 'zip']:
-            compression = file_ext
-        else:
-            compression = csv_compression_types[self.location_file.content_type]
-
-        df = ods_tools.read_csv(io.BytesIO(self.location_file.file.read()), compression=csv_compression_types[self.location_file.content_type])
-        return len(df.index)
+        if self.location_file.content_type in csv_compression_types:
+            df = ods_tools.read_csv(io.BytesIO(self.location_file.file.read()), compression=csv_compression_types[self.location_file.content_type])
+            return len(df.index)
 
 
 class PortfolioStatus(TimeStampedModel):

--- a/src/server/oasisapi/portfolios/viewsets.py
+++ b/src/server/oasisapi/portfolios/viewsets.py
@@ -83,10 +83,10 @@ class PortfolioViewSet(VerifyGroupAccessModelViewSet):
     filterset_class = PortfolioFilter
 
     supported_mime_types = [
+        'application/octet-stream',
         'application/json',
         'text/csv',
         'application/gzip',
-        'application/x-bzip2',
         'application/zip',
         'application/x-bzip2',
     ]

--- a/src/server/oasisapi/settings.py
+++ b/src/server/oasisapi/settings.py
@@ -343,7 +343,7 @@ else:
     raise ImproperlyConfigured('Invalid value for STORAGE_TYPE: {}'.format(STORAGE_TYPE))
 
 # storage selector for exposure files
-PORTFOLIO_PARQUET_STORAGE = iniconf.settings.getboolean('server', 'PORTFOLIO_PARQUET_STORAGE', fallback=False)
+PORTFOLIO_PARQUET_STORAGE = iniconf.settings.getboolean('server', 'PORTFOLIO_PARQUET_STORAGE', fallback=True)
 
 LOGGING = {
     'version': 1,

--- a/src/server/oasisapi/settings.py
+++ b/src/server/oasisapi/settings.py
@@ -255,7 +255,6 @@ FORCE_SCRIPT_NAME = '/api'
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/2.0/howto/static-files/
 MEDIA_URL = '/api/media/'
-MEDIA_ROOT = iniconf.settings.get('server', 'media_root', fallback=os.path.join(BASE_DIR, 'media'))
 STATIC_URL = '/api/static/'
 STATIC_DEBUG_URL = '/static/'  #when running
 STATIC_ROOT = os.path.join(BASE_DIR, 'static')

--- a/src/server/oasisapi/settings.py
+++ b/src/server/oasisapi/settings.py
@@ -39,13 +39,14 @@ if (len(sys.argv) >= 2 and sys.argv[1] == 'runserver'):
     DEBUG = True
     DEBUG_TOOLBAR = True
     URL_SUB_PATH = False
+    CONSOLE_DEBUG = True # disable celery / db checks in health check 
 else:
     # SECURITY WARNING: don't run with debug turned on in production!
     MEDIA_ROOT = iniconf.settings.get('server', 'media_root', fallback=os.path.join(BASE_DIR, 'media'))
     DEBUG = iniconf.settings.getboolean('server', 'debug', fallback=False)
     DEBUG_TOOLBAR = iniconf.settings.getboolean('server', 'debug_toolbar', fallback=False)
     URL_SUB_PATH = iniconf.settings.getboolean('server', 'URL_SUB_PATH', fallback=True)
-
+    CONSOLE_DEBUG = False
 
 # Django 3.2 - the default pri-key field changed to 'BigAutoField.',
 # https://docs.djangoproject.com/en/3.2/releases/3.2/#customizing-type-of-auto-created-primary-keys


### PR DESCRIPTION
<!--start_release_notes-->
### Fix loading and chunking for compressed exposure files 
* ~~Switched setting `PORTFOLIO_PARQUET_STORAGE` to true by default, this means if plain `text/csv` are uploaded, the API will convert these to parquet for storage and execution.~~  reverted until https://github.com/OasisLMF/OasisLMF/issues/1054
 is fixed 
* Fixed issue https://github.com/OasisLMF/OasisPlatform/issues/632 a file share mount is no longer needed for the task-controller, the location file length is now read by the server and passed as an integer.
* Fixed issue  https://github.com/OasisLMF/OasisPlatform/issues/627 The platform will now correctly execute exposure files compressed as `zip`, `gzip`, `bzip2` and `parquet`.  However this requires that the **content-type** header is correctly set in the file upload requests. 
* Added validation to enforce the **content-type** header is correctly set. Example, uploading `my_location_file.csv` with the header set as `application/zip` will return a bad request with the message: `File extention 'csv' mismatched with request header 'Content-Type': 'application/zip', should be set to 'text/csv'`. This is required for reading the file size when dynamically breaking up a location file into chunks.

<!--end_release_notes-->


**Todo:** 

- [x] ~~Running loss generation task using parquet files fails with~~ `RUNNING oasislmf.preparation.summaries.get_exposure_summary Killed`  <-- Not a platform issue https://github.com/OasisLMF/OasisLMF/issues/1054



- [x] Fix `"loss_strategy": "DYNAMIC_CHUNKS"` task_controller is trying to read the settings json without file mount access 
(Add validation to check the event chunk size is set when dynamic chunking is selected) 
https://github.com/OasisLMF/OasisPlatform/blob/392229867cc239e7c9d58e44febc7010c0267419/src/server/oasisapi/analyses/task_controller.py#L463-L464


- [x] ~~With Parquet exposure storage on, `PORTFOLIO_PARQUET_STORAGE=True`, converted csv files are stored twice in the inputs directory~~
Moved to https://github.com/OasisLMF/OasisPlatform/issues/644
```
oasis-worker(2.1.0) 9df6678e3e29 /tmp/run/analysis-65_files-2c287d7ac2de420cab322ef92630ed25 # ls -la
-rw-r--r-- 1 root root   9902 Jun  9 09:16 account.csv.parquet
-rw-r--r-- 1 root root   9902 Jun  9 09:16 account.parquet
-rw-r--r-- 1 root root    862 Jun  9 09:16 analysis_settings.json
-rw-r--r-- 1 root root     44 Jun  9 09:41 keys-errors.csv
-rw-r--r-- 1 root root 534706 Jun  9 09:41 keys.csv
-rw-r--r-- 1 root root 364056 Jun  9 09:16 location.csv.parquet
-rw-r--r-- 1 root root 364056 Jun  9 09:16 location.parquet
-rw-r--r-- 1 root root   1488 May 27 08:58 lookup_config.json
-rw-r--r-- 1 root root  13925 Jun  9 09:16 reinsinfo.parquet
-rw-r--r-- 1 root root   9920 Jun  9 09:16 reinsscope.parquet
-rw-r--r-- 1 root root  13925 Jun  9 09:16 ri_info.csv.parquet
-rw-r--r-- 1 root root   9920 Jun  9 09:16 ri_scope.csv.parquet
```