### PR TITLE
Fix/631 autoscale non zero

### DIFF
--- a/kubernetes/worker-controller/src/autoscaler.py
+++ b/kubernetes/worker-controller/src/autoscaler.py
@@ -109,15 +109,6 @@ class AutoScaler:
         desired_replicas = 0
         is_fixed_strategy = wd.auto_scaling.get('scaling_strategy') == 'FIXED_WORKERS' and self.never_shutdown_fixed_workers
 
-        ## DEBUG LOGGING 
-        strat = wd.auto_scaling.get('scaling_strategy')
-        logging.info(f'strat = {strat}')
-        logging.info(f'self.never_shutdown_fixed_workers = {self.never_shutdown_fixed_workers}')
-        logging.info(f'type(self.never_shutdown_fixed_workers) = {type(self.never_shutdown_fixed_workers)}')
-        logging.info(f'is_fixed_strategy = {is_fixed_strategy}')
-        logging.info(f'analysis_in_progress = {analysis_in_progress}')
-
-
         if analysis_in_progress or is_fixed_strategy:
 
             if analysis_in_progress:

--- a/kubernetes/worker-controller/src/autoscaler.py
+++ b/kubernetes/worker-controller/src/autoscaler.py
@@ -109,6 +109,15 @@ class AutoScaler:
         desired_replicas = 0
         is_fixed_strategy = wd.auto_scaling.get('scaling_strategy') == 'FIXED_WORKERS' and self.never_shutdown_fixed_workers
 
+        ## DEBUG LOGGING 
+        strat = wd.auto_scaling.get('scaling_strategy')
+        logging.info(f'strat = {strat}')
+        logging.info(f'self.never_shutdown_fixed_workers = {self.never_shutdown_fixed_workers}')
+        logging.info(f'type(self.never_shutdown_fixed_workers) = {type(self.never_shutdown_fixed_workers)}')
+        logging.info(f'is_fixed_strategy = {is_fixed_strategy}')
+        logging.info(f'analysis_in_progress = {analysis_in_progress}')
+
+
         if analysis_in_progress or is_fixed_strategy:
 
             if analysis_in_progress:

--- a/kubernetes/worker-controller/src/worker_controller.py
+++ b/kubernetes/worker-controller/src/worker_controller.py
@@ -33,6 +33,22 @@ from autoscaler import AutoScaler
 logging.basicConfig(format='%(asctime)s %(levelname)s: %(message)s', level=logging.INFO)
 
 
+def str2bool(v):
+    """ Func type for loading strings to boolean values using argparse
+        https://stackoverflow.com/a/43357954
+    """
+    if v is None:
+        return v
+    elif isinstance(v, bool):
+        return v
+    elif v.lower() in ('yes', 'true', 't', 'y', '1'):
+        return True
+    elif v.lower() in ('no', 'false', 'f', 'n', '0'):
+        return False
+    else:
+        raise ArgumentTypeError('Boolean value expected.') 
+
+
 def parse_args():
     """
     Parse command line arguments.
@@ -49,8 +65,8 @@ def parse_args():
     parser.add_argument('--limit', help='Hard limit for the total number of workers created', default=getenv('OASIS_TOTAL_WORKER_LIMIT'))
     parser.add_argument('--prioritized-models-limit', help='When prioritized runs are used - create workers for the models with the highest priority', default=getenv('OASIS_PRIORITIZED_MODELS_LIMIT'))
     parser.add_argument('--cluster', help='Type of kubernetes cluster to connect to, either "local" (~/.kube/config) or "in" to connect to the cluster the pod exists in', default=getenv('CLUSTER') or 'in')
-    parser.add_argument('--continue-update-scaling', help='Auto scaling - read the scaling settings from the API for a model on every update. (for testing)', default=getenv('OASIS_CONTINUE_UPDATE_SCALING') or False)
-    parser.add_argument('--never-shutdown-fixed-workers', help='Auto scaling - never scale to 0 for strategy FIXED_WORKERS.', default=getenv('OASIS_NEVER_SHUTDOWN_FIXED_WORKERS') or False)
+    parser.add_argument('--continue-update-scaling', help='Auto scaling - read the scaling settings from the API for a model on every update. (for testing)', type=str2bool, default=getenv('OASIS_CONTINUE_UPDATE_SCALING') or False)
+    parser.add_argument('--never-shutdown-fixed-workers', help='Auto scaling - never scale to 0 for strategy FIXED_WORKERS.', type=str2bool, default=getenv('OASIS_NEVER_SHUTDOWN_FIXED_WORKERS') or False)
 
     args = parser.parse_args()
 


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue after submitting a Pull Request. -->

<!--start_release_notes-->
### Fixed worker-controller not scaling fixed workers to 0 
The Debugging parameter `self.never_shutdown_fixed_workers`  was incorrectly read as a string instead of boolean. When evaluating this value, **bool('false')** returns `True` in the worker controller. Forcing this option on  https://github.com/OasisLMF/OasisPlatform/blob/07f5baa7248d8e2c6c5a3ea21aac38ee4d49e5c1/kubernetes/worker-controller/src/autoscaler.py#L110
<!--end_release_notes-->
