### PR TITLE
Fix/loclines lessthan chunks

### DIFF
--- a/src/server/oasisapi/analyses/models.py
+++ b/src/server/oasisapi/analyses/models.py
@@ -394,8 +394,9 @@ class Analysis(TimeStampedModel):
             loc_lines = self.portfolio.location_file_len()
         except Exception as e:
             raise ValidationError(f"Failed to read location file size for chunking: {e}")
-        if loc_lines < 1:
-            errors['portfolio'] = ['"location_file" must at least one row']
+        if isinstance(loc_lines, int):
+            if loc_lines < 1:
+                errors['portfolio'] = ['"location_file" must at least one row']
         if errors:
             raise ValidationError(errors)
 

--- a/src/server/oasisapi/analyses/models.py
+++ b/src/server/oasisapi/analyses/models.py
@@ -395,7 +395,7 @@ class Analysis(TimeStampedModel):
         except Exception as e:
             raise ValidationError(f"Failed to read location file size for chunking: {e}")
         if loc_lines < 1:
-            errors['portfolio'] = ['"location_file" must at lease one row']
+            errors['portfolio'] = ['"location_file" must at least one row']
         if errors:
             raise ValidationError(errors)
 

--- a/src/server/oasisapi/analyses/models.py
+++ b/src/server/oasisapi/analyses/models.py
@@ -385,19 +385,19 @@ class Analysis(TimeStampedModel):
         errors = {}
         if self.status not in valid_choices:
             errors['status'] = ['Analysis status must be one of [{}]'.format(', '.join(valid_choices))]
-
         if self.model.deleted:
             errors['model'] = ['Model pk "{}" has been deleted'.format(self.model.id)]
-
         if not self.portfolio.location_file:
             errors['portfolio'] = ['"location_file" must not be null']
 
-        if errors:
-            raise ValidationError(errors)
         try:
             loc_lines = self.portfolio.location_file_len()
         except Exception as e:
             raise ValidationError(f"Failed to read location file size for chunking: {e}")
+        if loc_lines < 1:
+            errors['portfolio'] = ['"location_file" must at lease one row']
+        if errors:
+            raise ValidationError(errors)
 
         self.status = self.status_choices.INPUTS_GENERATION_QUEUED
         self.lookup_errors_file = None

--- a/src/server/oasisapi/analyses/task_controller.py
+++ b/src/server/oasisapi/analyses/task_controller.py
@@ -322,7 +322,7 @@ class Controller:
 
         # fetch the number of lookup chunks and store in analysis
         if analysis.model.chunking_options.lookup_strategy == 'FIXED_CHUNKS':
-            num_chunks = analysis.model.chunking_options.fixed_lookup_chunks
+            num_chunks = min(analysis.model.chunking_options.fixed_lookup_chunks, loc_lines)
         elif analysis.model.chunking_options.lookup_strategy == 'DYNAMIC_CHUNKS':
             loc_lines_per_chunk = analysis.model.chunking_options.dynamic_locations_per_lookup
             num_chunks = ceil(loc_lines / loc_lines_per_chunk)


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue after submitting a Pull Request. -->

<!--start_release_notes-->
### Fixed issue with lookup chunking 
If `FIXED_CHUNKS` is on and set to a value higher than the number location rows, the run fails. Fixed by taking the minimum value between the two `min(analysis.model.chunking_options.fixed_lookup_chunks, loc_lines)`
<!--end_release_notes-->
