### PR TITLE
Fix/646 websocket error handling

### DIFF
--- a/kubernetes/charts/oasis-platform/values.yaml
+++ b/kubernetes/charts/oasis-platform/values.yaml
@@ -182,7 +182,7 @@ workerController:
 
   # Debug option - Read the auto scaling configuration from the API on every update 
   # default is only to read it on for each model each time replicas is changed from 0 (first analysis running)) 
-  continueUpdateScaling: false
+  continueUpdateScaling: true
 
   # Debug option - This prevents workers for a model set to FIXED_WORKERS to be scaled to 0. They will always be started. 
   neverShutdownFixedWorkers: false 


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue after submitting a Pull Request. -->

<!--start_release_notes-->
### Fix for websocket error handling
Added suggested workaround for Django channels `AsyncJsonWebsocketConsumer` class. Couldn't replicate issue, but adding the extra error handling shouldn't be an issue.   
<!--end_release_notes-->
