### PR TITLE
Fix large file download/upload timeout 

### DIFF
--- a/Dockerfile.api_server
+++ b/Dockerfile.api_server
@@ -27,6 +27,7 @@ COPY ./src/utils/wait-for-it.sh /usr/local/bin/wait-for-it
 COPY ./src/utils/wait-for-server.sh /usr/local/bin/wait-for-server
 
 COPY ./asgi ./asgi
+COPY ./wsgi ./wsgi
 COPY ./conf.ini ./
 COPY manage.py .
 COPY ./src/utils/set_default_user.py .
@@ -50,7 +51,8 @@ ENV OASIS_DEBUG=false
 ENV PATH=/home/server/.local/bin:$PATH
 
 EXPOSE 8000
+EXPOSE 8001
 EXPOSE 51970
 
 ENTRYPOINT ["startup"]
-CMD ["./asgi/run-asgi.sh"]
+CMD ["./wsgi/run-wsgi.sh"]

--- a/asgi/run-asgi.sh
+++ b/asgi/run-asgi.sh
@@ -1,2 +1,3 @@
 #!/usr/bin/env bash
-daphne -b 0.0.0.0 -p 8000 --root-path /api src.server.oasisapi.asgi:application
+#daphne -b 0.0.0.0 -p 8001 --root-path /api src.server.oasisapi.asgi:application
+daphne -b 0.0.0.0 -p 8001 src.server.oasisapi.asgi:application

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ volumes:
   filestore-OasisData:
 x-shared-env: &shared-env
   OASIS_DEBUG: 1
-  OASIS_URL_SUB PATH: "false"
+  OASIS_URL_SUB_PATH: 0
   OASIS_CELERY_BROKER_URL: "amqp://rabbit:rabbit@broker:5672"
   #OASIS_CELERY_BROKER_URL: "redis://broker:6379"
   OASIS_SERVER_DB_HOST: server-db
@@ -26,9 +26,10 @@ x-shared-env: &shared-env
 x-volumes: &shared-volumes
   - filestore-OasisData:/shared-fs:rw
 services:
-  server:
+  server_http:
    restart: always
    image: coreoasis/api_server:dev
+   command: ["./wsgi/run-wsgi.sh"]
    build:
      context: .
      dockerfile: Dockerfile.api_server
@@ -44,6 +45,21 @@ services:
      STARTUP_RUN_MIGRATIONS: "true"
      OASIS_ADMIN_USER: admin
      OASIS_ADMIN_PASS: password
+   volumes:
+     - filestore-OasisData:/shared-fs:rw
+     - ./src/server/oasisapi/analyses:/var/www/oasis/src/server/oasisapi/analyses
+  server_websocket:
+   restart: always
+   image: coreoasis/api_server:dev
+   command: ["./asgi/run-asgi.sh"]
+   links:
+     - server-db
+     - celery-db
+     - broker
+   ports:
+     - 8001:8001
+   environment:
+     <<: *shared-env
    volumes:
      - filestore-OasisData:/shared-fs:rw
      - ./src/server/oasisapi/analyses:/var/www/oasis/src/server/oasisapi/analyses

--- a/kubernetes/charts/oasis-platform/Chart.yaml
+++ b/kubernetes/charts/oasis-platform/Chart.yaml
@@ -4,7 +4,7 @@ version: 0.1.1
 type: application
 description: Deploys the Oasis Platform
 
-appVersion: "1.19.0"
+appVersion: "1.26.2"
 home: https://github.com/OasisLMF
 
 dependencies:

--- a/kubernetes/charts/oasis-platform/templates/_helpers.tpl
+++ b/kubernetes/charts/oasis-platform/templates/_helpers.tpl
@@ -168,12 +168,32 @@ Variables for a channel layer client
     configMapKeyRef:
       name: {{ .Values.databases.channel_layer.name }}
       key: host
+- name: OASIS_SERVER_CHANNEL_LAYER_PORT
+  valueFrom:
+    configMapKeyRef:
+      name: {{ .Values.databases.channel_layer.name }}
+      key: port
+- name: OASIS_SERVER_CHANNEL_LAYER_SSL
+  valueFrom:
+    configMapKeyRef:
+      name: {{ .Values.databases.channel_layer.name }}
+      key: ssl
 {{- if eq (.Values.databases.channel_layer.type) "azure_redis" }}
 - name: OASIS_SERVER_CHANNEL_LAYER_PASS
   valueFrom:
     secretKeyRef:
       name: {{ .Values.databases.channel_layer.name }}
       key: password
+- name: OASIS_SERVER_CHANNEL_LAYER_PORT
+  valueFrom:
+    configMapKeyRef:
+      name: {{ .Values.databases.channel_layer.name }}
+      key: port
+- name: OASIS_SERVER_CHANNEL_LAYER_SSL
+  valueFrom:
+    configMapKeyRef:
+      name: {{ .Values.databases.channel_layer.name }}
+      key: ssl
 {{- end }}
 - name: OASIS_INPUT_GENERATION_CONTROLLER_QUEUE
   value: task-controller

--- a/kubernetes/charts/oasis-platform/templates/config_maps.yaml
+++ b/kubernetes/charts/oasis-platform/templates/config_maps.yaml
@@ -13,6 +13,9 @@ metadata:
 data:
   host: {{ if ($v.host) }}{{ $v.host }}{{ else }}{{ $v.name }}{{ end }}
   port: {{ $v.port | quote }}
+  {{- if $v.ssl }}  
+  ssl: {{ $v.ssl | quote }}
+  {{- end }}
   {{- if $v.dbName }}
   dbName: {{ $v.dbName}}
   {{- end }}

--- a/kubernetes/charts/oasis-platform/templates/oasis_server.yaml
+++ b/kubernetes/charts/oasis-platform/templates/oasis_server.yaml
@@ -11,6 +11,18 @@ data:
   password: {{ include "h.password" (list .Values.oasisServer.name "password" . .Values.oasisServer.password (printf "A valid password for %s is required" .Values.oasisServer.name)) }}
 ---
 apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.oasisWebsocket.name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "h.labels" . | nindent 4}}
+type: Opaque
+data:
+  user: {{ required (printf "A valid user for oasis api is required") .Values.oasisWebsocket.user | b64enc }}
+  password: {{ include "h.password" (list .Values.oasisWebsocket.name "password" . .Values.oasisWebsocket.password (printf "A valid password for %s is required" .Values.oasisWebsocket.name)) }}
+---
+apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ .Values.oasisServer.name }}
@@ -19,6 +31,140 @@ metadata:
 data:
   host: {{ .Values.oasisServer.name }}
   port: "{{ .Values.oasisServer.port }}"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.oasisWebsocket.name }}
+  labels:
+    {{- include "h.labels" . | nindent 4 }}
+data:
+  host: {{ .Values.oasisWebsocket.name }}
+  port: "{{ .Values.oasisWebsocket.port }}"
+---  
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.oasisWebsocket.name }}
+  labels:
+    {{- include "h.labels" . | nindent 4}}
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.oasisWebsocket.port }}
+  selector:
+    app: {{ .Values.oasisWebsocket.name }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.oasisWebsocket.name }}
+  labels:
+    {{- include "h.labels" . | nindent 4}}
+spec:
+  selector:
+    matchLabels:
+      app: {{ .Values.oasisWebsocket.name }}
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        {{- include "h.labels" . | nindent 8}}
+        app: {{ .Values.oasisWebsocket.name }}
+      annotations:
+        checksum/oasis-server: {{ toJson .Values.oasisWebsocket | sha256sum }}
+        checksum/{{ .Values.databases.oasis_db.name }}: {{ toJson .Values.databases.oasis_db | sha256sum }}
+        checksum/{{ .Values.databases.celery_db.name }}: {{ toJson .Values.databases.celery_db | sha256sum }}
+    spec:
+      {{- include "h.affinity" . | nindent 6 }}
+      initContainers:
+        {{- include "h.initTcpAvailabilityCheckBySecret" (list . .Values.databases.oasis_db.name .Values.databases.celery_db.name .Values.keycloak.name .Values.databases.broker.name) | nindent 8}}
+      containers:
+        - image: {{ .Values.images.oasis.platform.image }}:{{ .Values.images.oasis.platform.version }}
+          name: {{ .Values.oasisWebsocket.name }}
+          imagePullPolicy: {{ .Values.images.oasis.platform.imagePullPolicy }}
+          env:
+            - name: OASIS_ADMIN_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.oasisWebsocket.name }}
+                  key: user
+            - name: OASIS_ADMIN_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.oasisWebsocket.name }}
+                  key: password
+            {{- include "h.serverDbVars" . | indent 12}}
+            {{- include "h.celeryDbVars" . | indent 12}}
+            {{- include "h.brokerVars" . | indent 12 }}
+            {{- include "h.channelLayerVars" . | indent 12 }}
+            - name: STARTUP_RUN_MIGRATIONS
+              value: "true"
+            - name: OASIS_DEBUG
+              value: "1"
+            - name: OASIS_URL_SUB_PATH
+              value: "0"
+            - name: INGRESS_EXTERNAL_HOST
+              value: {{ .Values.ingress.uiHostname }}
+            - name: INGRESS_INTERNAL_HOST
+              value: {{ .Release.Name | lower }}-ingress-nginx-controller
+            {{- if eq .Values.oasisServer.apiAuthType "keycloak" }}
+            - name: OASIS_SERVER_API_AUTH_TYPE
+              value: keycloak
+            - name: OASIS_SERVER_OIDC_CLIENT_NAME
+              value: {{ .Values.oasisServer.oidc.clientName }}
+            - name: OASIS_SERVER_OIDC_CLIENT_SECRET
+              value: {{ .Values.oasisServer.oidc.clientSecret }}
+            - name: OASIS_SERVER_OIDC_ENDPOINT
+              value: {{ .Values.oasisServer.oidc.endpoint }}
+            {{- end }}
+          ports:
+            - containerPort: {{ .Values.oasisWebsocket.port }}
+              name: {{ .Values.oasisWebsocket.name }}
+          command: [ "./asgi/run-asgi.sh" ]    
+          volumeMounts:
+            - name: shared-fs-persistent-storage
+              mountPath: /shared-fs
+{{- if (.Values.azure).secretProvider }}
+            - name: azure-secret-provider
+              mountPath: "/mnt/azure-secrets-store"
+              readOnly: true
+{{- end }}
+          startupProbe:
+            httpGet:
+              path: /healthcheck/
+              port: {{.Values.oasisWebsocket.port}}
+              scheme: HTTP
+            timeoutSeconds: 10
+            periodSeconds: 10
+            failureThreshold: 30
+          livenessProbe:
+            httpGet:
+              path: /healthcheck/
+              port: {{.Values.oasisWebsocket.port}}
+              scheme: HTTP
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 10
+            failureThreshold: 2
+      volumes:
+{{- if ((.Values.volumes.host).sharedFs) }}
+        - name: shared-fs-persistent-storage
+          persistentVolumeClaim:
+            claimName: {{ .Values.volumes.host.sharedFs.name }}
+{{- else if ((.Values.volumes.azureFiles).sharedFs) }}
+        - name: shared-fs-persistent-storage
+{{- toYaml .Values.volumes.azureFiles.sharedFs | nindent 10 }}
+{{- end }}
+{{- if (.Values.azure).secretProvider }}
+        - name: azure-secret-provider
+          csi:
+            driver: secrets-store.csi.k8s.io
+            readOnly: true
+            volumeAttributes:
+              secretProviderClass: "azure-secret-provider"
+{{- end }}
 ---
 apiVersion: v1
 kind: Service

--- a/kubernetes/charts/oasis-platform/templates/oasis_worker_controller.yaml
+++ b/kubernetes/charts/oasis-platform/templates/oasis_worker_controller.yaml
@@ -48,12 +48,12 @@ spec:
         app: oasis-worker-controller
       {{- include "h.labels" . | nindent 8}}
       annotations:
-        checksum/{{ .Values.oasisServer.name }}: {{ toJson .Values.oasisServer | sha256sum }}
+        checksum/{{ .Values.oasisServer.name }}: {{ toJson .Values.oasisWebsocket | sha256sum }}
     spec:
       {{- include "h.affinity" . | nindent 6 }}
       serviceAccountName: {{ $workerControllerServiceAccountName }}
       initContainers:
-      {{- include "h.initTcpAvailabilityCheckBySecret" (list . .Values.oasisServer.name) | nindent 8}}
+      {{- include "h.initTcpAvailabilityCheckBySecret" (list . .Values.oasisWebsocket.name) | nindent 8}}
       containers:
         - image: {{ .Values.images.oasis.worker_controller.image }}:{{ .Values.images.oasis.worker_controller.version }}
           imagePullPolicy: {{ .Values.images.oasis.worker_controller.imagePullPolicy }}
@@ -75,9 +75,9 @@ spec:
             - name: OASIS_NEVER_SHUTDOWN_FIXED_WORKERS
               value: "{{ .Values.workerController.neverShutdownFixedWorkers }}"
             - name: OASIS_API_HOST
-              value: {{ .Values.oasisServer.name }}
+              value: {{ .Values.oasisWebsocket.name }}
             - name: OASIS_API_PORT
-              value: {{ .Values.oasisServer.port | quote }}
+              value: {{ .Values.oasisWebsocket.port | quote }}
             - name: OASIS_CLUSTER_NAMESPACE
               value: {{ .Release.Namespace | quote }}
             {{- with .Values.workerController.totalWorkerLimit }}

--- a/kubernetes/charts/oasis-platform/values.yaml
+++ b/kubernetes/charts/oasis-platform/values.yaml
@@ -107,6 +107,7 @@ databases:
     type: redis
     name: channel-layer
     port: 6379
+    ssl: false
   broker:
     type: rabbitmq
     name: broker

--- a/kubernetes/charts/oasis-platform/values.yaml
+++ b/kubernetes/charts/oasis-platform/values.yaml
@@ -160,7 +160,7 @@ keycloak:
         password: password
         admin: true
 
-# Oasis API host, port and credentials
+# Oasis API host, port and credentials (for HTTP connections)
 oasisServer:
   name: oasis-server
   port: 8000
@@ -174,6 +174,22 @@ oasisServer:
     endpoint: https://ui.oasis.local/auth/realms/oasis/protocol/openid-connect/
     clientName: oasis-server
     clientSecret: e4f4fb25-2250-4210-a7d6-9b16c3d2ab77
+
+# Oasis API host, port and credentials (for Websocket connections)
+oasisWebsocket:
+  name: oasis-websocket
+  port: 8001
+  user: admin
+  password: password
+
+  # Use same settings as client (uncomment and update charts if needed)  
+  # Enable OIDC Keycloak authentication with 'keycloak or set to 'simple' for simple jwt.
+  #apiAuthType: keycloak
+  #oidc:
+  #  #endpoint: https://ui.oasis.local/auth/realms/oasis/protocol/openid-connect/
+  #  clientName: oasis-websocket
+  #  clientSecret: 4fbf064d-de2a-4f58-b031-14486a751a3d
+
 
 workerController:
   # The maximum number of workers the worker controller will start. No matter the number of analyses and models

--- a/requirements-server.in
+++ b/requirements-server.in
@@ -29,3 +29,4 @@ pyrabbit
 redis
 sqlalchemy
 whitenoise
+gunicorn

--- a/requirements-server.txt
+++ b/requirements-server.txt
@@ -131,6 +131,8 @@ drf-yasg==1.20.0
     # via -r requirements-server.in
 greenlet==1.1.2
     # via sqlalchemy
+gunicorn==20.1.0
+    # via -r requirements-server.in
 hiredis==2.0.0
     # via aioredis
 httplib2==0.19.1

--- a/src/server/oasisapi/analyses/management/commands/ws_echo.py
+++ b/src/server/oasisapi/analyses/management/commands/ws_echo.py
@@ -20,7 +20,7 @@ def on_error(app, error):
 
 class Command(BaseCommand):
     def add_arguments(self, parser):
-        parser.add_argument('--url', default='ws://localhost:8000/ws/v1/queue-status/')
+        parser.add_argument('--url', default='ws://localhost:8001/ws/v1/queue-status/')
 
     def handle(self, *args, **options):
         user = get_user_model().objects.first()

--- a/src/server/oasisapi/asgi.py
+++ b/src/server/oasisapi/asgi.py
@@ -11,3 +11,7 @@ os.environ.setdefault("DJANGO_SETTINGS_MODULE", "src.server.oasisapi.settings")
 django.setup()
 
 application = get_default_application()
+
+## ONLY run the websocket from here (add safeguard to remove HTTP router)
+#if 'http' in application.application_mapping:
+#    del application.application_mapping['http']

--- a/src/server/oasisapi/queues/viewsets.py
+++ b/src/server/oasisapi/queues/viewsets.py
@@ -27,7 +27,7 @@ class WebsocketViewSet(viewsets.ViewSet):
         To print the websocket directly use the following:
         ```
         pip install websocket_client
-        ./manage.py ws_echo --url ws://localhost:8000/ws/v1/queue-status/
+        ./manage.py ws_echo --url ws://localhost:8001/ws/v1/queue-status/
         ```
         """
         return Response(build_all_queue_status_message())

--- a/src/server/oasisapi/settings.py
+++ b/src/server/oasisapi/settings.py
@@ -11,8 +11,9 @@ https://docs.djangoproject.com/en/2.0/ref/settings/
 """
 
 import os
-
 import sys
+import ssl
+
 from django.core.exceptions import ImproperlyConfigured
 from rest_framework.reverse import reverse_lazy
 import urllib
@@ -390,15 +391,31 @@ if IN_TEST:
     BROKER_URL = 'memory://'
     LOGGING['root'] = {}
 
+
+CHANNEL_LAYER_SSL  = iniconf.settings.getboolean('server', 'channel_layer_ssl', fallback=False)
 CHANNEL_LAYER_HOST = iniconf.settings.get('server', 'channel_layer_host', fallback='localhost')
 CHANNEL_LAYER_PASS = iniconf.settings.get('server', 'channel_layer_pass', fallback='')
 CHANNEL_LAYER_USER = iniconf.settings.get('server', 'channel_layer_user', fallback='')
 CHANNEL_LAYER_PORT = iniconf.settings.get('server', 'channel_layer_port', fallback='6379')
+#CHANNEL_LAYER_PORT = iniconf.settings.get('server', 'channel_layer_port', fallback='6379' if not CHANNEL_LAYER_SSL else '6380')
+
+if CHANNEL_LAYER_SSL:
+    ssl_context = ssl.SSLContext()
+    ssl_context.check_hostname = False
+    channel_host = [{
+        'address': f'rediss://{CHANNEL_LAYER_USER}:{CHANNEL_LAYER_PASS}@{CHANNEL_LAYER_HOST}:{CHANNEL_LAYER_PORT}/0',
+        'ssl': ssl_context,
+    }]
+else:
+    channel_host = [f'redis://{CHANNEL_LAYER_USER}:{CHANNEL_LAYER_PASS}@{CHANNEL_LAYER_HOST}:{CHANNEL_LAYER_PORT}/0']
+
+
+
 CHANNEL_LAYERS = {
     'default': {
         'BACKEND': 'channels_redis.core.RedisChannelLayer',
         'CONFIG': {
-            'hosts': [f'redis://{CHANNEL_LAYER_USER}:{CHANNEL_LAYER_PASS}@{CHANNEL_LAYER_HOST}:{CHANNEL_LAYER_PORT}/0'],
+            'hosts': channel_host,
             'symmetric_encryption_keys': [SECRET_KEY],
             "capacity": 1500,
         },

--- a/src/server/oasisapi/settings.py
+++ b/src/server/oasisapi/settings.py
@@ -251,7 +251,7 @@ USE_L10N = True
 USE_TZ = True
 
 # Place the app in a sub path (swagger still available in /)
-FORCE_SCRIPT_NAME = '/api'
+#FORCE_SCRIPT_NAME = '/api/'
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/2.0/howto/static-files/

--- a/src/server/oasisapi/urls.py
+++ b/src/server/oasisapi/urls.py
@@ -119,11 +119,9 @@ urlpatterns = [
 ]
 
 urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
-
-
 if settings.URL_SUB_PATH:
     urlpatterns += static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
-    urlpatterns = [url(r'^api/', include(urlpatterns))]
+    urlpatterns = [url(r'^api/', include(urlpatterns))] + urlpatterns
 else:
     urlpatterns += static(settings.STATIC_DEBUG_URL, document_root=settings.STATIC_ROOT)
 

--- a/src/server/oasisapi/urls.py
+++ b/src/server/oasisapi/urls.py
@@ -120,8 +120,10 @@ urlpatterns = [
 
 urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 
+
 if settings.URL_SUB_PATH:
     urlpatterns += static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
+    urlpatterns = [url(r'^api/', include(urlpatterns))]
 else:
     urlpatterns += static(settings.STATIC_DEBUG_URL, document_root=settings.STATIC_ROOT)
 

--- a/src/server/oasisapi/wsgi.py
+++ b/src/server/oasisapi/wsgi.py
@@ -1,0 +1,6 @@
+# wsgi.py
+from django.core.wsgi import get_wsgi_application
+import os
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "src.server.oasisapi.settings")
+application = get_wsgi_application()

--- a/wsgi/run-wsgi.sh
+++ b/wsgi/run-wsgi.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# Gateway Config options
+# https://docs.gunicorn.org/en/stable/settings.html
+
+BIND_ADDR='0.0.0.0:8000'
+WORKERS=$(nproc --all)
+TIMEOUT=600
+LOG_LEVEL='info'
+
+export GUNICORN_CMD_ARGS="--bind=$BIND_ADDR --workers=$WORKERS --timeout $TIMEOUT --log-level=$LOG_LEVEL"
+gunicorn src.server.oasisapi.wsgi


### PR DESCRIPTION
<!--start_release_notes-->
### Fix health check failures on large file transfers

**Cause of the problem**
When the oasis server's gateway interface is running in async mode, a feature needed for websocket, HTTP API calls are handled synchronously and block. This causes long lasting http calls, such as file transfers, to cause liveness probe failures which restarts the running server. 

The issue is due to a problem in the Django stack, in the longer term switching to a fully async based REST API would be preferable, unfortunately this currently doesn't look possible due to DRF (Django rest Framework) not supporting async views. For more details on the problem see: https://github.com/django/channels/issues/1587

**Workaround**
The cleanest workaround is running a second deployment of the oasis server, dedicated to running the web-socket using an ASGI (Asynchronous Gateway) and only accessible internally. This could later be exposed as an external service via the ingress later on if needed. 

The main server will instead run WSGI (synchronous and threaded via workers) called https://gunicorn.org/
While the number of concurrent long lasting connections would still be limited by the number of cores on the platform node, this can be scaled up by using a later platform node, or increases the number of containers in the server's replica set.    


     
![Pods_update](https://user-images.githubusercontent.com/9889973/187887469-834c50bc-58fc-46d0-917a-4521b83d5c32.png)

- `oasis-websocket-69b66576d5-bsks6` - Only for websocket requests (ASGI)  
- `oasis-server-5b66f4c556-8vc25`  - Only for HTTP requests (WSGI)



**Testing the fix** 
Uploaded and downloaded a large file `junk-data.csv.zip` to a portfolio while polling the server's health check endpoint. Before the fix once the transfer started all heath-check calls would block and timeout. 
 




<!--end_release_notes-->
![test_fix_server](https://user-images.githubusercontent.com/9889973/187889577-89b7bb95-38b5-4c14-8a02-fb368a2ed173.png)

Note: there is a gunicorn timeout limit which is currently set to 600sec, If a request takes longer that 10mins the connection will terminate. This can be increased by editing https://github.com/OasisLMF/OasisPlatform/blob/da1adc9adf2fab067e5c21f22bcf20f7e5f56d05/wsgi/run-wsgi.sh#L8 