### PR TITLE
Add option for ssl redis

### DIFF
--- a/kubernetes/charts/oasis-platform/templates/_helpers.tpl
+++ b/kubernetes/charts/oasis-platform/templates/_helpers.tpl
@@ -168,12 +168,32 @@ Variables for a channel layer client
     configMapKeyRef:
       name: {{ .Values.databases.channel_layer.name }}
       key: host
+- name: OASIS_SERVER_CHANNEL_LAYER_PORT
+  valueFrom:
+    configMapKeyRef:
+      name: {{ .Values.databases.channel_layer.name }}
+      key: port
+- name: OASIS_SERVER_CHANNEL_LAYER_SSL
+  valueFrom:
+    configMapKeyRef:
+      name: {{ .Values.databases.channel_layer.name }}
+      key: ssl
 {{- if eq (.Values.databases.channel_layer.type) "azure_redis" }}
 - name: OASIS_SERVER_CHANNEL_LAYER_PASS
   valueFrom:
     secretKeyRef:
       name: {{ .Values.databases.channel_layer.name }}
       key: password
+- name: OASIS_SERVER_CHANNEL_LAYER_PORT
+  valueFrom:
+    configMapKeyRef:
+      name: {{ .Values.databases.channel_layer.name }}
+      key: port
+- name: OASIS_SERVER_CHANNEL_LAYER_SSL
+  valueFrom:
+    configMapKeyRef:
+      name: {{ .Values.databases.channel_layer.name }}
+      key: ssl
 {{- end }}
 - name: OASIS_INPUT_GENERATION_CONTROLLER_QUEUE
   value: task-controller

--- a/kubernetes/charts/oasis-platform/templates/config_maps.yaml
+++ b/kubernetes/charts/oasis-platform/templates/config_maps.yaml
@@ -14,7 +14,7 @@ data:
   host: {{ if ($v.host) }}{{ $v.host }}{{ else }}{{ $v.name }}{{ end }}
   port: {{ $v.port | quote }}
   {{- if $v.ssl }}  
-  ssl: {{ $v.ssl}}
+  ssl: {{ $v.ssl | quote }}
   {{- end }}
   {{- if $v.dbName }}
   dbName: {{ $v.dbName}}

--- a/kubernetes/charts/oasis-platform/templates/config_maps.yaml
+++ b/kubernetes/charts/oasis-platform/templates/config_maps.yaml
@@ -13,6 +13,9 @@ metadata:
 data:
   host: {{ if ($v.host) }}{{ $v.host }}{{ else }}{{ $v.name }}{{ end }}
   port: {{ $v.port | quote }}
+  {{- if $v.ssl }}  
+  ssl: {{ $v.ssl}}
+  {{- end }}
   {{- if $v.dbName }}
   dbName: {{ $v.dbName}}
   {{- end }}

--- a/kubernetes/charts/oasis-platform/values.yaml
+++ b/kubernetes/charts/oasis-platform/values.yaml
@@ -107,6 +107,7 @@ databases:
     type: redis
     name: channel-layer
     port: 6379
+    ssl: false
   broker:
     type: rabbitmq
     name: broker

--- a/src/server/oasisapi/settings.py
+++ b/src/server/oasisapi/settings.py
@@ -405,7 +405,7 @@ if CHANNEL_LAYER_SSL:
     channel_host = [{
         'address': f'rediss://{CHANNEL_LAYER_USER}:{CHANNEL_LAYER_PASS}@{CHANNEL_LAYER_HOST}:{CHANNEL_LAYER_PORT}/0',
         'ssl': ssl_context,
-    [{
+    }]
 else:
     channel_host = [f'redis://{CHANNEL_LAYER_USER}:{CHANNEL_LAYER_PASS}@{CHANNEL_LAYER_HOST}:{CHANNEL_LAYER_PORT}/0']
 

--- a/src/server/oasisapi/urls.py
+++ b/src/server/oasisapi/urls.py
@@ -119,11 +119,9 @@ urlpatterns = [
 ]
 
 urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
-
-
 if settings.URL_SUB_PATH:
     urlpatterns += static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
-    urlpatterns = [url(r'^api/', include(urlpatterns))]
+    urlpatterns = [url(r'^api/', include(urlpatterns))] + urlpatterns
 else:
     urlpatterns += static(settings.STATIC_DEBUG_URL, document_root=settings.STATIC_ROOT)
 


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue after submitting a Pull Request. -->

- [x] fix OasisUI routing for API access

<!--start_release_notes-->
### Use redis SSL port by default 
> Requires https://github.com/OasisLMF/OasisAzureDeployment/pull/6 to work correctly with [OasisAzureDeployment](https://github.com/OasisLMF/OasisAzureDeployment)

To enable, replace the values in https://github.com/OasisLMF/OasisPlatform/blob/7bb110f919c05a3a4ddf49c3fca669292176d9d4/kubernetes/charts/oasis-platform/values.yaml#L106-L109

with:
```
  channel_layer:
    type: redis
    name: channel-layer
    port: 6380
    ssl: true 
```






<!--end_release_notes-->
