### PR TITLE
Enable the check-missing-inputs in workers by default

### DIFF
--- a/Dockerfile.model_worker
+++ b/Dockerfile.model_worker
@@ -23,6 +23,7 @@ ENV PATH=/root/.local/bin:$PATH
 ENV DEBIAN_FRONTEND=noninteractive
 ENV OASIS_MEDIA_ROOT=/shared-fs
 ENV OASIS_ENV_OVERRIDE=true
+ENV OASIS_CHECK_MISSING_INPUTS=true
 
 # Setup worker dir and user
 RUN adduser --shell /bin/bash --disabled-password --gecos "" worker

--- a/Dockerfile.model_worker_centos
+++ b/Dockerfile.model_worker_centos
@@ -25,6 +25,7 @@ ENV PATH=/root/.local/bin:$PATH
 # Enviroment setup
 ENV OASIS_MEDIA_ROOT=/shared-fs
 ENV OASIS_ENV_OVERRIDE=true
+ENV OASIS_CHECK_MISSING_INPUTS=true
 
 # Setup worker dir and user
 RUN adduser --shell /bin/bash  worker

--- a/Dockerfile.model_worker_debian
+++ b/Dockerfile.model_worker_debian
@@ -2,6 +2,7 @@ FROM python:3.8
 
 ENV OASIS_MEDIA_ROOT=/shared-fs
 ENV OASIS_ENV_OVERRIDE=true
+ENV OASIS_CHECK_MISSING_INPUTS=true
 
 RUN apt-get update && apt-get install -y --no-install-recommends git vim libspatialindex-dev && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue after submitting a Pull Request. -->

<!--start_release_notes-->
### Fail loss generation tasks if generated outputs are missing
Loss analysis will now be marked as failed if either `IL` or `RI` is set in the `analysis_settings.json` but the oasis files are missing

https://github.com/OasisLMF/OasisLMF/pull/1112
<!--end_release_notes-->
