### PR TITLE
Update Django for CVE-2022-36359

### DIFF
--- a/requirements-server.txt
+++ b/requirements-server.txt
@@ -81,7 +81,7 @@ daphne==3.0.2
     # via
     #   -r requirements-server.in
     #   channels
-django==3.2.14
+django==3.2.15
     # via
     #   -r requirements-server.in
     #   channels


### PR DESCRIPTION
<!--start_release_notes-->
### Update Django
* fix needed for  CVE-2022-36359
<!--end_release_notes-->