### PR TITLE
Fix/error reading file len

### DIFF
--- a/src/server/oasisapi/analyses/models.py
+++ b/src/server/oasisapi/analyses/models.py
@@ -394,7 +394,10 @@ class Analysis(TimeStampedModel):
             loc_lines = self.portfolio.location_file_len()
         except Exception as e:
             raise ValidationError(f"Failed to read location file size for chunking: {e}")
-        if isinstance(loc_lines, int):
+        if not isinstance(loc_lines, int):
+                errors['portfolio'] = [f'Failed to read "location_file" size, content_type={self.portfolio.location_file.content_type} might not be supported']
+
+        else:
             if loc_lines < 1:
                 errors['portfolio'] = ['"location_file" must at least one row']
         if errors:

--- a/src/server/oasisapi/portfolios/models.py
+++ b/src/server/oasisapi/portfolios/models.py
@@ -56,9 +56,10 @@ class Portfolio(TimeStampedModel):
     def location_file_len(self):
         csv_compression_types = {
             'text/csv': 'infer',
+            'application/vnd.ms-excel': 'infer',
             'application/gzip': 'gzip',
             'application/x-bzip2': 'bz2',
-            'application/zip': 'zip'
+            'application/zip': 'zip',
         }
         if not self.location_file:
             return None


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue after submitting a Pull Request. -->

<!--start_release_notes-->
### Fix error when checking the location file length for chunking
Uploading `csv` exposure from Windows or azure services can return a content type of  "application/vnd.ms-excel".
This causes the Input_generation call to fail when processing the unknown type. 
<!--end_release_notes-->
