### PR TITLE
Always include ssl in configmap

### DIFF
--- a/kubernetes/charts/oasis-platform/templates/config_maps.yaml
+++ b/kubernetes/charts/oasis-platform/templates/config_maps.yaml
@@ -13,9 +13,7 @@ metadata:
 data:
   host: {{ if ($v.host) }}{{ $v.host }}{{ else }}{{ $v.name }}{{ end }}
   port: {{ $v.port | quote }}
-  {{- if $v.ssl }}  
   ssl: {{ $v.ssl | quote }}
-  {{- end }}
   {{- if $v.dbName }}
   dbName: {{ $v.dbName}}
   {{- end }}


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue after submitting a Pull Request. -->

<!--start_release_notes-->
### Fix config map ssl error
Fixes #718 by ensuring the ssl key is always included in the config maps, even if set to false.
<!--end_release_notes-->
