### PR TITLE
Update external image versions 

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -171,6 +171,7 @@ jobs:
         scan-type: 'image'
         exit-code: '0'
         ignore-unfixed: ${{ env.IGNORE_UNFIXED }}
+        severity: ${{ env.SEVERITY }}
         security-checks: 'vuln'
 
     - name: Upload scan results to Security tab

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -162,7 +162,7 @@ jobs:
         security-checks: 'vuln'
 
     - name: Create Report
-      if: ( success() || failure() ) && env.SEVERITY != 'SKIP'
+      if: ( success() || failure() ) && env.SEVERITY != 'SKIP' && matrix.exit-code == '1'
       uses: aquasecurity/trivy-action@master
       with:
         image-ref: ${{ env.IMAGE_REPO }}:${{ matrix.tag }}
@@ -174,7 +174,7 @@ jobs:
         security-checks: 'vuln'
 
     - name: Upload scan results to Security tab
-      if: ( success() || failure() ) && env.SEVERITY != 'SKIP'
+      if: ( success() || failure() ) && env.SEVERITY != 'SKIP' && matrix.exit-code == '1'
       uses: github/codeql-action/upload-sarif@v2
       with:
         sarif_file:  ${{ matrix.report }}

--- a/.github/workflows/scan-external.yml
+++ b/.github/workflows/scan-external.yml
@@ -97,6 +97,7 @@ jobs:
         scan-type: 'image'
         exit-code: '0'
         ignore-unfixed: ${{ env.IGNORE_UNFIXED }}
+        severity: ${{ env.SEVERITY }}
         security-checks: 'vuln'
 
     - name: Upload Trivy scan results to GitHub Security tab

--- a/.github/workflows/scan-external.yml
+++ b/.github/workflows/scan-external.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: [keycloak, redis, rabbitmq, postgres, mysql]
+        image: [keycloak, redis, rabbitmq, postgres]
         include:
         - image: keycloak
           report: 'keycloak-scan.sarif'
@@ -49,10 +49,6 @@ jobs:
         - image: postgres
           report: 'postgres-scan.sarif'
           exit-code: '1'
-
-        #- image: mysql
-        #  report: 'mysql-scan.sarif'
-        #  exit-code: '1'
 
     steps:
     - name: Set inputs

--- a/.github/workflows/scan-external.yml
+++ b/.github/workflows/scan-external.yml
@@ -50,9 +50,9 @@ jobs:
           report: 'postgres-scan.sarif'
           exit-code: '1'
 
-        - image: mysql
-          report: 'mysql-scan.sarif'
-          exit-code: '1'
+        #- image: mysql
+        #  report: 'mysql-scan.sarif'
+        #  exit-code: '1'
 
     steps:
     - name: Set inputs

--- a/.github/workflows/scan-external.yml
+++ b/.github/workflows/scan-external.yml
@@ -85,7 +85,7 @@ jobs:
         exit-code: ${{ matrix.exit-code }}
         ignore-unfixed: ${{ env.IGNORE_UNFIXED }}
         severity: ${{ env.SEVERITY }}
-        security-checks: 'vuln,config,secret'
+        security-checks: 'vuln'
 
     - name: Create Report
       if: success() || failure()
@@ -97,7 +97,7 @@ jobs:
         scan-type: 'image'
         exit-code: '0'
         ignore-unfixed: ${{ env.IGNORE_UNFIXED }}
-        security-checks: 'vuln,config,secret'
+        security-checks: 'vuln'
 
     - name: Upload Trivy scan results to GitHub Security tab
       if: success() || failure()

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -60,7 +60,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
 
-    - name: Trivy vulnerability scanner (File system)
+    - name: Trivy vulnerability scanner
       if: env.SEVERITY != ''
       uses: aquasecurity/trivy-action@master
       with:
@@ -68,7 +68,18 @@ jobs:
         exit-code: '1'
         ignore-unfixed: ${{ env.IGNORE_UNFIXED }}
         severity: ${{ env.SEVERITY }}
-        security-checks: 'vuln,config,secret'
+        security-checks: 'vuln'
+        skip-dirs: './docker'
+
+    - name: Trivy Configuration scanner (no fail) 
+      if: env.SEVERITY != ''
+      uses: aquasecurity/trivy-action@master
+      with:
+        scan-type: 'fs'
+        exit-code: '0'
+        ignore-unfixed: ${{ env.IGNORE_UNFIXED }}
+        severity: ${{ env.SEVERITY }}
+        security-checks: 'config,secret'
         skip-dirs: './docker'
 
     - name: Create Report
@@ -80,7 +91,7 @@ jobs:
         scan-type: 'fs'
         exit-code: '0'
         ignore-unfixed: ${{ env.IGNORE_UNFIXED }}
-        security-checks: 'vuln,config,secret'
+        security-checks: 'vuln'
         skip-dirs: './docker'
 
     - name: Upload Trivy scan results to GitHub Security tab

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -9,6 +9,8 @@ on:
     branches:
       - platform-2.0
       - platform-2.0-develop
+  schedule:
+    - cron:  '0 */6 * * *' # Run scan every 6 hours
 
   workflow_dispatch:
     inputs:
@@ -71,7 +73,7 @@ jobs:
         security-checks: 'vuln'
         skip-dirs: './docker'
 
-    - name: Trivy Configuration scanner (no fail) 
+    - name: Trivy Configuration scanner (no fail)
       if: env.SEVERITY != ''
       uses: aquasecurity/trivy-action@master
       with:

--- a/kubernetes/charts/oasis-platform/resources/oasis-realm.json
+++ b/kubernetes/charts/oasis-platform/resources/oasis-realm.json
@@ -526,69 +526,49 @@
     "defaultClientScopes" : [ "web-origins", "roles", "profile", "email" ],
     "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
   }, {
-    "id" : "a957f94c-dbab-440f-9aaf-9b529b12f24f",
+    "id" : "b9b8c572-956e-4e0e-8113-0f3a97e88c4c",
     "clientId" : "oasis-server",
-    "rootUrl" : "${authBaseUrl}",
+    "name" : "",
+    "description" : "",
+    "rootUrl" : "",
+    "adminUrl" : "",
+    "baseUrl" : "",
     "surrogateAuthRequired" : false,
     "enabled" : true,
     "alwaysDisplayInConsole" : false,
     "clientAuthenticatorType" : "client-secret",
-    "secret" : "**********",
-    "redirectUris" : [ "http://localhost:*", "/*", "https://localhost:*" ],
-    "webOrigins" : [ "+" ],
+    "secret" : "e4f4fb25-2250-4210-a7d6-9b16c3d2ab77",
+    "redirectUris" : [ "*" ],
+    "webOrigins" : [ ],
     "notBefore" : 0,
     "bearerOnly" : false,
     "consentRequired" : false,
     "standardFlowEnabled" : true,
-    "implicitFlowEnabled" : false,
+    "implicitFlowEnabled" : true,
     "directAccessGrantsEnabled" : true,
     "serviceAccountsEnabled" : false,
-    "publicClient" : false,
+    "publicClient" : true,
     "frontchannelLogout" : false,
     "protocol" : "openid-connect",
     "attributes" : {
-      "id.token.as.detached.signature" : "false",
-      "saml.assertion.signature" : "false",
-      "saml.force.post.binding" : "false",
-      "saml.multivalued.roles" : "false",
-      "saml.encrypt" : "false",
+      "client.secret.creation.time" : "1677167475",
       "post.logout.redirect.uris" : "+",
       "oauth2.device.authorization.grant.enabled" : "false",
       "backchannel.logout.revoke.offline.tokens" : "false",
-      "saml.server.signature" : "false",
-      "saml.server.signature.keyinfo.ext" : "false",
       "use.refresh.tokens" : "true",
-      "exclude.session.state.from.auth.response" : "false",
+      "tls-client-certificate-bound-access-tokens" : "false",
       "oidc.ciba.grant.enabled" : "false",
-      "saml.artifact.binding" : "false",
       "backchannel.logout.session.required" : "true",
       "client_credentials.use_refresh_token" : "false",
-      "saml_force_name_id_format" : "false",
+      "acr.loa.map" : "{}",
       "require.pushed.authorization.requests" : "false",
-      "saml.client.signature" : "false",
-      "tls.client.certificate.bound.access.tokens" : "false",
-      "saml.authnstatement" : "false",
       "display.on.consent.screen" : "false",
-      "saml.onetimeuse.condition" : "false"
+      "token.response.type.bearer.lower-case" : "false"
     },
     "authenticationFlowBindingOverrides" : { },
     "fullScopeAllowed" : true,
     "nodeReRegistrationTimeout" : -1,
-    "protocolMappers" : [ {
-      "id" : "0352301c-2263-4865-ab85-532febb91db9",
-      "name" : "Groups",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-group-membership-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "full.path" : "true",
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "claim.name" : "groups",
-        "userinfo.token.claim" : "true"
-      }
-    } ],
-    "defaultClientScopes" : [ "web-origins", "openid", "roles", "profile", "email" ],
+    "defaultClientScopes" : [ "web-origins", "acr", "openid", "roles", "profile", "email" ],
     "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
   }, {
     "id" : "40223c47-11d9-49e5-a552-197fbbfb21c3",
@@ -709,7 +689,7 @@
       "saml.onetimeuse.condition" : "false"
     },
     "authenticationFlowBindingOverrides" : {
-      "browser" : "084888e1-ccfd-4f12-87cc-d027f422f5c0"
+      "browser" : "17a35dea-0549-4fbb-8766-c04b0ef5ead2"
     },
     "fullScopeAllowed" : true,
     "nodeReRegistrationTimeout" : -1,
@@ -1274,7 +1254,7 @@
       "subType" : "authenticated",
       "subComponents" : { },
       "config" : {
-        "allowed-protocol-mapper-types" : [ "saml-user-property-mapper", "oidc-usermodel-attribute-mapper", "saml-role-list-mapper", "oidc-full-name-mapper", "oidc-usermodel-property-mapper", "oidc-address-mapper", "saml-user-attribute-mapper", "oidc-sha256-pairwise-sub-mapper" ]
+        "allowed-protocol-mapper-types" : [ "oidc-usermodel-attribute-mapper", "saml-role-list-mapper", "saml-user-property-mapper", "oidc-usermodel-property-mapper", "oidc-sha256-pairwise-sub-mapper", "oidc-full-name-mapper", "saml-user-attribute-mapper", "oidc-address-mapper" ]
       }
     }, {
       "id" : "5c1d8674-1b1f-4723-9aa0-2784339267ad",
@@ -1292,7 +1272,7 @@
       "subType" : "anonymous",
       "subComponents" : { },
       "config" : {
-        "allowed-protocol-mapper-types" : [ "oidc-full-name-mapper", "oidc-usermodel-attribute-mapper", "saml-user-property-mapper", "oidc-sha256-pairwise-sub-mapper", "saml-user-attribute-mapper", "saml-role-list-mapper", "oidc-address-mapper", "oidc-usermodel-property-mapper" ]
+        "allowed-protocol-mapper-types" : [ "oidc-usermodel-attribute-mapper", "oidc-sha256-pairwise-sub-mapper", "saml-role-list-mapper", "saml-user-property-mapper", "oidc-address-mapper", "oidc-full-name-mapper", "oidc-usermodel-property-mapper", "saml-user-attribute-mapper" ]
       }
     } ],
     "org.keycloak.keys.KeyProvider" : [ {
@@ -1341,7 +1321,7 @@
   "internationalizationEnabled" : false,
   "supportedLocales" : [ ],
   "authenticationFlows" : [ {
-    "id" : "3a43585c-8c49-4338-b0cf-508cda7445e5",
+    "id" : "957c3fd1-aba2-4438-8a63-08c3f111bdb4",
     "alias" : "Account verification options",
     "description" : "Method with which to verity the existing account",
     "providerId" : "basic-flow",
@@ -1363,7 +1343,7 @@
       "userSetupAllowed" : false
     } ]
   }, {
-    "id" : "14230e21-8cb6-4402-9eda-5877f8c9113e",
+    "id" : "765ddd7f-548d-4760-b301-31851f30d1fc",
     "alias" : "Authentication Options",
     "description" : "Authentication options.",
     "providerId" : "basic-flow",
@@ -1392,7 +1372,7 @@
       "userSetupAllowed" : false
     } ]
   }, {
-    "id" : "8402a20f-b8e1-43bd-9ff5-3341e1024e2a",
+    "id" : "8fa36c33-c908-43b4-8129-2cbe00094e55",
     "alias" : "Browser - Conditional OTP",
     "description" : "Flow to determine if the OTP is required for the authentication",
     "providerId" : "basic-flow",
@@ -1414,7 +1394,7 @@
       "userSetupAllowed" : false
     } ]
   }, {
-    "id" : "98c460d2-c9e9-4dd9-b2be-f35addd7c064",
+    "id" : "a1bc4ae4-2659-4bde-a189-ed2569654e8d",
     "alias" : "Direct Grant - Conditional OTP",
     "description" : "Flow to determine if the OTP is required for the authentication",
     "providerId" : "basic-flow",
@@ -1436,7 +1416,7 @@
       "userSetupAllowed" : false
     } ]
   }, {
-    "id" : "5ebf80fc-7816-42f4-8c09-e585930d6221",
+    "id" : "32b95adf-48fa-453d-98be-a4680bd7b663",
     "alias" : "First broker login - Conditional OTP",
     "description" : "Flow to determine if the OTP is required for the authentication",
     "providerId" : "basic-flow",
@@ -1458,7 +1438,7 @@
       "userSetupAllowed" : false
     } ]
   }, {
-    "id" : "73bbf382-c5b4-4251-8ae2-640fd5716072",
+    "id" : "cc6da506-9dc0-4611-a2ba-f97c44470ad0",
     "alias" : "Handle Existing Account",
     "description" : "Handle what to do if there is existing account with same email/username like authenticated identity provider",
     "providerId" : "basic-flow",
@@ -1480,7 +1460,7 @@
       "userSetupAllowed" : false
     } ]
   }, {
-    "id" : "057b2155-fb54-4dd6-9071-a238ba7d74a7",
+    "id" : "8b7f07c4-bcf9-46e1-afaf-93fd125a42e5",
     "alias" : "Reset - Conditional OTP",
     "description" : "Flow to determine if the OTP should be reset or not. Set to REQUIRED to force.",
     "providerId" : "basic-flow",
@@ -1502,7 +1482,7 @@
       "userSetupAllowed" : false
     } ]
   }, {
-    "id" : "9c7e08c4-0c83-4546-a30c-43ed3e1c9fb0",
+    "id" : "f2b684a0-0abc-43d0-9fb2-fe9395adcab7",
     "alias" : "User creation or linking",
     "description" : "Flow for the existing/non-existing user alternatives",
     "providerId" : "basic-flow",
@@ -1525,7 +1505,7 @@
       "userSetupAllowed" : false
     } ]
   }, {
-    "id" : "3ea354f9-f1ce-4b3c-9d90-516d36480d28",
+    "id" : "cfceab8a-621b-426e-a87d-b2efb0e0a1b8",
     "alias" : "Verify Existing Account by Re-authentication",
     "description" : "Reauthentication of existing account",
     "providerId" : "basic-flow",
@@ -1547,7 +1527,7 @@
       "userSetupAllowed" : false
     } ]
   }, {
-    "id" : "084888e1-ccfd-4f12-87cc-d027f422f5c0",
+    "id" : "17a35dea-0549-4fbb-8766-c04b0ef5ead2",
     "alias" : "browser",
     "description" : "browser based authentication",
     "providerId" : "basic-flow",
@@ -1583,7 +1563,7 @@
       "userSetupAllowed" : false
     } ]
   }, {
-    "id" : "196f1a25-9615-4c59-b49d-8027b78635bf",
+    "id" : "6b9a0d19-cdd0-4b90-840f-898361007444",
     "alias" : "clients",
     "description" : "Base authentication for clients",
     "providerId" : "client-flow",
@@ -1619,7 +1599,7 @@
       "userSetupAllowed" : false
     } ]
   }, {
-    "id" : "55cce57f-a8c6-44f6-8ab8-2f08af25a121",
+    "id" : "e8bdcec7-338d-4446-9e1e-0e0dcc796b83",
     "alias" : "direct grant",
     "description" : "OpenID Connect Resource Owner Grant",
     "providerId" : "basic-flow",
@@ -1648,7 +1628,7 @@
       "userSetupAllowed" : false
     } ]
   }, {
-    "id" : "74cd1b75-b991-42f2-aab9-79e2df690fd8",
+    "id" : "dfc97434-b01e-40e0-90c0-4c698da9bdaf",
     "alias" : "docker auth",
     "description" : "Used by Docker clients to authenticate against the IDP",
     "providerId" : "basic-flow",
@@ -1663,7 +1643,7 @@
       "userSetupAllowed" : false
     } ]
   }, {
-    "id" : "50c6c64d-6e50-462d-b208-fedc25870430",
+    "id" : "d1bc6437-e891-49a4-baf0-6742db215ab7",
     "alias" : "first broker login",
     "description" : "Actions taken after first broker login with identity provider account, which is not yet linked to any Keycloak account",
     "providerId" : "basic-flow",
@@ -1686,7 +1666,7 @@
       "userSetupAllowed" : false
     } ]
   }, {
-    "id" : "8a3f7ecd-1875-4ceb-a22e-6d49afda4ac6",
+    "id" : "31d5516e-a198-4d01-a48c-c0e68500733d",
     "alias" : "forms",
     "description" : "Username, password, otp and other auth forms.",
     "providerId" : "basic-flow",
@@ -1708,7 +1688,7 @@
       "userSetupAllowed" : false
     } ]
   }, {
-    "id" : "ff257af6-7e31-4633-82e5-0a4c1700d2a9",
+    "id" : "dc0dcc7f-8528-47cf-8283-b318ed9638ea",
     "alias" : "http challenge",
     "description" : "An authentication flow based on challenge-response HTTP Authentication Schemes",
     "providerId" : "basic-flow",
@@ -1730,7 +1710,7 @@
       "userSetupAllowed" : false
     } ]
   }, {
-    "id" : "f543c1e9-1de9-44d4-a07e-712b64fc3af4",
+    "id" : "bbd28157-8942-4ac9-8067-ed8b59bf476b",
     "alias" : "registration",
     "description" : "registration flow",
     "providerId" : "basic-flow",
@@ -1746,7 +1726,7 @@
       "userSetupAllowed" : false
     } ]
   }, {
-    "id" : "b453b53b-7e96-42e1-b965-74821ffeb710",
+    "id" : "69edc775-74ca-43e0-aaba-102e349054c8",
     "alias" : "registration form",
     "description" : "registration form",
     "providerId" : "form-flow",
@@ -1782,7 +1762,7 @@
       "userSetupAllowed" : false
     } ]
   }, {
-    "id" : "1784ce89-0f1f-4471-9fae-b3d36452580e",
+    "id" : "96d4f6df-98bb-4131-9e92-9ac7fe9c19d6",
     "alias" : "reset credentials",
     "description" : "Reset credentials for a user if they forgot their password or something",
     "providerId" : "basic-flow",
@@ -1818,7 +1798,7 @@
       "userSetupAllowed" : false
     } ]
   }, {
-    "id" : "55b0c943-360c-40f3-90aa-a1cd74f68f07",
+    "id" : "ccb3aaf5-1d4a-4487-83b1-e4c63f0dabce",
     "alias" : "saml ecp",
     "description" : "SAML ECP Profile Authentication Flow",
     "providerId" : "basic-flow",
@@ -1834,13 +1814,13 @@
     } ]
   } ],
   "authenticatorConfig" : [ {
-    "id" : "a30a690f-f03a-4a8f-82c4-f7160a5c8ad7",
+    "id" : "f2caeab5-caae-43aa-9316-aa476a1658b7",
     "alias" : "create unique user config",
     "config" : {
       "require.password.update.after.registration" : "false"
     }
   }, {
-    "id" : "0aa44261-ef70-4ff0-afe6-f09e572d4045",
+    "id" : "1a4b4ad5-3b71-4fe4-8dcd-edcc9d02b282",
     "alias" : "review profile config",
     "config" : {
       "update.profile.on.first.login" : "missing"

--- a/kubernetes/charts/oasis-platform/templates/oasis_server.yaml
+++ b/kubernetes/charts/oasis-platform/templates/oasis_server.yaml
@@ -204,7 +204,7 @@ spec:
       {{- include "h.affinity" . | nindent 6 }}
       initContainers:
         {{- include "h.initTcpAvailabilityCheckBySecret" (list . .Values.databases.oasis_db.name .Values.databases.celery_db.name .Values.keycloak.name .Values.databases.broker.name) | nindent 8}}
-        - name: volume-mount-permissions
+        - name: set-mount-permissions
           image: busybox
           command: ["sh", "-c", "find /shared-fs -user root -exec chown 1000:1000 {} \\;"]
           volumeMounts:

--- a/kubernetes/charts/oasis-platform/templates/oasis_server.yaml
+++ b/kubernetes/charts/oasis-platform/templates/oasis_server.yaml
@@ -41,7 +41,7 @@ metadata:
 data:
   host: {{ .Values.oasisWebsocket.name }}
   port: "{{ .Values.oasisWebsocket.port }}"
----  
+---
 apiVersion: v1
 kind: Service
 metadata:
@@ -122,7 +122,7 @@ spec:
           ports:
             - containerPort: {{ .Values.oasisWebsocket.port }}
               name: {{ .Values.oasisWebsocket.name }}
-          command: [ "./asgi/run-asgi.sh" ]    
+          command: [ "./asgi/run-asgi.sh" ]
           volumeMounts:
             - name: shared-fs-persistent-storage
               mountPath: /shared-fs
@@ -204,6 +204,12 @@ spec:
       {{- include "h.affinity" . | nindent 6 }}
       initContainers:
         {{- include "h.initTcpAvailabilityCheckBySecret" (list . .Values.databases.oasis_db.name .Values.databases.celery_db.name .Values.keycloak.name .Values.databases.broker.name) | nindent 8}}
+        - name: volume-mount-permissions
+          image: busybox
+          command: ["sh", "-c", "find /shared-fs -user root -exec chown 1000:1000 {} \\;"]
+          volumeMounts:
+          - mountPath: /shared-fs
+            name: shared-fs-persistent-storage
       containers:
         - image: {{ .Values.images.oasis.platform.image }}:{{ .Values.images.oasis.platform.version }}
           name: {{ .Values.oasisServer.name }}

--- a/kubernetes/charts/oasis-platform/values.yaml
+++ b/kubernetes/charts/oasis-platform/values.yaml
@@ -9,17 +9,17 @@ images:
       imagePullPolicy: Never
     ui:
       image: coreoasis/oasisui_app
-      version: 1.11.4
+      version: 1.11.6
     worker_controller:
       image: coreoasis/worker_controller
       version: dev
       imagePullPolicy: Never
   postgres:
     image: postgres
-    version: 12.8-alpine3.14
+    version: 15.2-alpine3.17
   mysql:
     image: mysql
-    version: 8.0.26
+    version: 8.0.32
   keycloak:
     image: quay.io/keycloak/keycloak
     version: 20.0.3
@@ -28,10 +28,10 @@ images:
     version: 1.28
   redis:
     image: redis
-    version: 5.0.7
+    version: 7.0.8-alpine3.17
   rabbitmq:
     image: rabbitmq
-    version: 3.8-management-alpine
+    version: 3.11-management-alpine
 
 
 # Chart default values. Override by passing --set or -f to helm.

--- a/requirements-server.txt
+++ b/requirements-server.txt
@@ -24,21 +24,19 @@ attrs==22.2.0
     #   jsonschema
     #   service-identity
     #   twisted
-autobahn==23.1.1
+autobahn==23.1.2
     # via daphne
 automat==22.10.0
     # via twisted
 azure-core==1.26.3
-    # via
-    #   azure-storage-blob
-    #   msrest
-azure-storage-blob==12.14.1
+    # via azure-storage-blob
+azure-storage-blob==12.15.0
     # via django-storages
 billiard==3.6.4.0
     # via celery
-boto3==1.26.63
+boto3==1.26.79
     # via -r requirements-server.in
-botocore==1.29.63
+botocore==1.29.79
     # via
     #   boto3
     #   s3transfer
@@ -47,9 +45,7 @@ celery==5.2.7
     #   -r requirements-server.in
     #   django-celery-results
 certifi==2022.12.7
-    # via
-    #   msrest
-    #   requests
+    # via requests
 cffi==1.15.1
     # via cryptography
 chainmap==1.0.3
@@ -96,7 +92,7 @@ cryptography==39.0.1
     #   service-identity
 daphne==2.5.0
     # via channels
-django==3.2.17
+django==3.2.18
     # via
     #   channels
     #   django-debug-toolbar
@@ -111,7 +107,7 @@ django==3.2.17
     #   mozilla-django-oidc
 django-celery-results==2.4.0
     # via -r requirements-server.in
-django-cleanup==6.0.0
+django-cleanup==7.0.0
     # via -r requirements-server.in
 django-debug-toolbar==3.8.1
     # via -r requirements-server.in
@@ -133,13 +129,13 @@ djangorestframework-simplejwt==5.2.2
     # via -r requirements-server.in
 drf-nested-routers==0.93.4
     # via -r requirements-server.in
-drf-yasg==1.21.4
+drf-yasg==1.21.5
     # via -r requirements-server.in
 greenlet==2.0.2
     # via sqlalchemy
 gunicorn==20.1.0
     # via -r requirements-server.in
-hiredis==2.2.1
+hiredis==2.2.2
     # via aioredis
 httplib2==0.21.0
     # via pyrabbit
@@ -157,7 +153,7 @@ incremental==22.10.0
 inflection==0.5.1
     # via drf-yasg
 isodate==0.6.1
-    # via msrest
+    # via azure-storage-blob
 itypes==1.2.0
     # via coreapi
 jinja2==3.1.2
@@ -184,15 +180,11 @@ mozilla-django-oidc==3.0.0
     # via -r requirements-server.in
 msgpack==0.6.2
     # via channels-redis
-msrest==0.7.1
-    # via azure-storage-blob
-numpy==1.24.1
+numpy==1.24.2
     # via
     #   pandas
     #   pyarrow
-oauthlib==3.2.2
-    # via requests-oauthlib
-ods-tools==3.0.2
+ods-tools==3.0.3
     # via -r requirements-server.in
 packaging==23.0
     # via drf-yasg
@@ -202,7 +194,7 @@ pandas==1.5.3
     #   ods-tools
 pathlib2==2.3.7.post1
     # via -r requirements-server.in
-prompt-toolkit==3.0.36
+prompt-toolkit==3.0.37
     # via click-repl
 psycopg2-binary==2.9.5
     # via -r requirements-server.in
@@ -241,17 +233,13 @@ pytz==2022.7.1
     #   djangorestframework
     #   drf-yasg
     #   pandas
-redis==4.4.2
+redis==4.5.1
     # via -r requirements-server.in
 requests==2.28.2
     # via
     #   azure-core
     #   coreapi
     #   mozilla-django-oidc
-    #   msrest
-    #   requests-oauthlib
-requests-oauthlib==1.3.1
-    # via msrest
 ruamel-yaml==0.17.21
     # via drf-yasg
 ruamel-yaml-clib==0.2.7
@@ -279,9 +267,10 @@ twisted[tls]==22.10.0
     # via daphne
 txaio==23.1.1
     # via autobahn
-typing-extensions==4.4.0
+typing-extensions==4.5.0
     # via
     #   azure-core
+    #   azure-storage-blob
     #   twisted
 uritemplate==4.1.1
     # via
@@ -298,7 +287,7 @@ vine==5.0.0
     #   kombu
 wcwidth==0.2.6
     # via prompt-toolkit
-whitenoise==6.3.0
+whitenoise==6.4.0
     # via -r requirements-server.in
 zope-interface==5.5.2
     # via twisted

--- a/requirements-server.txt
+++ b/requirements-server.txt
@@ -86,7 +86,7 @@ coreschema==0.0.4
     # via
     #   coreapi
     #   drf-yasg
-cryptography==39.0.0
+cryptography==39.0.1
     # via
     #   autobahn
     #   azure-storage-blob

--- a/requirements-worker.txt
+++ b/requirements-worker.txt
@@ -21,8 +21,7 @@ azure-core==1.26.3
     # via
     #   -r requirements-worker.in
     #   azure-storage-blob
-    #   msrest
-azure-storage-blob==12.14.1
+azure-storage-blob==12.15.0
     # via -r requirements-worker.in
 bcrypt==4.0.1
     # via paramiko
@@ -32,9 +31,9 @@ billiard==3.6.4.0
     #   celery
 binaryornot==0.4.4
     # via cookiecutter
-boto3==1.26.63
+boto3==1.26.79
     # via -r requirements-worker.in
-botocore==1.29.63
+botocore==1.29.79
     # via
     #   boto3
     #   s3transfer
@@ -43,7 +42,6 @@ celery==5.2.7
 certifi==2022.12.7
     # via
     #   fiona
-    #   msrest
     #   pyproj
     #   requests
 cffi==1.15.1
@@ -94,11 +92,11 @@ exceptiongroup==1.1.0
     # via pytest
 fasteners==0.18
     # via -r requirements-worker.in
-fastparquet==2023.1.0
+fastparquet==2023.2.0
     # via oasislmf
 filelock==3.9.0
     # via -r requirements-worker.in
-fiona==1.9.0
+fiona==1.9.1
     # via geopandas
 forex-python==1.8
     # via oasislmf
@@ -113,7 +111,7 @@ idna==3.4
 iniconfig==2.0.0
     # via pytest
 isodate==0.6.1
-    # via msrest
+    # via azure-storage-blob
 jinja2==3.1.2
     # via
     #   cookiecutter
@@ -140,8 +138,6 @@ markupsafe==2.1.2
     # via jinja2
 msgpack==1.0.4
     # via oasislmf
-msrest==0.7.1
-    # via azure-storage-blob
 munch==2.5.0
     # via fiona
 natsort==8.2.0
@@ -161,11 +157,9 @@ numpy==1.22.4
     #   scikit-learn
     #   scipy
     #   shapely
-oasislmf[extra]==1.27.0
+oasislmf[extra]==1.27.1
     # via -r requirements-worker.in
-oauthlib==3.2.2
-    # via requests-oauthlib
-ods-tools==3.0.2
+ods-tools==3.0.3
     # via oasislmf
 packaging==23.0
     # via
@@ -185,7 +179,7 @@ pathlib2==2.3.7.post1
     # via -r requirements-worker.in
 pluggy==1.0.0
     # via pytest
-prompt-toolkit==3.0.36
+prompt-toolkit==3.0.37
     # via click-repl
 psycopg2-binary==2.9.5
     # via -r requirements-worker.in
@@ -216,7 +210,7 @@ python-dateutil==2.8.2
     #   arrow
     #   botocore
     #   pandas
-python-slugify==8.0.0
+python-slugify==8.0.1
     # via cookiecutter
 pytz==2022.7.1
     # via
@@ -234,14 +228,10 @@ requests==2.28.2
     #   azure-core
     #   cookiecutter
     #   forex-python
-    #   msrest
     #   oasislmf
     #   pycap
     #   redi
-    #   requests-oauthlib
     #   requests-toolbelt
-requests-oauthlib==1.3.1
-    # via msrest
 requests-toolbelt==0.10.1
     # via oasislmf
 rtree==1.0.1
@@ -250,7 +240,7 @@ s3transfer==0.6.0
     # via boto3
 scikit-learn==1.2.1
     # via oasislmf
-scipy==1.10.0
+scipy==1.10.1
     # via
     #   oasislmf
     #   scikit-learn
@@ -264,7 +254,7 @@ shapely==2.0.1
     #   oasislmf
 shutilwhich==1.1.0
     # via oasislmf
-simplejson==3.18.1
+simplejson==3.18.3
     # via forex-python
 six==1.16.0
     # via
@@ -291,9 +281,10 @@ tomli==2.0.1
     #   setuptools-scm
 tqdm==4.64.1
     # via oasislmf
-typing-extensions==4.4.0
+typing-extensions==4.5.0
     # via
     #   azure-core
+    #   azure-storage-blob
     #   setuptools-scm
 urllib3==1.26.14
     # via

--- a/requirements-worker.txt
+++ b/requirements-worker.txt
@@ -84,7 +84,7 @@ cookiecutter==2.1.1
     # via oasislmf
 cramjam==2.6.2
     # via fastparquet
-cryptography==39.0.0
+cryptography==39.0.1
     # via
     #   azure-storage-blob
     #   paramiko

--- a/requirements.txt
+++ b/requirements.txt
@@ -151,7 +151,7 @@ coverage[toml]==7.1.0
     #   pytest-cov
 cramjam==2.6.2
     # via fastparquet
-cryptography==39.0.0
+cryptography==39.0.1
     # via
     #   autobahn
     #   azure-storage-blob

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,8 +43,7 @@ azure-core==1.26.3
     # via
     #   -r ./requirements-worker.in
     #   azure-storage-blob
-    #   msrest
-azure-storage-blob==12.14.1
+azure-storage-blob==12.15.0
     # via
     #   -r ./requirements-worker.in
     #   django-storages
@@ -84,7 +83,6 @@ celery==5.2.7
 certifi==2022.12.7
     # via
     #   fiona
-    #   msrest
     #   pyproj
     #   requests
 cffi==1.15.1
@@ -145,7 +143,7 @@ coreschema==0.0.4
     # via
     #   coreapi
     #   drf-yasg
-coverage[toml]==7.1.0
+coverage[toml]==7.2.1
     # via
     #   -r requirements.in
     #   pytest-cov
@@ -168,7 +166,7 @@ decorator==5.1.1
     #   ipython
 distlib==0.3.6
     # via virtualenv
-django==3.2.17
+django==3.2.18
     # via
     #   channels
     #   django-debug-toolbar
@@ -212,7 +210,7 @@ docopt==0.6.2
     # via redi
 drf-nested-routers==0.93.4
     # via -r ./requirements-server.in
-drf-yasg==1.21.4
+drf-yasg==1.21.5
     # via -r ./requirements-server.in
 exceptiongroup==1.1.0
     # via
@@ -273,7 +271,7 @@ ipdb==0.13.11
 ipython==8.9.0
     # via ipdb
 isodate==0.6.1
-    # via msrest
+    # via azure-storage-blob
 itypes==1.2.0
     # via coreapi
 jedi==0.18.2
@@ -326,8 +324,6 @@ msgpack==0.6.2
     # via
     #   channels-redis
     #   oasislmf
-msrest==0.7.1
-    # via azure-storage-blob
 munch==2.5.0
     # via fiona
 natsort==8.2.0
@@ -347,11 +343,9 @@ numpy==1.22.4
     #   scikit-learn
     #   scipy
     #   shapely
-oasislmf[extra]==1.27.0
+oasislmf[extra]==1.27.1
     # via -r ./requirements-worker.in
-oauthlib==3.2.2
-    # via requests-oauthlib
-ods-tools==3.0.2
+ods-tools==3.0.3
     # via
     #   -r ./requirements-server.in
     #   oasislmf
@@ -499,14 +493,10 @@ requests==2.28.2
     #   coreapi
     #   forex-python
     #   mozilla-django-oidc
-    #   msrest
     #   oasislmf
     #   pycap
     #   redi
-    #   requests-oauthlib
     #   requests-toolbelt
-requests-oauthlib==1.3.1
-    # via msrest
 requests-toolbelt==0.10.1
     # via oasislmf
 rtree==1.0.1
@@ -519,7 +509,7 @@ s3transfer==0.6.0
     # via boto3
 scikit-learn==1.2.1
     # via oasislmf
-scipy==1.10.0
+scipy==1.10.1
     # via
     #   oasislmf
     #   scikit-learn
@@ -535,7 +525,7 @@ shapely==2.0.1
     #   oasislmf
 shutilwhich==1.1.0
     # via oasislmf
-simplejson==3.18.1
+simplejson==3.18.3
     # via forex-python
 six==1.16.0
     # via
@@ -596,6 +586,7 @@ txaio==23.1.1
 typing-extensions==4.4.0
     # via
     #   azure-core
+    #   azure-storage-blob
     #   setuptools-scm
     #   twisted
 uritemplate==4.1.1
@@ -611,7 +602,7 @@ vine==5.0.0
     #   amqp
     #   celery
     #   kombu
-virtualenv==20.17.1
+virtualenv==20.19.0
     # via tox
 waitress==2.1.2
     # via webtest

--- a/scripts/update-packages.sh
+++ b/scripts/update-packages.sh
@@ -1,7 +1,8 @@
 pkg_list=(
-    'ods-tools==3.*'
+    'ods-tools==2.*'
     'oasislmf==1.27.*'
     joblib
+    cryptography
     oauthlib
     parso
     certifi

--- a/scripts/update-packages.sh
+++ b/scripts/update-packages.sh
@@ -1,5 +1,5 @@
 pkg_list=(
-    'ods-tools==2.*'
+    'ods-tools==3.*'
     'oasislmf==1.27.*'
     joblib
     cryptography

--- a/src/server/oasisapi/auth/serializers.py
+++ b/src/server/oasisapi/auth/serializers.py
@@ -12,6 +12,7 @@ from .. import settings
 from ..oidc.keycloak_auth import keycloak_create_connection
 from urllib3.util import connection
 
+
 class SimpleTokenObtainPairSerializer(BaseTokenObtainPairSerializer):
     def __init__(self, *args, **kwargs):
         super(SimpleTokenObtainPairSerializer, self).__init__(*args, **kwargs)

--- a/src/server/oasisapi/auth/serializers.py
+++ b/src/server/oasisapi/auth/serializers.py
@@ -9,6 +9,8 @@ from rest_framework_simplejwt.serializers import TokenRefreshSerializer as BaseT
 
 from .. import settings
 
+from ..oidc.keycloak_auth import keycloak_create_connection
+from urllib3.util import connection
 
 class SimpleTokenObtainPairSerializer(BaseTokenObtainPairSerializer):
     def __init__(self, *args, **kwargs):
@@ -61,6 +63,7 @@ class OIDCTokenObtainPairSerializer(TokenObtainSerializer):
     """
     Token serializer to authenticate and obtain a access token from Keyloak
     """
+    connection.create_connection = keycloak_create_connection
 
     def __init__(self, *args, **kwargs):
         super(OIDCTokenObtainPairSerializer, self).__init__(*args, **kwargs)
@@ -98,6 +101,7 @@ class OIDCTokenRefreshSerializer(serializers.Serializer):
     """
     Token serializer to obtain a new access token from Keycloak
     """
+    connection.create_connection = keycloak_create_connection
 
     def validate(self, attrs):
         if 'HTTP_AUTHORIZATION' not in self.context['request'].META.keys():


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue after submitting a Pull Request. -->

<!--start_release_notes-->
### Update external image versions 
 * Fixed token authentication and realm import for keycloak 20.0.3 
 * Updated external images to latest versions (RabbitMQ, Postgre, Redis) 
 * Fixed Non-root file mount permissions, Added `initContainer` to the Oasis-Server which allows access for default user/group `1000:1000`
 * Updated Python Packages 
 * Fixed excessive CVE reporting from scans  
<!--end_release_notes-->

- [x] Update all images
- [x] Update CI CVE reporting   
- [x] Fix keycloak token issuing 
- [x] Test workaround for mount permissions 
- [x] Update CI to test newer external images   (docker compose update) 
- [x] Test Azure deployment 
