### PR TITLE
Fixes for merging of distributed input files

### DIFF
--- a/src/model_execution_worker/distributed_tasks.py
+++ b/src/model_execution_worker/distributed_tasks.py
@@ -722,7 +722,7 @@ def collect_keys(
             df = df[~df.index.duplicated(keep='first')]
         pd_write_func = getattr(df, f"to_{file_type}")
         # Only write index for parquet files to avoid useless extra column for csv files.
-        pd_write_func(output_file, index=file_type=='parquet')
+        pd_write_func(output_file, index=file_type == 'parquet')
 
     def take_first(paths, output_file):
         first_path = paths[0]

--- a/src/model_execution_worker/distributed_tasks.py
+++ b/src/model_execution_worker/distributed_tasks.py
@@ -751,9 +751,7 @@ def collect_keys(
 
                 if file_name in ['events', 'occurrence', 'ensemble_mapping']:
                     take_first(file_chunks, file_merged)
-                elif file_type == 'csv':
-                    merge_dataframes(file_chunks, file_merged, file_type)
-                elif file_type == 'parquet':
+                elif file_type in ['csv', 'parquet']:
                     merge_dataframes(file_chunks, file_merged, file_type)
                 else:
                     logging.info(f'No merge method for file: "{file}" --skipped--')


### PR DESCRIPTION

<!--start_release_notes-->
### Improve merging of distributed input files
For files named `events.*`, `occurrence.*` or `ensemble_mapping.*`, take the first file (i.e. assume they are all identical and no merging is required).

For all other csv files, concatenate them.

For all other parquet files, concatenate them respecting indices (i.e. retain the existing indices in the merged output and remove duplicates based on these indices).
<!--end_release_notes-->
