### PR TITLE
Traefik example for OasisPlatform in docker-compose

### DIFF
--- a/compose/traefik.docker-compose.yml
+++ b/compose/traefik.docker-compose.yml
@@ -1,39 +1,39 @@
 version: "3"
 services:
   server:
-    restart: always
-    image: coreoasis/api_server:latest
-    ports:
-      - 8000:8000
-    links:
-      - server-db
-      - celery-db
-      - rabbit
-    environment:
-      - OASIS_ADMIN_USER=admin
-      - OASIS_ADMIN_PASS=password
-      - OASIS_DEBUG=1
-      - OASIS_RABBIT_HOST=rabbit
-      - OASIS_RABBIT_PORT=5672
-      - OASIS_RABBIT_USER=rabbit
-      - OASIS_RABBIT_PASS=rabbit
-      - OASIS_SERVER_DB_HOST=server-db
-      - OASIS_SERVER_DB_PASS=oasis
-      - OASIS_SERVER_DB_USER=oasis
-      - OASIS_SERVER_DB_NAME=oasis
-      - OASIS_SERVER_DB_PORT=3306
-      - OASIS_CELERY_DB_ENGINE=db+mysql+pymysql
-      - OASIS_CELERY_DB_HOST=celery-db
-      - OASIS_CELERY_DB_PASS=password
-      - OASIS_CELERY_DB_USER=celery
-      - OASIS_CELERY_DB_NAME=celery
-      - OASIS_CELERY_DB_PORT=3306
-      - STARTUP_RUN_MIGRATIONS=true
-    volumes:
-      - ${OASIS_MEDIA_ROOT:-./docker-shared-fs}:/shared-fs:rw
-    labels:
-      - "traefik.enable=true"
-      # /*--Production: replace "admin.localhost" with a vaild domain that is pointed at your server.--*/
+   restart: always
+   image: coreoasis/api_server:latest
+   ports:
+     - 8000:8000
+   links:
+     - server-db
+     - celery-db
+     - rabbit
+   environment:
+     - OASIS_ADMIN_USER=admin
+     - OASIS_ADMIN_PASS=password
+     - OASIS_DEBUG=1
+     - OASIS_RABBIT_HOST=rabbit
+     - OASIS_RABBIT_PORT=5672
+     - OASIS_RABBIT_USER=rabbit
+     - OASIS_RABBIT_PASS=rabbit
+     - OASIS_SERVER_DB_HOST=server-db
+     - OASIS_SERVER_DB_PASS=oasis
+     - OASIS_SERVER_DB_USER=oasis
+     - OASIS_SERVER_DB_NAME=oasis
+     - OASIS_SERVER_DB_PORT=3306
+     - OASIS_CELERY_DB_ENGINE=db+mysql+pymysql
+     - OASIS_CELERY_DB_HOST=celery-db
+     - OASIS_CELERY_DB_PASS=password
+     - OASIS_CELERY_DB_USER=celery
+     - OASIS_CELERY_DB_NAME=celery
+     - OASIS_CELERY_DB_PORT=3306
+     - STARTUP_RUN_MIGRATIONS=true
+   volumes:
+     - ${OASIS_MEDIA_ROOT:-./docker-shared-fs}:/shared-fs:rw
+   labels:
+     - "traefik.enable=true"
+     # /*--Production: replace "admin.localhost" with a vaild domain that is pointed at your server.--*/
       - "traefik.http.routers.django_admin.rule=Host(`django.localhost`)"
       - "traefik.http.routers.django_admin.entrypoints=websecure"
       - "traefik.http.routers.django_admin.tls.certresolver=letsencrypt"
@@ -45,64 +45,55 @@ services:
       #- "traefik.http.services.django_admin.loadbalancer.sticky.cookie.httponly=true"
 
   worker-monitor:
-    restart: always
-    image: coreoasis/api_server:latest
-    command:
-      [
-        wait-for-server,
-        "server:8000",
-        celery,
-        worker,
-        -A,
-        src.server.oasisapi,
-        --loglevel=INFO,
-      ]
-    links:
-      - server-db
-      - celery-db
-      - rabbit
-    environment:
-      - OASIS_DEBUG=1
-      - OASIS_RABBIT_HOST=rabbit
-      - OASIS_RABBIT_PORT=5672
-      - OASIS_RABBIT_USER=rabbit
-      - OASIS_RABBIT_PASS=rabbit
-      - OASIS_SERVER_DB_HOST=server-db
-      - OASIS_SERVER_DB_PASS=oasis
-      - OASIS_SERVER_DB_USER=oasis
-      - OASIS_SERVER_DB_NAME=oasis
-      - OASIS_SERVER_DB_PORT=3306
-      - OASIS_CELERY_DB_ENGINE=db+mysql+pymysql
-      - OASIS_CELERY_DB_HOST=celery-db
-      - OASIS_CELERY_DB_PASS=password
-      - OASIS_CELERY_DB_USER=celery
-      - OASIS_CELERY_DB_NAME=celery
-      - OASIS_CELERY_DB_PORT=3306
-    volumes:
-      - ${OASIS_MEDIA_ROOT:-./docker-shared-fs}:/shared-fs:rw
+   restart: always
+   image: coreoasis/api_server:latest
+   command: [wait-for-server, 'server:8000', celery, -A, src.server.oasisapi, worker, --loglevel=INFO]
+   links:
+     - server-db
+     - celery-db
+     - rabbit
+   environment:
+     - OASIS_DEBUG=1
+     - OASIS_RABBIT_HOST=rabbit
+     - OASIS_RABBIT_PORT=5672
+     - OASIS_RABBIT_USER=rabbit
+     - OASIS_RABBIT_PASS=rabbit
+     - OASIS_SERVER_DB_HOST=server-db
+     - OASIS_SERVER_DB_PASS=oasis
+     - OASIS_SERVER_DB_USER=oasis
+     - OASIS_SERVER_DB_NAME=oasis
+     - OASIS_SERVER_DB_PORT=3306
+     - OASIS_CELERY_DB_ENGINE=db+mysql+pymysql
+     - OASIS_CELERY_DB_HOST=celery-db
+     - OASIS_CELERY_DB_PASS=password
+     - OASIS_CELERY_DB_USER=celery
+     - OASIS_CELERY_DB_NAME=celery
+     - OASIS_CELERY_DB_PORT=3306
+   volumes:
+     - ${OASIS_MEDIA_ROOT:-./docker-shared-fs}:/shared-fs:rw
   worker:
     restart: always
     image: coreoasis/model_worker:latest
     links:
-      - celery-db
-      - rabbit:myrabbit
+     - celery-db
+     - rabbit:myrabbit
     environment:
-      - OASIS_MODEL_SUPPLIER_ID=OasisLMF
-      - OASIS_MODEL_ID=PiWind
-      - OASIS_MODEL_VERSION_ID=1
-      - OASIS_RABBIT_HOST=rabbit
-      - OASIS_RABBIT_PORT=5672
-      - OASIS_RABBIT_USER=rabbit
-      - OASIS_RABBIT_PASS=rabbit
-      - OASIS_CELERY_DB_ENGINE=db+mysql+pymysql
-      - OASIS_CELERY_DB_HOST=celery-db
-      - OASIS_CELERY_DB_PASS=password
-      - OASIS_CELERY_DB_USER=celery
-      - OASIS_CELERY_DB_NAME=celery
-      - OASIS_CELERY_DB_PORT=3306
+     - OASIS_MODEL_SUPPLIER_ID=OasisLMF
+     - OASIS_MODEL_ID=PiWind
+     - OASIS_MODEL_VERSION_ID=1
+     - OASIS_RABBIT_HOST=rabbit
+     - OASIS_RABBIT_PORT=5672
+     - OASIS_RABBIT_USER=rabbit
+     - OASIS_RABBIT_PASS=rabbit
+     - OASIS_CELERY_DB_ENGINE=db+mysql+pymysql
+     - OASIS_CELERY_DB_HOST=celery-db
+     - OASIS_CELERY_DB_PASS=password
+     - OASIS_CELERY_DB_USER=celery
+     - OASIS_CELERY_DB_NAME=celery
+     - OASIS_CELERY_DB_PORT=3306
     volumes:
-      - ${OASIS_MODEL_DATA_DIR:-./data/static}:/var/oasis/:rw
-      - ${OASIS_MEDIA_ROOT:-./docker-shared-fs}:/shared-fs:rw
+     - ${OASIS_MODEL_DATA_DIR:-./data/static}:/var/oasis/:rw
+     - ${OASIS_MEDIA_ROOT:-./docker-shared-fs}:/shared-fs:rw
   server-db:
     restart: always
     image: mysql:8.0
@@ -148,8 +139,8 @@ services:
       - --port=5555
       - --broker_api=http://rabbit:rabbit@rabbit:15672/api/
     links:
-      - celery-db
-      - rabbit
+     - celery-db
+     - rabbit
   user-interface:
     image: coreoasis/oasisui_app:latest
     environment:
@@ -190,9 +181,9 @@ services:
     volumes:
       - /etc/localtime:/etc/localtime:ro
       - /var/run/docker.sock:/var/run/docker.sock:ro
-      - ./traefik/config/traefik.yml:/etc/traefik/traefik.yml:ro
-      - ./traefik/config/dynamic.yml:/etc/traefik/dynamic.yml:ro
-      - ./traefik/letsencrypt:/letsencrypt
+      #- ./traefik/config/traefik.yml:/etc/traefik/traefik.yml:ro
+      #- ./traefik/config/dynamic.yml:/etc/traefik/dynamic.yml:ro
+      #- ./traefik/letsencrypt:/letsencrypt
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.traefik-secure.entrypoints=websecure"

--- a/compose/traefik.docker-compose.yml
+++ b/compose/traefik.docker-compose.yml
@@ -181,8 +181,8 @@ services:
     volumes:
       - /etc/localtime:/etc/localtime:ro
       - /var/run/docker.sock:/var/run/docker.sock:ro
-      #- ./traefik/config/traefik.yml:/etc/traefik/traefik.yml:ro
-      #- ./traefik/config/dynamic.yml:/etc/traefik/dynamic.yml:ro
+      - ./traefik/config/traefik.yml:/etc/traefik/traefik.yml:ro
+      - ./traefik/config/dynamic.yml:/etc/traefik/dynamic.yml:ro
       #- ./traefik/letsencrypt:/letsencrypt
     labels:
       - "traefik.enable=true"

--- a/compose/traefik.docker-compose.yml
+++ b/compose/traefik.docker-compose.yml
@@ -1,0 +1,202 @@
+version: "3"
+services:
+  server:
+    restart: always
+    image: coreoasis/api_server:latest
+    ports:
+      - 8000:8000
+    links:
+      - server-db
+      - celery-db
+      - rabbit
+    environment:
+      - OASIS_ADMIN_USER=admin
+      - OASIS_ADMIN_PASS=password
+      - OASIS_DEBUG=1
+      - OASIS_RABBIT_HOST=rabbit
+      - OASIS_RABBIT_PORT=5672
+      - OASIS_RABBIT_USER=rabbit
+      - OASIS_RABBIT_PASS=rabbit
+      - OASIS_SERVER_DB_HOST=server-db
+      - OASIS_SERVER_DB_PASS=oasis
+      - OASIS_SERVER_DB_USER=oasis
+      - OASIS_SERVER_DB_NAME=oasis
+      - OASIS_SERVER_DB_PORT=3306
+      - OASIS_CELERY_DB_ENGINE=db+mysql+pymysql
+      - OASIS_CELERY_DB_HOST=celery-db
+      - OASIS_CELERY_DB_PASS=password
+      - OASIS_CELERY_DB_USER=celery
+      - OASIS_CELERY_DB_NAME=celery
+      - OASIS_CELERY_DB_PORT=3306
+      - STARTUP_RUN_MIGRATIONS=true
+    volumes:
+      - ${OASIS_MEDIA_ROOT:-./docker-shared-fs}:/shared-fs:rw
+    labels:
+      - "traefik.enable=true"
+      # /*--Production: replace "admin.localhost" with a vaild domain that is pointed at your server.--*/
+      - "traefik.http.routers.django_admin.rule=Host(`django.localhost`)"
+      - "traefik.http.routers.django_admin.entrypoints=websecure"
+      - "traefik.http.routers.django_admin.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.django_admin.service=django_admin"
+      - "traefik.http.services.django_admin.loadbalancer.sticky.cookie=true"
+      - "traefik.http.services.django_admin.loadBalancer.sticky.cookie.name=django_admin"
+      # /*--Uncomment them base on your needs--*/
+      #- "traefik.http.services.django_admin.loadbalancer.sticky.cookie.secure=true"
+      #- "traefik.http.services.django_admin.loadbalancer.sticky.cookie.httponly=true"
+
+  worker-monitor:
+    restart: always
+    image: coreoasis/api_server:latest
+    command:
+      [
+        wait-for-server,
+        "server:8000",
+        celery,
+        worker,
+        -A,
+        src.server.oasisapi,
+        --loglevel=INFO,
+      ]
+    links:
+      - server-db
+      - celery-db
+      - rabbit
+    environment:
+      - OASIS_DEBUG=1
+      - OASIS_RABBIT_HOST=rabbit
+      - OASIS_RABBIT_PORT=5672
+      - OASIS_RABBIT_USER=rabbit
+      - OASIS_RABBIT_PASS=rabbit
+      - OASIS_SERVER_DB_HOST=server-db
+      - OASIS_SERVER_DB_PASS=oasis
+      - OASIS_SERVER_DB_USER=oasis
+      - OASIS_SERVER_DB_NAME=oasis
+      - OASIS_SERVER_DB_PORT=3306
+      - OASIS_CELERY_DB_ENGINE=db+mysql+pymysql
+      - OASIS_CELERY_DB_HOST=celery-db
+      - OASIS_CELERY_DB_PASS=password
+      - OASIS_CELERY_DB_USER=celery
+      - OASIS_CELERY_DB_NAME=celery
+      - OASIS_CELERY_DB_PORT=3306
+    volumes:
+      - ${OASIS_MEDIA_ROOT:-./docker-shared-fs}:/shared-fs:rw
+  worker:
+    restart: always
+    image: coreoasis/model_worker:latest
+    links:
+      - celery-db
+      - rabbit:myrabbit
+    environment:
+      - OASIS_MODEL_SUPPLIER_ID=OasisLMF
+      - OASIS_MODEL_ID=PiWind
+      - OASIS_MODEL_VERSION_ID=1
+      - OASIS_RABBIT_HOST=rabbit
+      - OASIS_RABBIT_PORT=5672
+      - OASIS_RABBIT_USER=rabbit
+      - OASIS_RABBIT_PASS=rabbit
+      - OASIS_CELERY_DB_ENGINE=db+mysql+pymysql
+      - OASIS_CELERY_DB_HOST=celery-db
+      - OASIS_CELERY_DB_PASS=password
+      - OASIS_CELERY_DB_USER=celery
+      - OASIS_CELERY_DB_NAME=celery
+      - OASIS_CELERY_DB_PORT=3306
+    volumes:
+      - ${OASIS_MODEL_DATA_DIR:-./data/static}:/var/oasis/:rw
+      - ${OASIS_MEDIA_ROOT:-./docker-shared-fs}:/shared-fs:rw
+  server-db:
+    restart: always
+    image: mysql:8.0
+    command:
+      - --default-authentication-plugin=mysql_native_password
+    environment:
+      - MYSQL_ROOT_PASSWORD=password
+      - MYSQL_USER=oasis
+      - MYSQL_PASSWORD=oasis
+      - MYSQL_DATABASE=oasis
+    volumes:
+      - ${OASIS_DOCKER_DB_DATA_DIR:-./db-data}/server:/var/lib/mysql/:rw
+  celery-db:
+    restart: always
+    image: mysql
+    command:
+      - --default-authentication-plugin=mysql_native_password
+    environment:
+      - MYSQL_ROOT_PASSWORD=password
+      - MYSQL_USER=celery
+      - MYSQL_PASSWORD=password
+      - MYSQL_DATABASE=celery
+    volumes:
+      - ${OASIS_DOCKER_DB_DATA_DIR:-./db-data}/celery:/var/lib/mysql/:rw
+  rabbit:
+    restart: always
+    image: rabbitmq:3-management
+    environment:
+      - RABBITMQ_DEFAULT_USER=rabbit
+      - RABBITMQ_DEFAULT_PASS=rabbit
+    ports:
+      - 5672:5672
+      - 15672:15672
+  flower:
+    restart: always
+    image: iserko/docker-celery-flower
+    ports:
+      - 5555:5555
+    environment:
+      - CELERY_BROKER_URL=amqp://rabbit:rabbit@rabbit:5672
+    entrypoint:
+      - flower
+      - --port=5555
+      - --broker_api=http://rabbit:rabbit@rabbit:15672/api/
+    links:
+      - celery-db
+      - rabbit
+  user-interface:
+    image: coreoasis/oasisui_app:latest
+    environment:
+      - API_IP=server
+      - API_PORT=8000
+      - API_VERSION=v1
+      - API_SHARE_FILEPATH=./downloads
+      - OASIS_ENVIRONMENT=oasis_localhost
+    ports:
+      - 8080:3838
+    labels:
+      - "traefik.enable=true"
+      # /*--Production: replace "app.localhost" with a vaild domain that is pointed at your server--*/
+      - "traefik.http.routers.user_interface.rule=Host(`app.localhost`)"
+      - "traefik.http.routers.user_interface.entrypoints=websecure"
+      - "traefik.http.routers.user_interface.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.user_interface.service=user_interface"
+      - "traefik.http.services.user_interface.loadbalancer.sticky.cookie=true"
+      - "traefik.http.services.user_interface.loadBalancer.sticky.cookie.name=user_interface"
+      # /*--Uncomment them base on your needs--*/
+      #- "traefik.http.services.user_interface.loadbalancer.sticky.cookie.secure=true"
+      #- "traefik.http.services.user_interface.loadbalancer.sticky.cookie.httponly=true"
+      #- "traefik.http.middlewares.user_interface.ratelimit.average=5"
+      # /*--Production: replace "app.localhost" with the doamin that you used as Host--*/
+      - "traefik.http.services.user_interface.loadbalancer.healthcheck.hostname=app.localhost"
+      - "traefik.http.services.user_interface.loadbalancer.healthcheck.interval=30s"
+      - "traefik.http.services.user_interface.loadbalancer.healthcheck.timeout=10s"
+
+  traefik:
+    image: traefik:v2.9
+    container_name: traefik
+    restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    ports:
+      - 80:80
+      - 443:443
+    volumes:
+      - /etc/localtime:/etc/localtime:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ./traefik/config/traefik.yml:/etc/traefik/traefik.yml:ro
+      - ./traefik/config/dynamic.yml:/etc/traefik/dynamic.yml:ro
+      - ./traefik/letsencrypt:/letsencrypt
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.traefik-secure.entrypoints=websecure"
+      # /*--Production: replace "traefik.localhost" with a vaild domain that is pointed at your server--*/
+      - "traefik.http.routers.traefik-secure.rule=Host(`traefik.localhost`)"
+      - "traefik.http.routers.traefik-secure.middlewares=user-auth@file"
+      - "traefik.http.routers.traefik-secure.service=api@internal"

--- a/compose/traefik/config/dynamic.yml
+++ b/compose/traefik/config/dynamic.yml
@@ -1,0 +1,27 @@
+http:
+  middlewares:
+    secureHeaders:
+      headers:
+        sslRedirect: true
+        forceSTSHeader: true
+        stsIncludeSubdomains: true
+        stsPreload: true
+        stsSeconds: 31536000
+
+    user-auth:
+      basicAuth:
+        # use tools like apache2-utils and generate the hash
+        users:
+          - "admin:$apr1$Sqa1eyFb$T5FA2YGQDLsKid4Xj6rGB0"
+
+tls:
+  options:
+    default:
+      cipherSuites:
+        - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+        - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+        - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+        - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+        - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
+        - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305
+      minVersion: VersionTLS12

--- a/compose/traefik/config/traefik.yml
+++ b/compose/traefik/config/traefik.yml
@@ -1,0 +1,42 @@
+api:
+  dashboard: true
+
+serversTransport:
+  maxIdleConnsPerHost: 100
+  forwardingTimeouts:
+    dialTimeout: 300s
+    idleConnTimeout: 5s
+
+entryPoints:
+  web:
+    address: :80
+    http:
+      redirections:
+        entryPoint:
+          to: websecure
+
+  websecure:
+    address: :443
+    http:
+      middlewares:
+        - secureHeaders@file
+      tls:
+        certResolver: letsencrypt
+
+providers:
+  docker:
+    endpoint: "unix:///var/run/docker.sock"
+    exposedByDefault: false
+  file:
+    filename: dynamic.yml
+    directory: "/etc/traefik/"
+
+certificatesResolvers:
+  letsencrypt:
+    acme:
+      # use your own vaild email address here
+      email: ssl@firora.com
+      storage: /letsencrypt/acme.json
+      keyType: EC384
+      httpChallenge:
+        entryPoint: web


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue after submitting a Pull Request. -->

<!--start_release_notes-->
### Traefik example using docker-compose 
An example docker-compose file using [Traefik](https://doc.traefik.io/traefik/providers/docker/) as a reverse proxy for OasisUI.  
<!--end_release_notes-->
