### PR TITLE
Clear user-data before tar of generated data

### DIFF
--- a/src/model_execution_worker/distributed_tasks.py
+++ b/src/model_execution_worker/distributed_tasks.py
@@ -780,6 +780,11 @@ def write_input_files(self, params, run_data_uuid=None, analysis_id=None, initia
     params['oasis_files_dir'] = params['target_dir']
     OasisManager().generate_files(**params)
 
+    # clear out user-data,
+    # these files should not be sorted in the generated inputs tar
+    if params['user_data_dir'] is not None:
+        shutil.rmtree(params['user_data_dir'])
+
     return {
         'lookup_error_location': filestore.put(os.path.join(params['target_dir'], 'keys-errors.csv')),
         'lookup_success_location': filestore.put(os.path.join(params['target_dir'], 'gul_summary_map.csv')),


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue after submitting a Pull Request. -->

<!--start_release_notes-->
### Bug Fix for user-data 
The generated inputs tar has a copy of the symlink set (or files) loaded into the input generation directory. 
This creates two issues: 
1. There are now two sets user-data files in the loss calc run folder 
2. The unexpected set of symlinks trips up oasislmf's execution causing an loss analysis to fail with  
```
oasislmf.utils.exceptions.OasisException: Error preparing the 'run' directory: [Errno 21] Is a directory: '/tmp/run/analysis-3_losses-1987ce8eb5a74152bc3ed58b82584850/input-data/user-data'
```

<!--end_release_notes-->
