### PR TITLE
Plat 2.1.1 fixes

### DIFF
--- a/docker/Dockerfile.mvn-build
+++ b/docker/Dockerfile.mvn-build
@@ -1,4 +1,4 @@
-FROM maven:latest
+FROM maven:3.6-openjdk-17
 
 ARG DOCKER_USER=build
 RUN addgroup $DOCKER_USER && useradd -m -g $DOCKER_USER $DOCKER_USER

--- a/docker/Dockerfile.mvn-build
+++ b/docker/Dockerfile.mvn-build
@@ -1,10 +1,6 @@
 FROM maven:3.6-openjdk-17
 
-ARG DOCKER_USER=build
-RUN addgroup $DOCKER_USER && useradd -m -g $DOCKER_USER $DOCKER_USER
-USER $DOCKER_USER
 WORKDIR /home/build
-
 COPY ./docker/entrypoint_mvn-build.sh /usr/local/bin/mvm-build.sh
 COPY ./docker/pom.xml /tmp/
 ENTRYPOINT ["/bin/bash", "-c", "mvm-build.sh \"$@\"", "--"]

--- a/kubernetes/charts/oasis-models/templates/workers.yaml
+++ b/kubernetes/charts/oasis-models/templates/workers.yaml
@@ -50,8 +50,9 @@ spec:
             exec:
               command: ["celery", "-A", "src.model_execution_worker.distributed_tasks", "inspect", "ping"]
             initialDelaySeconds: 30
-            periodSeconds: 120
+            periodSeconds: 60
             timeoutSeconds: 60
+            failureThreshold: 15
           volumeMounts:
             - name: shared-fs-persistent-storage
               mountPath: /shared-fs

--- a/kubernetes/charts/oasis-models/templates/workers.yaml
+++ b/kubernetes/charts/oasis-models/templates/workers.yaml
@@ -50,8 +50,8 @@ spec:
             exec:
               command: ["celery", "-A", "src.model_execution_worker.distributed_tasks", "inspect", "ping"]
             initialDelaySeconds: 30
-            periodSeconds: 60
-            timeoutSeconds: 30
+            periodSeconds: 120
+            timeoutSeconds: 60
           volumeMounts:
             - name: shared-fs-persistent-storage
               mountPath: /shared-fs

--- a/kubernetes/charts/oasis-platform/values.yaml
+++ b/kubernetes/charts/oasis-platform/values.yaml
@@ -202,7 +202,7 @@ workerController:
   continueUpdateScaling: true
 
   # Debug option - This prevents workers for a model set to FIXED_WORKERS to be scaled to 0. They will always be started. 
-  neverShutdownFixedWorkers: true
+  neverShutdownFixedWorkers: false
 
   # Settings related to prioritized runs
   priority:

--- a/kubernetes/charts/oasis-platform/values.yaml
+++ b/kubernetes/charts/oasis-platform/values.yaml
@@ -202,7 +202,7 @@ workerController:
   continueUpdateScaling: true
 
   # Debug option - This prevents workers for a model set to FIXED_WORKERS to be scaled to 0. They will always be started. 
-  neverShutdownFixedWorkers: false 
+  neverShutdownFixedWorkers: true
 
   # Settings related to prioritized runs
   priority:

--- a/src/model_execution_worker/distributed_tasks.py
+++ b/src/model_execution_worker/distributed_tasks.py
@@ -659,6 +659,8 @@ def prepare_keys_file_chunk(
 
         location_df = load_location_data(params['oed_location_csv'])
         location_df = pd.np.array_split(location_df, num_chunks)[chunk_idx]
+        location_df.reset_index(drop=True, inplace=True)
+
         chunk_keys_fp = os.path.join(chunk_target_dir, 'keys.csv')
         chunk_keys_errors_fp = os.path.join(chunk_target_dir, 'keys-errors.csv')
         lookup.generate_key_files(


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue after submitting a Pull Request. -->

<!--start_release_notes-->
### Fixes for current release 2.1.1 
* Fixed issue with location file chunking, without re-indexing the location file chunk some supplier lookup classes will drop keys
* Increased liveness probes on worker pods, workers under full load can timeout from celery and restart. 
<!--end_release_notes-->
