### PR TITLE
Fixed bug in collect keys for debian worker

### DIFF
--- a/src/model_execution_worker/distributed_tasks.py
+++ b/src/model_execution_worker/distributed_tasks.py
@@ -743,7 +743,7 @@ def collect_keys(
         # extract chunks
         chunk_tars = [Path(d['chunk_keys']) for d in params]
         for tar in chunk_tars:
-            dirname = tar.name.removesuffix(''.join(tar.suffixes))
+            dirname = tar.name.rstrip(''.join(tar.suffixes))
             extract_to = chunks_dir / dirname
             filestore.extract(tar.as_posix(), extract_to.as_posix(), storage_subdir)
 


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue after submitting a Pull Request. -->

<!--start_release_notes-->
### Fixed bug in collect keys for debian worker
* `str.removesuffix` is not supported in py3.8, replaced with `rstrip`
<!--end_release_notes-->
