### PR TITLE
Fix pre-analysis hook 

### DIFF
--- a/src/model_execution_worker/distributed_tasks.py
+++ b/src/model_execution_worker/distributed_tasks.py
@@ -613,10 +613,10 @@ def pre_analysis_hook(self,
             pre_hook_output = OasisManager().exposure_pre_analysis(**params)
             files_modified = pre_hook_output.get('modified', {})
 
-            pre_loc_fp = os.path.join(pre_hook_output, files_modified.get('location'))
-            pre_acc_fp = os.path.join(pre_hook_output, files_modified.get('account'))
-            pre_info_fp = os.path.join(pre_hook_output, files_modified.get('ri_info'))
-            pre_scope_fp = os.path.join(pre_hook_output, files_modified.get('ri_scope'))
+            pre_loc_fp = os.path.join(hook_target_dir, files_modified.get('location'))
+            pre_acc_fp = os.path.join(hook_target_dir, files_modified.get('account'))
+            pre_info_fp = os.path.join(hook_target_dir, files_modified.get('ri_info'))
+            pre_scope_fp = os.path.join(hook_target_dir, files_modified.get('ri_scope'))
 
             # store updated files
             params['pre_loc_file'] = filestore.put(pre_loc_fp, subdir=params['storage_subdir'])


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue after submitting a Pull Request. -->

<!--start_release_notes-->
### Fix pre-analysis hook 
The return value from `OasisManager().exposure_pre_analysis(**params)` has changed its keys. 
For example `oed_location_csv` is now `location`.  

This bug won't crash an execution, however the updated exposure files are not passed on to the **generate-keys** or **generate-oasis-files** sub-tasks. 
<!--end_release_notes-->


https://github.com/OasisLMF/OasisPlatform/blob/135754e53e308ff7cefb378000857b53a13b818a/src/model_execution_worker/distributed_tasks.py#L616-L620