### PR TITLE
Fixed portfolio file linking with Azure Blobs 

### DIFF
--- a/src/server/oasisapi/portfolios/serializers.py
+++ b/src/server/oasisapi/portfolios/serializers.py
@@ -308,8 +308,10 @@ class PortfolioStorageSerializer(serializers.ModelSerializer):
                     return self.inferr_content_type(stored_filename)
 
             #  Find content_type from Blob Storage
-            # elif hasattr(default_storage, 'azure_container'):
-            #     --- Add option to read content_type from blob store ---
+             elif hasattr(default_storage, 'azure_container'):
+                blob_client = default_storage.client.get_blob_client(stored_filename)
+                blob_properties = blob_client.get_blob_properties()
+                return blob_properties.content_settings.content_type
 
             else:
                 return self.inferr_content_type(stored_filename)

--- a/src/server/oasisapi/portfolios/serializers.py
+++ b/src/server/oasisapi/portfolios/serializers.py
@@ -1,4 +1,5 @@
 from os import path
+import mimetypes
 
 from botocore.exceptions import ClientError as S3_ClientError
 from django.contrib.auth.models import Group
@@ -283,18 +284,35 @@ class PortfolioStorageSerializer(serializers.ModelSerializer):
             raise serializers.ValidationError(errors)
         return super(PortfolioStorageSerializer, self).validate(attrs)
 
+    def inferr_content_type(self, stored_filename):
+        inferred_type = mimetypes.MimeTypes().guess_type(stored_filename)[0]
+        if not inferred_type and stored_filename.lower().endswith('parquet'):
+            # mimetypes dosn't work for parquet so handle that here
+            inferred_type = 'application/octet-stream'
+        if not inferred_type:
+            inferred_type = default_storage.default_content_type
+        return inferred_type
+
     def get_content_type(self, stored_filename):
         try:  # fetch content_type stored in Django's DB
             return RelatedFile.objects.get(file=path.basename(stored_filename)).content_type
         except ObjectDoesNotExist:
-            try:  # Find content_type from S3 Object header
-                object_header = default_storage.connection.meta.client.head_object(
-                    Bucket=default_storage.bucket_name,
-                    Key=stored_filename)
-                return object_header['ContentType']
-            except ClientError:
-                # fallback to the default content_type
-                return default_storage.default_content_type
+            # Find content_type from S3 Object header
+            if hasattr(default_storage, 'bucket'):
+                try:
+                    object_header = default_storage.connection.meta.client.head_object(
+                        Bucket=default_storage.bucket_name,
+                        Key=stored_filename)
+                    return object_header['ContentType']
+                except S3_ClientError:
+                    return self.inferr_content_type(stored_filename)
+
+            #  Find content_type from Blob Storage
+            #elif hasattr(default_storage, 'azure_container'):
+            #     --- Add option to read content_type from blob store ---
+
+            else:
+                return self.inferr_content_type(stored_filename)
 
     def update(self, instance, validated_data):
         files_for_removal = list()

--- a/src/server/oasisapi/portfolios/serializers.py
+++ b/src/server/oasisapi/portfolios/serializers.py
@@ -308,7 +308,7 @@ class PortfolioStorageSerializer(serializers.ModelSerializer):
                     return self.inferr_content_type(stored_filename)
 
             #  Find content_type from Blob Storage
-            #elif hasattr(default_storage, 'azure_container'):
+            # elif hasattr(default_storage, 'azure_container'):
             #     --- Add option to read content_type from blob store ---
 
             else:


### PR DESCRIPTION
> Rebased from https://github.com/OasisLMF/OasisPlatform/pull/682

<!--start_release_notes-->
### Fixed portfolio file linking 
Fixed the endpoint `/v1/portfolios/{id}/storage_links/` when connecting unregistered blobs (not already in the Django `default_storage` adapter) and connecting the blob to a portfolio as an exposure file. 
<!--end_release_notes-->
