### PR TITLE
Common datasets

### DIFF
--- a/kubernetes/charts/oasis-models/templates/workers.yaml
+++ b/kubernetes/charts/oasis-models/templates/workers.yaml
@@ -58,15 +58,13 @@ spec:
               mountPath: /shared-fs
             {{- range .volumes }}
             - name: {{ .name }}
-              {{- if eq .source "azureFiles" }}
+              {{- if .subPath }}
+              subPath: {{ .subPath }}
+              {{- else if eq .source "azureFiles" }}
               subPath: {{ printf "%s/%s/%s" $worker.supplierId $worker.modelId $worker.modelVersionId }}
               {{- end }}
               mountPath: {{ .mountPath }}
             {{- end }}
-            # HACK to enable a shared datasets dir
-            - name: oasis-models-azure-file
-              subPath: datasets
-              mountPath: /datasets
 {{- if .registryCredentials }}
       imagePullSecrets:
         - name: {{ .registryCredentials }}

--- a/kubernetes/charts/oasis-models/templates/workers.yaml
+++ b/kubernetes/charts/oasis-models/templates/workers.yaml
@@ -64,7 +64,7 @@ spec:
               mountPath: {{ .mountPath }}
             {{- end }}
             # HACK to enable a shared datasets dir
-            - name: oasis-models-azure-files
+            - name: oasis-models-azure-file
               subPath: datasets
               mountPath: /datasets
 {{- if .registryCredentials }}

--- a/kubernetes/charts/oasis-models/templates/workers.yaml
+++ b/kubernetes/charts/oasis-models/templates/workers.yaml
@@ -63,6 +63,10 @@ spec:
               {{- end }}
               mountPath: {{ .mountPath }}
             {{- end }}
+            // HACK to enable a shared datasets dir
+            - name: oasis-models-azure-files
+              subPath: datasets
+              mountPath: /datasets
 {{- if .registryCredentials }}
       imagePullSecrets:
         - name: {{ .registryCredentials }}

--- a/kubernetes/charts/oasis-models/templates/workers.yaml
+++ b/kubernetes/charts/oasis-models/templates/workers.yaml
@@ -63,7 +63,7 @@ spec:
               {{- end }}
               mountPath: {{ .mountPath }}
             {{- end }}
-            // HACK to enable a shared datasets dir
+            # HACK to enable a shared datasets dir
             - name: oasis-models-azure-files
               subPath: datasets
               mountPath: /datasets

--- a/kubernetes/charts/oasis-models/values.yaml
+++ b/kubernetes/charts/oasis-models/values.yaml
@@ -45,6 +45,9 @@ workers:
 #        source: Can either be 'host' or 'azureFiles':
 #                host       - Host path on kubernetes node
 #                azureFiles - Azure files on account storage
+#        subPath: Subdirectory of the volume to mount at the given path. If not specified, for Azure
+#                 volumes this will default to {supplierId}/{modelId}/{modelVersionId}.
+#                 Can be used to make available cross-model data.
       - name: piwind-model-data-pv
         type: model-data
         mountPath: /home/worker/model


### PR DESCRIPTION
<!--start_release_notes-->
### Support for cross-model data on Azure
Platform 2 model workers can now specify volumes with optional custom subpaths. This allows workers for different models to share files and thus avoids some duplication of data.

Example:
```yaml
    volumes:
      # Existing behaviour: `AZURE_MODELS_ROOT/supplier/model/version/` mounted at `/home/worker/model`.
      - name: oasis-models-azure-file
        type: model-data
        mountPath: /home/worker/model
        source: azureFiles
      # New option: `AZURE_MODELS_ROOT/common/datasets/` mounted at `/datasets`.
      - name: oasis-models-azure-file
        type: model-data
        mountPath: /datasets
        source: azureFiles
        subPath: common/datasets
```
<!--end_release_notes-->

#870 