### PR TITLE
Revert keycloak version to 21.1.1

### DIFF
--- a/kubernetes/charts/oasis-platform/values.yaml
+++ b/kubernetes/charts/oasis-platform/values.yaml
@@ -22,7 +22,7 @@ images:
     version: 8.0.33
   keycloak:
     image: quay.io/keycloak/keycloak
-    version: 22.0.0
+    version: 21.1.1
   init:
     image: busybox
     version: 1.28


### PR DESCRIPTION
<!--start_release_notes-->
### Revert keycloak version to 21.1.1
The Keycloak admin console is broken in version 22, configuration needs a review to fix https://github.com/OasisLMF/OasisPlatform/issues/876 

In the meantime, reverting keycloak to the last working version 21.1.1
<!--end_release_notes-->
