### PR TITLE
revert settings compatibility to older version

### DIFF
--- a/src/server/oasisapi/analyses/tests/test_analysis_api.py
+++ b/src/server/oasisapi/analyses/tests/test_analysis_api.py
@@ -779,7 +779,9 @@ class AnalysisSettingsJson(WebTestMixin, TestCase):
                     "source_tag": "test_source",
                     "analysis_tag": "test_analysis",
                     "model_supplier_id": "OasisIM",
+                    'module_supplier_id': 'OasisIM',
                     "model_name_id": "1",
+                    'model_version_id': '1',
                     "number_of_samples": 10,
                     "gul_threshold": 0,
                     "model_settings": {
@@ -797,9 +799,7 @@ class AnalysisSettingsJson(WebTestMixin, TestCase):
                             "lec_output": False
                         }
                     ],
-                    "il_output": False,
-                    'model_version_id': '1',
-                    'model_supplier_id': 'OasisIM'
+                    "il_output": False
                 }
 
                 self.app.post(

--- a/src/server/oasisapi/schemas/serializers.py
+++ b/src/server/oasisapi/schemas/serializers.py
@@ -181,5 +181,20 @@ class AnalysisSettingsSerializer(JsonSettingsSerializer):
         self.schemaClass = AnalysisSettingSchema()
 
     def validate(self, data):
-        data = self.schemaClass.compatibility(data)
+
+        # Note: Workaround for to support workers 1.15.x and older. With the analysis settings schema change the workers with fail
+        # These are added into existing files as a 'fix' so older workers can run without patching the worker schema
+        # This *SHOULD* be removed at a later date once older models are not longer used
+        compatibility_field_map = {
+            "module_supplier_id": {
+                "updated_to": "model_supplier_id"
+            },
+            "model_version_id": {
+                "updated_to": "model_name_id"
+            },
+        }
+        for key in compatibility_field_map:
+            if key not in data:
+                data[key] = data[compatibility_field_map[key]['updated_to']]
+
         return super(AnalysisSettingsSerializer, self).validate_json(data)

--- a/src/server/oasisapi/schemas/serializers.py
+++ b/src/server/oasisapi/schemas/serializers.py
@@ -185,6 +185,7 @@ class AnalysisSettingsSerializer(JsonSettingsSerializer):
         # Note: Workaround for to support workers 1.15.x and older. With the analysis settings schema change the workers with fail
         # These are added into existing files as a 'fix' so older workers can run without patching the worker schema
         # This *SHOULD* be removed at a later date once older models are not longer used
+        data = self.schemaClass.compatibility(data)
         compatibility_field_map = {
             "module_supplier_id": {
                 "updated_to": "model_supplier_id"


### PR DESCRIPTION
<!--start_release_notes-->
### Add back settings compatibility workaround
Bug added when the analysis settings compatibility mapping (needed for workers 1.15.x) was moved to ods-tools. 
Reverted to the settings validation from platform (1.27.1)

https://github.com/OasisLMF/OasisPlatform/blob/bcc3a28a19ab52ff5582c6c13851996aa74a46fe/src/server/oasisapi/schemas/serializers.py#L207-L220

This stores both older and newer keys in the analysis settings file when its posted to the server.  
<!--end_release_notes-->
