### PR TITLE
Fix syntax in flower chart template

### DIFF
--- a/kubernetes/charts/oasis-monitoring/templates/flower.yaml
+++ b/kubernetes/charts/oasis-monitoring/templates/flower.yaml
@@ -33,7 +33,7 @@ spec:
             - name: FLOWER_LOGGING
               value: INFO
             - name: FLOWER_UNAUTHENTICATED_API
-              value: true
+              value: "true"
           livenessProbe:
             failureThreshold: 2
             httpGet:


### PR DESCRIPTION
<!--start_release_notes-->
### Fix Flower chart template
Fix **oasis-monitor** chart, deployment fails with `cannot unmarshal bool into Go struct field EnvVar.spec.template.spec.containers.env.value of type string` 
<!--end_release_notes-->
