### PR TITLE
Fix/websock schmea

### DIFF
--- a/src/server/oasisapi/asgi.py
+++ b/src/server/oasisapi/asgi.py
@@ -13,5 +13,6 @@ django.setup()
 application = get_default_application()
 
 # ONLY run the websocket from here (add safeguard to remove HTTP router)
-if 'http' in application.application_mapping:
-    del application.application_mapping['http']
+if os.getenv('OASIS_DISABLE_HTTP', default=True):
+    if 'http' in application.application_mapping:
+        del application.application_mapping['http']

--- a/src/server/oasisapi/queues/serializers.py
+++ b/src/server/oasisapi/queues/serializers.py
@@ -14,7 +14,7 @@ class QueueSerializer(serializers.Serializer):
     running_count = serializers.IntegerField()
     models = serializers.SerializerMethodField()
 
-    @swagger_serializer_method(serializer_or_field=AnalysisModelSerializer)
+    @swagger_serializer_method(serializer_or_field=AnalysisModelSerializer(many=True))
     def get_models(self, instance, *args, **kwargs):
         models = [m for m in AnalysisModel.objects.all() if str(m) == instance['name']]
         return AnalysisModelSerializer(instance=models, many=True).data
@@ -55,6 +55,6 @@ class WebsocketSerializer(serializers.Serializer):
     status = serializers.CharField()
     content = serializers.SerializerMethodField()
 
-    @swagger_serializer_method(serializer_or_field=WebsocketContentSerializer)
+    @swagger_serializer_method(serializer_or_field=WebsocketContentSerializer(many=True))
     def get_content(self, instance, *args, **kwargs):
         pass

--- a/src/server/oasisapi/queues/viewsets.py
+++ b/src/server/oasisapi/queues/viewsets.py
@@ -19,7 +19,7 @@ class QueueViewSet(viewsets.ViewSet):
 
 
 class WebsocketViewSet(viewsets.ViewSet):
-    @swagger_auto_schema(responses={200: WebsocketSerializer(many=True, read_only=True)})
+    @swagger_auto_schema(responses={200: WebsocketSerializer(many=False, read_only=True)})
     def list(self, request, *args, **kwargs):
         """
         This endpoint documents the schema for the WebSocket used for async status updates at


### PR DESCRIPTION
**IMPORTANT: Please attach or create an issue after submitting a Pull Request.

<!--start_release_notes-->
### Adjusted fixes for Websocket 
* Added `OASIS_DISABLE_HTTP` env var to web-socket container 

1. The websocket object is within an array in the schema but the actual payload comes as a singular object
2. websocket->websocketcontent is an array in the actual payload but it’s a singular object in schema
3. websocket->websocketcontent->models is an array in the actual payload but it’s a singular object in the schema


<!--end_release_notes-->
