### PR TITLE
Proof of Concept for Platform1 support in Platform2 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,19 +63,6 @@ services:
    volumes:
      - filestore-OasisData:/shared-fs:rw
      - ./src/server/oasisapi:/var/www/oasis/src/server/oasisapi
-  worker-monitor:
-   restart: always
-   image: coreoasis/api_server:dev
-   command: [celery, -A, src.server.oasisapi.celery_app, worker, --loglevel=INFO, -Q, celery-platform-2]
-   links:
-     - server-db
-     - celery-db
-     - broker
-   environment:
-     <<: *shared-env
-   volumes:
-     - filestore-OasisData:/shared-fs:rw
-     - ./src/server/oasisapi:/var/www/oasis/src/server/oasisapi
   task-controller:
    restart: always
    image: coreoasis/api_server:dev
@@ -100,7 +87,59 @@ services:
    environment:
      <<: *shared-env
    volumes: *shared-volumes
-  worker:
+
+
+
+
+  worker-monitor_v1:
+   restart: always
+   image: coreoasis/api_server:1.28.3
+   command: [celery, -A, src.server.oasisapi.celery_app, worker, --loglevel=INFO, -Q, celery]
+   links:
+     - server-db
+     - celery-db
+     - broker
+   environment:
+     <<: *shared-env
+   volumes:
+     - filestore-OasisData:/shared-fs:rw
+
+  worker-monitor_v2:
+   restart: always
+   image: coreoasis/api_server:dev
+   command: [celery, -A, src.server.oasisapi.celery_app, worker, --loglevel=INFO, -Q, celery-platform-2]
+   links:
+     - server-db
+     - celery-db
+     - broker
+   environment:
+     <<: *shared-env
+   volumes:
+     - filestore-OasisData:/shared-fs:rw
+     - ./src/server/oasisapi:/var/www/oasis/src/server/oasisapi
+
+
+  worker_v1:
+    restart: always
+    image: coreoasis/model_worker:1.28.3
+    build:
+      context: .
+      dockerfile: Dockerfile.model_worker
+    links:
+     - celery-db
+     - broker:mybroker
+    environment:
+     <<: *shared-env
+     OASIS_MODEL_SUPPLIER_ID: OasisLMF
+     OASIS_MODEL_ID: PiWind
+     OASIS_MODEL_VERSION_ID: 1
+     OASIS_MODEL_NUM_ANALYSIS_CHUNKS: 8
+    volumes:
+     - ${OASIS_MODEL_DATA_DIR:-./data/static}:/home/worker/model:rw
+     - filestore-OasisData:/shared-fs:rw
+
+
+  worker_v2:
     restart: always
     image: coreoasis/model_worker:dev
     build:
@@ -119,6 +158,10 @@ services:
      - ${OASIS_MODEL_DATA_DIR:-./data/static}:/home/worker/model:rw
      - ./src/model_execution_worker:/home/worker/src/model_execution_worker
      - filestore-OasisData:/shared-fs:rw
+
+
+
+
   server-db:
     restart: always
     image: postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,7 @@ x-shared-env: &shared-env
   OASIS_LOSSES_GENERATION_CONTROLLER_QUEUE: task-controller
 x-volumes: &shared-volumes
   - filestore-OasisData:/shared-fs:rw
+
 services:
   server_http:
    restart: always
@@ -94,15 +95,14 @@ services:
   worker-monitor_v1:
    restart: always
    image: coreoasis/api_server:1.28.3
-   command: [wait-for-server, 'server:8000', celery, -A, src.server.oasisapi, worker, --loglevel=INFO]
-   #command: [celery, -A, src.server.oasisapi.celery_app, worker, --loglevel=INFO, -Q, celery]
+   command: [celery, -A, src.server.oasisapi, worker, --loglevel=INFO]
    links:
      - server-db
      - celery-db
      - broker
    environment:
      - OASIS_DEBUG=1
-     - OASIS_RABBIT_HOST=rabbit
+     - OASIS_RABBIT_HOST=broker
      - OASIS_RABBIT_PORT=5672
      - OASIS_RABBIT_USER=rabbit
      - OASIS_RABBIT_PASS=rabbit
@@ -111,7 +111,8 @@ services:
      - OASIS_SERVER_DB_USER=oasis
      - OASIS_SERVER_DB_NAME=oasis
      - OASIS_SERVER_DB_PORT=5432
-     - OASIS_CELERY_DB_ENGINE=db+mysql+pymysql
+     - OASIS_SERVER_DB_ENGINE=django.db.backends.postgresql_psycopg2
+     - OASIS_CELERY_DB_ENGINE=db+postgresql+psycopg2
      - OASIS_CELERY_DB_HOST=celery-db
      - OASIS_CELERY_DB_PASS=password
      - OASIS_CELERY_DB_USER=celery
@@ -141,22 +142,24 @@ services:
       context: .
       dockerfile: Dockerfile.model_worker
     links:
+     - server-db
      - celery-db
-     - broker:mybroker
+     - broker
     environment:
      - OASIS_MODEL_SUPPLIER_ID=OasisLMF
      - OASIS_MODEL_ID=PiWind
      - OASIS_MODEL_VERSION_ID=1
-     - OASIS_RABBIT_HOST=rabbit
+     - OASIS_RABBIT_HOST=broker
      - OASIS_RABBIT_PORT=5672
      - OASIS_RABBIT_USER=rabbit
      - OASIS_RABBIT_PASS=rabbit
-     - OASIS_CELERY_DB_ENGINE=db+mysql+pymysql
+     - OASIS_SERVER_DB_ENGINE=django.db.backends.postgresql_psycopg2
+     - OASIS_CELERY_DB_ENGINE=db+postgresql+psycopg2
      - OASIS_CELERY_DB_HOST=celery-db
      - OASIS_CELERY_DB_PASS=password
      - OASIS_CELERY_DB_USER=celery
      - OASIS_CELERY_DB_NAME=celery
-     - OASIS_CELERY_DB_PORT=3306
+     - OASIS_CELERY_DB_PORT=5432
      - OASIS_MODEL_DATA_DIRECTORY=/home/worker/model
     volumes:
      - ${OASIS_MODEL_DATA_DIR:-./data/static}:/home/worker/model:rw

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,7 +66,7 @@ services:
   worker-monitor:
    restart: always
    image: coreoasis/api_server:dev
-   command: [celery, -A, src.server.oasisapi.celery_app, worker, --loglevel=INFO]
+   command: [celery, -A, src.server.oasisapi.celery_app, worker, --loglevel=INFO, -Q, celery-platform-2]
    links:
      - server-db
      - celery-db
@@ -92,7 +92,7 @@ services:
   celery-beat:
    restart: always
    image: coreoasis/api_server:dev
-   command: [celery, -A, src.server.oasisapi.celery_app, beat, --loglevel=INFO]
+   command: [celery, -A, src.server.oasisapi.celery_app, beat, --loglevel=INFO, -Q, celery-platform-2]
    links:
      - server-db
      - celery-db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,7 +79,7 @@ services:
   celery-beat:
    restart: always
    image: coreoasis/api_server:dev
-   command: [celery, -A, src.server.oasisapi.celery_app, beat, --loglevel=INFO, -Q, celery-platform-2]
+   command: [celery, -A, src.server.oasisapi.celery_app, beat, --loglevel=INFO]
    links:
      - server-db
      - celery-db
@@ -94,13 +94,29 @@ services:
   worker-monitor_v1:
    restart: always
    image: coreoasis/api_server:1.28.3
-   command: [celery, -A, src.server.oasisapi.celery_app, worker, --loglevel=INFO, -Q, celery]
+   command: [wait-for-server, 'server:8000', celery, -A, src.server.oasisapi, worker, --loglevel=INFO]
+   #command: [celery, -A, src.server.oasisapi.celery_app, worker, --loglevel=INFO, -Q, celery]
    links:
      - server-db
      - celery-db
      - broker
    environment:
-     <<: *shared-env
+     - OASIS_DEBUG=1
+     - OASIS_RABBIT_HOST=rabbit
+     - OASIS_RABBIT_PORT=5672
+     - OASIS_RABBIT_USER=rabbit
+     - OASIS_RABBIT_PASS=rabbit
+     - OASIS_SERVER_DB_HOST=server-db
+     - OASIS_SERVER_DB_PASS=oasis
+     - OASIS_SERVER_DB_USER=oasis
+     - OASIS_SERVER_DB_NAME=oasis
+     - OASIS_SERVER_DB_PORT=5432
+     - OASIS_CELERY_DB_ENGINE=db+mysql+pymysql
+     - OASIS_CELERY_DB_HOST=celery-db
+     - OASIS_CELERY_DB_PASS=password
+     - OASIS_CELERY_DB_USER=celery
+     - OASIS_CELERY_DB_NAME=celery
+     - OASIS_CELERY_DB_PORT=5432
    volumes:
      - filestore-OasisData:/shared-fs:rw
 
@@ -118,7 +134,6 @@ services:
      - filestore-OasisData:/shared-fs:rw
      - ./src/server/oasisapi:/var/www/oasis/src/server/oasisapi
 
-
   worker_v1:
     restart: always
     image: coreoasis/model_worker:1.28.3
@@ -129,11 +144,20 @@ services:
      - celery-db
      - broker:mybroker
     environment:
-     <<: *shared-env
-     OASIS_MODEL_SUPPLIER_ID: OasisLMF
-     OASIS_MODEL_ID: PiWind
-     OASIS_MODEL_VERSION_ID: 1
-     OASIS_MODEL_NUM_ANALYSIS_CHUNKS: 8
+     - OASIS_MODEL_SUPPLIER_ID=OasisLMF
+     - OASIS_MODEL_ID=PiWind
+     - OASIS_MODEL_VERSION_ID=1
+     - OASIS_RABBIT_HOST=rabbit
+     - OASIS_RABBIT_PORT=5672
+     - OASIS_RABBIT_USER=rabbit
+     - OASIS_RABBIT_PASS=rabbit
+     - OASIS_CELERY_DB_ENGINE=db+mysql+pymysql
+     - OASIS_CELERY_DB_HOST=celery-db
+     - OASIS_CELERY_DB_PASS=password
+     - OASIS_CELERY_DB_USER=celery
+     - OASIS_CELERY_DB_NAME=celery
+     - OASIS_CELERY_DB_PORT=3306
+     - OASIS_MODEL_DATA_DIRECTORY=/home/worker/model
     volumes:
      - ${OASIS_MODEL_DATA_DIR:-./data/static}:/home/worker/model:rw
      - filestore-OasisData:/shared-fs:rw

--- a/src/conf/celeryconf.py
+++ b/src/conf/celeryconf.py
@@ -77,6 +77,8 @@ CELERY_QUEUE_MAX_PRIORITY = 10
 # Set to make internal and subtasks inherit priority
 CELERY_INHERIT_PARENT_PRIORITY = True
 
+# Default Queue Name
+CELERY_DEFAULT_QUEUE = "celery-platform-2"
 
 # setup the beat schedule
 def crontab_from_string(s):

--- a/src/model_execution_worker/distributed_tasks.py
+++ b/src/model_execution_worker/distributed_tasks.py
@@ -197,7 +197,7 @@ def notify_api_status(analysis_pk, task_status):
     signature(
         'set_task_status',
         args=(analysis_pk, task_status, datetime.now().timestamp()),
-        queue='celery'
+        queue='celery-platform-2'
     ).delay()
 
 

--- a/src/model_execution_worker/tasks.py
+++ b/src/model_execution_worker/tasks.py
@@ -288,7 +288,7 @@ def notify_api_status(analysis_pk, task_status):
     signature(
         'set_task_status',
         args=(analysis_pk, task_status),
-        queue='celery'
+        queue='celery-platform-2'
     ).delay({}, priority=analysis_pk)
 
 
@@ -605,7 +605,7 @@ def on_error(request, ex, traceback, record_task_name, analysis_pk, initiator_pk
         signature(
             record_task_name,
             args=(analysis_pk, initiator_pk, traceback),
-            queue='celery'
+            queue='celery-platform-2'
         ).delay({})
 
 

--- a/src/model_execution_worker/tasks.py
+++ b/src/model_execution_worker/tasks.py
@@ -288,7 +288,7 @@ def notify_api_status(analysis_pk, task_status):
     signature(
         'set_task_status',
         args=(analysis_pk, task_status),
-        queue='celery-platform-2'
+        queue='celery'
     ).delay({}, priority=analysis_pk)
 
 
@@ -605,7 +605,7 @@ def on_error(request, ex, traceback, record_task_name, analysis_pk, initiator_pk
         signature(
             record_task_name,
             args=(analysis_pk, initiator_pk, traceback),
-            queue='celery-platform-2'
+            queue='celery'
         ).delay({})
 
 

--- a/src/server/oasisapi/analyses/models.py
+++ b/src/server/oasisapi/analyses/models.py
@@ -26,6 +26,10 @@ from ....common.data import STORED_FILENAME, ORIGINAL_FILENAME
 from ....conf import iniconf
 
 
+from .tasks import record_generate_input_result, record_run_analysis_result
+from celery import signature
+
+
 class AnalysisTaskStatusQuerySet(models.QuerySet):
     @classmethod
     def _send_socket_messages(cls, objects):

--- a/src/server/oasisapi/analyses/task_controller.py
+++ b/src/server/oasisapi/analyses/task_controller.py
@@ -341,7 +341,7 @@ class Controller:
                 run_data_uuid,
                 'Record input files',
                 'record-input-files',
-                'celery',
+                'celery-platform-2',
                 TaskParams(analysis_finish_status=analysis_finish_status),
             ),
             cls.get_subtask_statuses_and_signature(
@@ -485,7 +485,7 @@ class Controller:
                 run_data_uuid,
                 'Record losses files',
                 'record-losses-files',
-                'celery',
+                'celery-platform-2',
                 TaskParams(**base_kwargs),
             ),
             cls.get_subtask_statuses_and_signature(

--- a/src/server/oasisapi/analyses/task_controller.py
+++ b/src/server/oasisapi/analyses/task_controller.py
@@ -244,7 +244,7 @@ class Controller:
 
         :return: The name of the queue
         """
-        return str(analysis.model)
+        return str(analysis.model) + '-platform-2'
 
     @classmethod
     def get_inputs_generation_tasks(
@@ -413,7 +413,7 @@ class Controller:
 
         :return: The name of the queue
         """
-        return str(analysis.model)
+        return str(analysis.model) + '-platform-2'
 
     @classmethod
     def get_loss_generation_tasks(cls, analysis: 'Analysis', initiator: User, run_data_uuid: str, num_chunks: int):

--- a/src/server/oasisapi/analyses/tasks.py
+++ b/src/server/oasisapi/analyses/tasks.py
@@ -725,3 +725,98 @@ def update_task_id(task_update_list):
             analysis_id=analysis_id,
             slug=slug,
         ).update(task_id=task_id)
+
+
+
+
+
+
+# --------------------------------------
+
+@celery_app.task(name='record_generate_input_result', base=LogTaskError)
+def record_generate_input_result(result, analysis_pk, initiator_pk):
+    logger.info('result: {}, analysis_pk: {}, initiator_pk: {}'.format(
+        result, analysis_pk, initiator_pk))
+
+    from .models import Analysis
+    (
+        input_location,
+        lookup_error_fp,
+        lookup_success_fp,
+        lookup_validation_fp,
+        summary_levels_fp,
+        traceback_fp,
+        return_code,
+    ) = result
+
+    analysis = Analysis.objects.get(pk=analysis_pk)
+    initiator = get_user_model().objects.get(pk=initiator_pk)
+
+    # Remove previous output
+    delete_prev_output(analysis, [
+        'output_file',
+        'input_file',
+        'lookup_errors_file',
+        'lookup_success_file',
+        'lookup_validation_file',
+        'summary_levels_file',
+        'input_generation_traceback_file',
+        'run_traceback_file',
+        'run_log_file',
+    ])
+
+    # SUCCESS
+    if return_code == 0:
+        analysis.status = Analysis.status_choices.READY
+    # FAILED
+    else:
+        analysis.status = Analysis.status_choices.INPUTS_GENERATION_ERROR
+
+    # Add current Output
+    analysis.input_file = store_file(input_location, 'application/gzip', initiator,
+                                     filename=f'analysis_{analysis_pk}_inputs.tar.gz') if input_location else None
+    analysis.lookup_success_file = store_file(lookup_success_fp, 'text/csv', initiator,
+                                              filename=f'analysis_{analysis_pk}_gul_summary_map.csv') if lookup_success_fp else None
+    analysis.lookup_errors_file = store_file(lookup_error_fp, 'text/csv', initiator, required=False,
+                                             filename=f'analysis_{analysis_pk}_keys-errors.csv') if lookup_error_fp else None
+    analysis.lookup_validation_file = store_file(lookup_validation_fp, 'application/json', initiator, required=False,
+                                                 filename=f'analysis_{analysis_pk}_exposure_summary_report.json') if lookup_validation_fp else None
+    analysis.summary_levels_file = store_file(summary_levels_fp, 'application/json', initiator, required=False,
+                                              filename=f'analysis_{analysis_pk}_exposure_summary_levels.json') if summary_levels_fp else None
+    analysis.task_finished = timezone.now()
+
+    # always store traceback
+    if traceback_fp:
+        analysis.input_generation_traceback_file = store_file(
+            traceback_fp, 'text/plain', initiator, filename=f'analysis_{analysis_pk}_generation_traceback.txt')
+        logger.info(analysis.input_generation_traceback_file)
+    analysis.save()
+
+
+
+@celery_app.task(name='record_run_analysis_result', base=LogTaskError)
+def record_run_analysis_result(res, analysis_pk, initiator_pk):
+    output_location, traceback_location, log_location, return_code = res
+    logger.info('output_location: {}, log_location: {}, traceback_location: {}, status: {}, analysis_pk: {}, initiator_pk: {}'.format(
+        output_location, traceback_location, log_location, return_code, analysis_pk, initiator_pk))
+
+    from .models import Analysis
+    initiator = get_user_model().objects.get(pk=initiator_pk)
+    analysis = Analysis.objects.get(pk=analysis_pk)
+    analysis.status = Analysis.status_choices.RUN_COMPLETED if return_code == 0 else Analysis.status_choices.RUN_ERROR
+    analysis.task_finished = timezone.now()
+
+    delete_prev_output(analysis, ['output_file', 'run_log_file', 'run_traceback_file'])
+
+    # Store results
+    if return_code == 0:
+        analysis.output_file = store_file(output_location, 'application/gzip', initiator, filename=f'analysis_{analysis_pk}_output.tar.gz')
+    # Store Ktools logs
+    if log_location:
+        analysis.run_log_file = store_file(log_location, 'application/gzip', initiator, filename=f'analysis_{analysis_pk}_logs.tar.gz')
+    # record the error file
+    if traceback_location:
+        analysis.run_traceback_file = store_file(traceback_location, 'text/plain', initiator, filename=f'analysis_{analysis_pk}_run_traceback.txt')
+    analysis.save()
+
+

--- a/src/server/oasisapi/analyses/tasks.py
+++ b/src/server/oasisapi/analyses/tasks.py
@@ -457,7 +457,7 @@ def start_input_and_loss_generation_task(analysis_pk, initiator_pk):
 
 @celery_app.task(bind=True, name='record_input_files')
 def record_input_files(self, result, analysis_id=None, initiator_id=None, run_data_uuid=None, slug=None, analysis_finish_status='READY'):
-
+    from .models import Analysis
     record_sub_task_start.delay(analysis_id=analysis_id, task_slug=slug, task_id=self.request.id, dt=datetime.now().timestamp())
     logger.info('record_input_files: analysis_id: {}, initiator_id: {}'.format(analysis_id, initiator_id))
     logger.info('results: {}'.format(result))

--- a/src/server/oasisapi/analyses/tasks.py
+++ b/src/server/oasisapi/analyses/tasks.py
@@ -681,6 +681,7 @@ def mark_task_as_queued_receiver(*args, headers=None, body=None, **kwargs):
 
 @celery_app.task(name='mark_task_as_queued')
 def mark_task_as_queued(analysis_id, slug, task_id, dt):
+    from .models import AnalysisTaskStatus
     AnalysisTaskStatus.objects.filter(
         analysis_id=analysis_id,
         slug=slug,

--- a/src/server/oasisapi/analyses/viewsets.py
+++ b/src/server/oasisapi/analyses/viewsets.py
@@ -218,7 +218,9 @@ class AnalysisViewSet(VerifyGroupAccessModelViewSet):
                          'run_traceback_file']
 
     task_action_types = ['run',
+                         'run_platform_1',
                          'generate_inputs',
+                         'generate_inputs_platform_1',
                          'generate_and_run',
                          'cancel',
                          'cancel_generate_inputs',
@@ -259,6 +261,45 @@ class AnalysisViewSet(VerifyGroupAccessModelViewSet):
             return [MultiPartParser]
         else:
             return api_settings.DEFAULT_PARSER_CLASSES
+
+
+
+    # ---- platform 1 -------------------------------------------------------- #
+
+
+    @swagger_auto_schema(responses={200: AnalysisSerializer})
+    @action(methods=['post'], detail=True)
+    def run_platform_1(self, request, pk=None, version=None):
+        """
+        Runs all the analysis. The analysis must have one of the following
+        statuses, `NEW`, `RUN_COMPLETED`, `RUN_CANCELLED` or
+        `RUN_ERROR`
+        """
+        obj = self.get_object()
+        verify_user_is_in_obj_groups(request.user, obj.model, 'You are not allowed to run this model')
+        obj.run_v1(request.user)
+        return Response(AnalysisSerializer(instance=obj, context=self.get_serializer_context()).data)
+
+
+    @swagger_auto_schema(responses={200: AnalysisSerializer})
+    @action(methods=['post'], detail=True)
+    def generate_inputs_platform_1(self, request, pk=None, version=None):
+        """
+        Generates the inputs for the analysis based on the portfolio.
+        The analysis must have one of the following statuses, `INPUTS_GENERATION_QUEUED` or `INPUTS_GENERATION_STARTED`
+        """
+        obj = self.get_object()
+        verify_user_is_in_obj_groups(request.user, obj.model, 'You are not allowed to run this model')
+        obj.generate_inputs_v1(request.user)
+        return Response(AnalysisSerializer(instance=obj, context=self.get_serializer_context()).data)
+
+
+    # ------------------------------------------------------------------------
+
+
+
+
+
 
     @swagger_auto_schema(responses={200: AnalysisSerializer})
     @action(methods=['post'], detail=True)

--- a/src/server/oasisapi/analyses/viewsets.py
+++ b/src/server/oasisapi/analyses/viewsets.py
@@ -266,6 +266,17 @@ class AnalysisViewSet(VerifyGroupAccessModelViewSet):
 
     # ---- platform 1 -------------------------------------------------------- #
 
+    @swagger_auto_schema(responses={200: AnalysisSerializer})
+    @action(methods=['post'], detail=True)
+    def generate_inputs_platform_1(self, request, pk=None, version=None):
+        """
+        Generates the inputs for the analysis based on the portfolio.
+        The analysis must have one of the following statuses, `INPUTS_GENERATION_QUEUED` or `INPUTS_GENERATION_STARTED`
+        """
+        obj = self.get_object()
+        verify_user_is_in_obj_groups(request.user, obj.model, 'You are not allowed to run this model')
+        obj.generate_inputs_v1(request.user)
+        return Response(AnalysisSerializer(instance=obj, context=self.get_serializer_context()).data)
 
     @swagger_auto_schema(responses={200: AnalysisSerializer})
     @action(methods=['post'], detail=True)
@@ -279,20 +290,6 @@ class AnalysisViewSet(VerifyGroupAccessModelViewSet):
         verify_user_is_in_obj_groups(request.user, obj.model, 'You are not allowed to run this model')
         obj.run_v1(request.user)
         return Response(AnalysisSerializer(instance=obj, context=self.get_serializer_context()).data)
-
-
-    @swagger_auto_schema(responses={200: AnalysisSerializer})
-    @action(methods=['post'], detail=True)
-    def generate_inputs_platform_1(self, request, pk=None, version=None):
-        """
-        Generates the inputs for the analysis based on the portfolio.
-        The analysis must have one of the following statuses, `INPUTS_GENERATION_QUEUED` or `INPUTS_GENERATION_STARTED`
-        """
-        obj = self.get_object()
-        verify_user_is_in_obj_groups(request.user, obj.model, 'You are not allowed to run this model')
-        obj.generate_inputs_v1(request.user)
-        return Response(AnalysisSerializer(instance=obj, context=self.get_serializer_context()).data)
-
 
     # ------------------------------------------------------------------------
 

--- a/src/server/oasisapi/celery_app.py
+++ b/src/server/oasisapi/celery_app.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 import os
+import copy
 
 from celery import Celery
 from django.conf import settings
@@ -10,3 +11,10 @@ os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'src.server.oasisapi.settings')
 celery_app = Celery('oasisapi')
 celery_app.config_from_object('django.conf:settings')
 celery_app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)
+
+
+#import ipdb; ipdb.set_trace()
+
+celery_app_v1 = copy.deepcopy(celery_app)
+celery_app_v1.conf.task_default_routing_key = 'celery'
+celery_app_v1.conf['CELERY_QUEUE_MAX_PRIORITY'] = None

--- a/src/startup_worker.sh
+++ b/src/startup_worker.sh
@@ -32,4 +32,4 @@ else
 fi
 
 # Start new worker on init
-celery --app src.model_execution_worker.distributed_tasks worker $WORKER_CONCURRENCY --loglevel=INFO -Q "${OASIS_MODEL_SUPPLIER_ID}-${OASIS_MODEL_ID}-${OASIS_MODEL_VERSION_ID}" ${OASIS_CELERY_EXTRA_ARGS} |& tee -a /var/log/oasis/worker.log
+celery --app src.model_execution_worker.distributed_tasks worker $WORKER_CONCURRENCY --loglevel=INFO -Q "${OASIS_MODEL_SUPPLIER_ID}-${OASIS_MODEL_ID}-${OASIS_MODEL_VERSION_ID}-platform-2" ${OASIS_CELERY_EXTRA_ARGS} |& tee -a /var/log/oasis/worker.log


### PR DESCRIPTION
### How it works

Added two new endpoints for testing `/v1/analyses/{id}/generate_inputs_platform_1/`,   `/v1/analyses/{id}/run_platform_1/` 

![Screenshot from 2023-11-06 11-51-25](https://github.com/OasisLMF/OasisPlatform/assets/9889973/1a7bd6d0-bac5-445d-877e-e440eb53c052)

These dispatch celery tasks to the original default queues **celery**  and **{model-supplier}-{model-name}-{ver}**  which has no priority options set:
 https://github.com/OasisLMF/OasisPlatform/blob/8d983a5f744280b30ded0d5be5565192b7a2f7ef/src/server/oasisapi/celery_app.py#L18-L20
 
 While the existing queue dispatch endpoints `/v1/analyses/{id}/generate_inputs` and `/v1/analyses/{id}/run`  now submit tasks to the queues **celery-platform-2** and **{model-supplier}-{model-name}-{ver}-platform-2** which have a max-priority value of `10`
 
![Screenshot from 2023-11-06 12-00-37](https://github.com/OasisLMF/OasisPlatform/assets/9889973/8cfa0fc7-aea9-4d98-b1bd-7650b2dfd41d)

That allows older model workers `1.x.x` to run together with `2.x.x` so long as they are both pointed at the correct queues.   
 
 
 
![Screenshot from 2023-11-06 11-52-20](https://github.com/OasisLMF/OasisPlatform/assets/9889973/336d271c-a6c6-42d0-8ae8-da7c181bf541)

For example, calling `/v1/analyses/{id}/generate_inputs_platform_1/` will run input generation on the **coreoasis/model_worker:1.28.3** using the single server task workflow. 

While, `/v1/analyses/{id}/generate_inputs` runs on `coreoasis/model_worker:dev` (platform 2) 
using the distributed workflow
 