### PR TITLE
Fix Keycloak DB connection

### DIFF
--- a/kubernetes/charts/oasis-platform/templates/keycloak.yaml
+++ b/kubernetes/charts/oasis-platform/templates/keycloak.yaml
@@ -95,7 +95,8 @@ spec:
         - name: {{ .Values.keycloak.name }}
           image: {{ .Values.images.keycloak.image }}:{{ .Values.images.keycloak.version }}
           args: [
-            "start-dev",
+            #"start-dev",  # --- Development mode --- # 
+            "start",
             "--import-realm",
             "--http-relative-path /auth",
             "--proxy edge",

--- a/kubernetes/charts/oasis-platform/templates/keycloak.yaml
+++ b/kubernetes/charts/oasis-platform/templates/keycloak.yaml
@@ -111,12 +111,11 @@ spec:
               {{- else }}
               value: postgres
               {{- end }}
-            - name: KC_DB_URL
-              value: "jdbc:postgresql://oasis-plndlajorgidw.postgres.database.azure.com:5432/keycloak"
-              #valueFrom:
-              #  configMapKeyRef:
-              #    name: {{ .Values.databases.keycloak_db.name }}
-              #    key: host
+            - name: KC_DB_URL_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ .Values.databases.keycloak_db.name }}
+                  key: host
             - name: KC_DB_URL_PORT
               valueFrom:
                 configMapKeyRef:

--- a/kubernetes/charts/oasis-platform/templates/keycloak.yaml
+++ b/kubernetes/charts/oasis-platform/templates/keycloak.yaml
@@ -95,7 +95,7 @@ spec:
         - name: {{ .Values.keycloak.name }}
           image: {{ .Values.images.keycloak.image }}:{{ .Values.images.keycloak.version }}
           args: [
-            "start-dev", 
+            "start-dev",
             "--import-realm",
             "--http-relative-path /auth",
             "--proxy edge",
@@ -103,35 +103,36 @@ spec:
           ports:
             - containerPort: {{ .Values.keycloak.port }}
           env:
-            - name: KEYCLOAK_PROXY_ADDRESS_FORWARDING
+            - name: KC_PROXY_ADDRESS_FORWARDING
               value: "true"
-            - name: DB_VENDOR
+            - name: KC_DB
               {{- if eq .Values.databases.keycloak_db.type "mysql" }}
               value: mysql
               {{- else }}
               value: postgres
               {{- end }}
-            - name: DB_ADDR
-              valueFrom:
-                configMapKeyRef:
-                  name: {{ .Values.databases.keycloak_db.name }}
-                  key: host
-            - name: DB_PORT
+            - name: KC_DB_URL
+              value: "jdbc:postgresql://oasis-plndlajorgidw.postgres.database.azure.com:5432/keycloak"
+              #valueFrom:
+              #  configMapKeyRef:
+              #    name: {{ .Values.databases.keycloak_db.name }}
+              #    key: host
+            - name: KC_DB_URL_PORT
               valueFrom:
                 configMapKeyRef:
                   name: {{ .Values.databases.keycloak_db.name }}
                   key: port
-            - name: DB_DATABASE
+            - name: KC_DB_URL_DATABASE
               valueFrom:
                 configMapKeyRef:
                   name: {{ .Values.databases.keycloak_db.name }}
                   key: dbName
-            - name: DB_USER
+            - name: KC_DB_USERNAME
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.databases.keycloak_db.name }}
                   key: user
-            - name: DB_PASSWORD
+            - name: KC_DB_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.databases.keycloak_db.name }}
@@ -146,11 +147,11 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.keycloak.name }}
                   key: password
-            - name: KEYCLOAK_LOGLEVEL
-              value: INFO
+            - name: KC_LOGLEVEL
+              value: DEBUG
             - name: PROXY_ADDRESS_FORWARDING
               value: "true"
-            - name: KEYCLOAK_IMPORT
+            - name: KC_IMPORT
               value: "/opt/keycloak/data/import/oasis-realm.json"
           startupProbe:
             httpGet:

--- a/requirements-server.txt
+++ b/requirements-server.txt
@@ -92,7 +92,7 @@ cryptography==41.0.2
     #   service-identity
 daphne==2.5.0
     # via channels
-django==3.2.20
+django==3.2.23
     # via
     #   channels
     #   django-celery-results
@@ -119,7 +119,9 @@ django-model-utils==4.3.1
 django-request-logging==0.7.5
     # via -r requirements-server.in
 django-storages[azure]==1.13.2
-    # via -r requirements-server.in
+    # via
+    #   -r requirements-server.in
+    #   django-storages
 djangorestframework==3.14.0
     # via
     #   -r requirements-server.in
@@ -207,7 +209,7 @@ prompt-toolkit==3.0.38
     # via click-repl
 psycopg2-binary==2.9.6
     # via -r requirements-server.in
-pyarrow==11.0.0
+pyarrow==14.0.1
     # via -r requirements-server.in
 pyasn1==0.4.8
     # via
@@ -273,7 +275,9 @@ sqlparse==0.4.4
     #   django
     #   django-debug-toolbar
 twisted[tls]==22.10.0
-    # via daphne
+    # via
+    #   daphne
+    #   twisted
 txaio==23.1.1
     # via autobahn
 typing-extensions==4.5.0

--- a/requirements-worker.txt
+++ b/requirements-worker.txt
@@ -136,7 +136,9 @@ numpy==1.22.4
     #   scipy
     #   shapely
 oasislmf[extra]==1.28.1
-    # via -r requirements-worker.in
+    # via
+    #   -r requirements-worker.in
+    #   oasislmf
 ods-tools==3.1.0
     # via oasislmf
 packaging==23.0
@@ -159,7 +161,7 @@ prompt-toolkit==3.0.38
     # via click-repl
 psycopg2-binary==2.9.6
     # via -r requirements-worker.in
-pyarrow==11.0.0
+pyarrow==14.0.1
     # via oasislmf
 pycparser==2.21
     # via cffi

--- a/requirements.txt
+++ b/requirements.txt
@@ -153,7 +153,7 @@ decorator==5.1.1
     #   ipython
 distlib==0.3.6
     # via virtualenv
-django==3.2.20
+django==3.2.23
     # via
     #   channels
     #   django-celery-results
@@ -183,7 +183,9 @@ django-model-utils==4.3.1
 django-request-logging==0.7.5
     # via -r ./requirements-server.in
 django-storages[azure]==1.13.2
-    # via -r ./requirements-server.in
+    # via
+    #   -r ./requirements-server.in
+    #   django-storages
 django-webtest==1.9.10
     # via -r requirements.in
 djangorestframework==3.14.0
@@ -327,7 +329,9 @@ numpy==1.22.4
     #   scipy
     #   shapely
 oasislmf[extra]==1.28.1
-    # via -r ./requirements-worker.in
+    # via
+    #   -r ./requirements-worker.in
+    #   oasislmf
 ods-tools==3.1.0
     # via
     #   -r ./requirements-server.in
@@ -381,7 +385,7 @@ ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.2
     # via stack-data
-pyarrow==11.0.0
+pyarrow==14.0.1
     # via
     #   -r ./requirements-server.in
     #   oasislmf
@@ -534,7 +538,9 @@ traitlets==5.9.0
     #   ipython
     #   matplotlib-inline
 twisted[tls]==22.10.0
-    # via daphne
+    # via
+    #   daphne
+    #   twisted
 txaio==23.1.1
     # via autobahn
 typing-extensions==4.5.0

--- a/src/model_execution_worker/distributed_tasks.py
+++ b/src/model_execution_worker/distributed_tasks.py
@@ -479,6 +479,7 @@ def keys_generation_task(fn):
         params.setdefault('target_dir', params['root_run_dir'])
         params.setdefault('user_data_dir', os.path.join(params['root_run_dir'], 'user-data'))
         params.setdefault('lookup_complex_config_json', os.path.join(params['root_run_dir'], 'analysis_settings.json'))
+        params.setdefault('analysis_settings_json', os.path.join(params['root_run_dir'], 'analysis_settings.json'))
 
         # Generate keys files
         params.setdefault('keys_fp', os.path.join(params['root_run_dir'], 'keys.csv'))

--- a/src/model_execution_worker/distributed_tasks.py
+++ b/src/model_execution_worker/distributed_tasks.py
@@ -522,6 +522,7 @@ def keys_generation_task(fn):
             maybe_fetch_file(settings_file, params['lookup_complex_config_json'])
         else:
             params['lookup_complex_config_json'] = None
+            params['analysis_settings_json'] = None
         if complex_data_files:
             maybe_prepare_complex_data_files(complex_data_files, params['user_data_dir'])
         else:


### PR DESCRIPTION
<!--start_release_notes-->
### Fix Keycloak DB connection 
The newer versions of Keycloak switched the environment variable prefix from `KEYCLOAK` to `KC`. This caused the Keycloak server to silently fallback on local `dev-file` data storage which is not persistence across restarts. 

Fixed the Database connection to correctly connect to PostgresSQL. 

> **Reference:** [Keycloak documentation - Configuring the database](https://www.keycloak.org/server/db)
<!--end_release_notes-->
