### PR TITLE
Reduce Github actions load

### DIFF
--- a/.github/workflows/build-schema.yml
+++ b/.github/workflows/build-schema.yml
@@ -1,12 +1,11 @@
 name: Platform Schema (OpenAPI)
 
 on:
+  pull_request:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
+      - stable**  
   workflow_dispatch:
     inputs:
       ods_branch:

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -5,7 +5,12 @@
 
 name: Code Quality
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - stable**  
 
 env:
   max_line_length: 150

--- a/.github/workflows/scan-external.yml
+++ b/.github/workflows/scan-external.yml
@@ -1,12 +1,11 @@
 name: External Vulnerability Scanning
 
 on:
+  pull_request:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - stable**
+      - stable**  
 
   workflow_dispatch:
     inputs:

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -1,12 +1,11 @@
 name: Platform Vulnerability Scanning
 
 on:
+  pull_request:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
+      - stable**  
   schedule:
     - cron:  '0 */6 * * *' # Run scan every 6 hours
 

--- a/.github/workflows/test-images.yml
+++ b/.github/workflows/test-images.yml
@@ -1,12 +1,11 @@
 name: Platform Image Tests
 
 on:
+  pull_request:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
+      - stable**  
   workflow_dispatch:
     inputs:
       last_release:

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -1,12 +1,11 @@
 name: Platform Python Tests
 
 on:
+  pull_request:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
+      - stable**  
   workflow_dispatch:
     inputs:
       ods_branch:


### PR DESCRIPTION
### Reduce Github actions load
Only run the full set of testing jobs when:
* A Pull Request is active 
* If a commit is pushed the to `main` or `stable/**` branches 
<!--end_release_notes-->
