### PR TITLE
Fix Azure support for workers (platform 1)

### DIFF
--- a/src/conf/celeryconf.py
+++ b/src/conf/celeryconf.py
@@ -1,3 +1,4 @@
+import urllib
 from src.conf.iniconf import settings
 
 #: Celery config - ignore result?
@@ -21,8 +22,8 @@ if CELERY_RESULTS_DB_BACKEND == 'db+sqlite':
 else:
     CELERY_RESULT_BACKEND = '{DB_ENGINE}://{DB_USER}:{DB_PASS}@{DB_HOST}:{DB_PORT}/{DB_NAME}'.format(
         DB_ENGINE=settings.get('celery', 'db_engine'),
-        DB_USER=settings.get('celery', 'db_user'),
-        DB_PASS=settings.get('celery', 'db_pass'),
+        DB_USER=urllib.parse.quote(settings.get('celery', 'db_user')),
+        DB_PASS=urllib.parse.quote(settings.get('celery', 'db_pass')),
         DB_HOST=settings.get('celery', 'db_host'),
         DB_PORT=settings.get('celery', 'db_port'),
         DB_NAME=settings.get('celery', 'db_name', fallback='celery'),

--- a/src/model_execution_worker/storage_manager.py
+++ b/src/model_execution_worker/storage_manager.py
@@ -130,7 +130,7 @@ class BaseStorageConnector(object):
             self.media_root,
             self._get_unique_filename(ext))
         self.logger.info('Store file: {} -> {}'.format(file_path, stored_fp))
-        return shutil.copy(file_path, stored_fp)
+        return shutil.copyfile(file_path, stored_fp)
 
     def _store_dir(self, directory_path, suffix=None, arcname=None):
         """ Compress and store a directory

--- a/src/model_execution_worker/tasks.py
+++ b/src/model_execution_worker/tasks.py
@@ -639,7 +639,7 @@ def prepare_complex_model_file_inputs(complex_model_files, run_directory):
             to_path = os.path.join(run_directory, orig_fn)
             if os.name == 'nt':
                 logging.info(f'complex_model_file: copy {from_path} to {to_path}')
-                shutil.copy(from_path, to_path)
+                shutil.copyfile(from_path, to_path)
             else:
                 logging.info(f'complex_model_file: link {from_path} to {to_path}')
                 os.symlink(from_path, to_path)


### PR DESCRIPTION
<!--start_release_notes-->
### Fix Azure support for workers (platform 1)
Two fixes for platform 1 workers (`1.15.x`, `1.23.x`, `1.27.x`, `1.28.x`) running on azure via kubernetes. 
*  CeleryDB passwords with special characters (like `#`) can crash workers because these are not escaped correctly 
* Workers fail to store results in the shared-fs file mount due to `chmod` causing an exception.  
<!--end_release_notes-->
