### PR TITLE
Always post model version info on worker startup (platform 1)

### DIFF
--- a/src/model_execution_worker/tasks.py
+++ b/src/model_execution_worker/tasks.py
@@ -188,7 +188,7 @@ def register_worker(sender, **k):
     if settings.getboolean('worker', 'DISABLE_WORKER_SETTINGS_REG', fallback=False):
         m_settings = None
         logging.info(('Worker settings registration DISABLED: to enable:\n'
-                      '  set DISABLE_WORKER_SETTINGS_REG=False in conf.ini or\n' 
+                      '  set DISABLE_WORKER_SETTINGS_REG=False in conf.ini or\n'
                       '  set the envoritment variable OASIS_DISABLE_WORKER_REG=False'))
     else:
         m_settings = get_model_settings()

--- a/src/model_execution_worker/tasks.py
+++ b/src/model_execution_worker/tasks.py
@@ -184,9 +184,10 @@ def register_worker(sender, **k):
     logging.info('Worker: SUPPLIER_ID={}, MODEL_ID={}, VERSION_ID={}'.format(m_supplier, m_name, m_id))
     logging.info('versions: {}'.format(m_version))
 
-    # Check for 'DISABLE_WORKER_REG' before sending task to API
+    # Check for 'DISABLE_WORKER_REG' and only Post version info (skip model settings)
     if settings.getboolean('worker', 'DISABLE_WORKER_REG', fallback=False):
-        logging.info(('Worker auto-registration DISABLED: to enable:\n'
+        m_settings = None
+        logging.info(('Worker auto-registration settings DISABLED: to enable:\n'
                       '  set DISABLE_WORKER_REG=False in conf.ini or\n'
                       '  set the envoritment variable OASIS_DISABLE_WORKER_REG=False'))
     else:
@@ -194,11 +195,12 @@ def register_worker(sender, **k):
         m_settings = get_model_settings()
         logging.info('settings: {}'.format(m_settings))
 
-        signature(
-            'run_register_worker',
-            args=(m_supplier, m_name, m_id, m_settings, m_version),
-            queue='celery'
-        ).delay()
+    # Send Worker Info
+    signature(
+        'run_register_worker',
+        args=(m_supplier, m_name, m_id, m_settings, m_version),
+        queue='celery'
+    ).delay()
 
     # Required ENV
     logging.info("LOCK_FILE: {}".format(settings.get('worker', 'LOCK_FILE')))

--- a/src/model_execution_worker/tasks.py
+++ b/src/model_execution_worker/tasks.py
@@ -184,23 +184,28 @@ def register_worker(sender, **k):
     logging.info('Worker: SUPPLIER_ID={}, MODEL_ID={}, VERSION_ID={}'.format(m_supplier, m_name, m_id))
     logging.info('versions: {}'.format(m_version))
 
-    # Check for 'DISABLE_WORKER_REG' and only Post version info (skip model settings)
-    if settings.getboolean('worker', 'DISABLE_WORKER_REG', fallback=False):
+    # skip adding model settings on register
+    if settings.getboolean('worker', 'DISABLE_WORKER_SETTINGS_REG', fallback=False):
         m_settings = None
-        logging.info(('Worker auto-registration settings DISABLED: to enable:\n'
-                      '  set DISABLE_WORKER_REG=False in conf.ini or\n'
+        logging.info(('Worker settings registration DISABLED: to enable:\n'
+                      '  set DISABLE_WORKER_SETTINGS_REG=False in conf.ini or\n' 
                       '  set the envoritment variable OASIS_DISABLE_WORKER_REG=False'))
     else:
-        logging.info('Auto registrating with the Oasis API:')
         m_settings = get_model_settings()
         logging.info('settings: {}'.format(m_settings))
 
     # Send Worker Info
-    signature(
-        'run_register_worker',
-        args=(m_supplier, m_name, m_id, m_settings, m_version),
-        queue='celery'
-    ).delay()
+    if settings.getboolean('worker', 'DISABLE_WORKER_REG', fallback=False):
+        logging.info(('Worker auto-registration DISABLED: to enable:\n'
+                      '  set DISABLE_WORKER_REG=False in conf.ini or\n'
+                      '  set the envoritment variable OASIS_DISABLE_WORKER_REG=False'))
+    else:
+        logging.info('Auto registrating with the Oasis API:')
+        signature(
+            'run_register_worker',
+            args=(m_supplier, m_name, m_id, m_settings, m_version),
+            queue='celery'
+        ).delay()
 
     # Required ENV
     logging.info("LOCK_FILE: {}".format(settings.get('worker', 'LOCK_FILE')))


### PR DESCRIPTION
<!--start_release_notes-->
### Always post model version info on worker startup

Added new environment variable `OASIS_DISABLE_WORKER_SETTINGS_REG={True | False}`.  When set to true a workers `model_settings.json` file is skipped when a worker connects to a queue. 

**Example:** 
```
OASIS_DISABLE_WORKER_SETTINGS_REG=True   # Only disables sending `model_settings`
OASIS_DISABLE_WORKER_REG=False           # Disables all registration (when true, nothing is sent to the API) 
```

 With the above set when a worker joins a queue it will:
-  Check the API for a model entry in the DB (supplier, name, version) 
-  If not found, creates a new model 
-  Adds the oasis component versions to the API DB 
 
 ##### Example: worker image tagged `1.28.4`
```
curl -X 'GET' 'http://localhost:8000/api/v1/models/2/versions/'
{
  "ver_ktools": "fmcalc : version: 3.11.0 - git update: ",
  "ver_oasislmf": "1.28.4",
  "ver_platform": "1.28.4"
}
```
<!--end_release_notes-->