### PR TITLE
Fixed AMQP idle channels issues 

### DIFF
--- a/src/server/oasisapi/queues/utils.py
+++ b/src/server/oasisapi/queues/utils.py
@@ -14,6 +14,7 @@ def _get_queue_consumers(queue_name):
     with celery_app_v2.pool.acquire(block=True) as conn:
         chan = conn.channel()
         name, message_count, consumers = chan.queue_declare(queue=queue_name, passive=True)
+        chan.close()
         return consumers
 
 
@@ -21,6 +22,7 @@ def _get_queue_message_count(queue_name):
     with celery_app_v2.pool.acquire(block=True) as conn:
         chan = conn.channel()
         name, message_count, consumers = chan.queue_declare(queue=queue_name, passive=True)
+        chan.close()
         return message_count
 
 


### PR DESCRIPTION
<!--start_release_notes-->
### Fixed AMQP idle channels buildup
Channel connections were not closed on exit of celery queue query, this results in a build up of idle channel connections that eventually causes https://github.com/OasisLMF/OasisPlatform/issues/953
<!--end_release_notes-->
