### PR TITLE
Split OpenAPI schemas between v1 and v2 versions of the API 

### DIFF
--- a/.github/workflows/build-schema.yml
+++ b/.github/workflows/build-schema.yml
@@ -31,7 +31,7 @@ jobs:
     if: ${{ ! failure() || ! cancelled() }}
     needs: ods_tools
     env:
-      SCHEMA_ALL: 'reports/openapi-schema-all.json'
+      SCHEMA_ALL: 'reports/openapi-schema.json'
       SCHEMA_V1: 'reports/openapi-schema-v1.json'
       SCHEMA_V2: 'reports/openapi-schema-v2.json'
     runs-on: ubuntu-22.04
@@ -59,13 +59,13 @@ jobs:
         pip uninstall ods-tools -y
         pip install ${{ needs.ods_tools.outputs.whl_filename }}
 
-    - name: Generate OpenAPI (all)
+    - name: Generate OpenAPI
       run: |
         test -d $(dirname ${{ env.SCHEMA_ALL }}) || mkdir -p $(dirname ${{ env.SCHEMA_ALL }})
         python ./manage.py migrate
         python ./manage.py generate_swagger ${{ env.SCHEMA_ALL }}
 
-    - name: Generate OpenAPI (v1)
+    - name: Generate OpenAPI (only v1)
       run: |
         test -d $(dirname ${{ env.SCHEMA_V1 }}) || mkdir -p $(dirname ${{ env.SCHEMA_V1 }})
         python ./manage.py migrate
@@ -73,7 +73,7 @@ jobs:
       env:
         OASIS_GEN_SWAGGER_V1: 1
 
-    - name: Generate OpenAPI (v2)
+    - name: Generate OpenAPI (only v2)
       run: |
         test -d $(dirname ${{ env.SCHEMA_V2 }}) || mkdir -p $(dirname ${{ env.SCHEMA_V2 }})
         python ./manage.py migrate
@@ -81,21 +81,21 @@ jobs:
       env:
         OASIS_GEN_SWAGGER_V2: 1
 
-    - name: Store OpenAPI schema (all)
+    - name: Store OpenAPI schema
       uses: actions/upload-artifact@v3
       with:
         name: openapi-schema
         path: ${{ env.SCHEMA_ALL }}
         retention-days: 3
 
-    - name: Store OpenAPI schema (v1)
+    - name: Store OpenAPI schema (only v1)
       uses: actions/upload-artifact@v3
       with:
         name: openapi-schema-v1
         path: ${{ env.SCHEMA_V1 }}
         retention-days: 3
 
-    - name: Store OpenAPI schema (v2)
+    - name: Store OpenAPI schema (only v2)
       uses: actions/upload-artifact@v3
       with:
         name: openapi-schema-v2

--- a/.github/workflows/build-schema.yml
+++ b/.github/workflows/build-schema.yml
@@ -32,8 +32,8 @@ jobs:
     needs: ods_tools
     env:
       SCHEMA_ALL: 'reports/openapi-schema.json'
-      SCHEMA_V1: 'reports/openapi-schema-v1.json'
-      SCHEMA_V2: 'reports/openapi-schema-v2.json'
+      SCHEMA_V1: 'reports/v1-openapi-schema.json'
+      SCHEMA_V2: 'reports/v2-openapi-schema.json'
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
@@ -91,14 +91,14 @@ jobs:
     - name: Store OpenAPI schema (only v1)
       uses: actions/upload-artifact@v3
       with:
-        name: openapi-schema-v1
+        name: v1-openapi-schema
         path: ${{ env.SCHEMA_V1 }}
         retention-days: 3
 
     - name: Store OpenAPI schema (only v2)
       uses: actions/upload-artifact@v3
       with:
-        name: openapi-schema-v2
+        name: v2-openapi-schema
         path: ${{ env.SCHEMA_V2 }}
         retention-days: 3
 

--- a/.github/workflows/build-schema.yml
+++ b/.github/workflows/build-schema.yml
@@ -31,7 +31,9 @@ jobs:
     if: ${{ ! failure() || ! cancelled() }}
     needs: ods_tools
     env:
-      SCHEMA: 'reports/openapi-schema.json'
+      SCHEMA_ALL: 'reports/openapi-schema-all.json'
+      SCHEMA_V1: 'reports/openapi-schema-v1.json'
+      SCHEMA_V2: 'reports/openapi-schema-v2.json'
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
@@ -57,17 +59,47 @@ jobs:
         pip uninstall ods-tools -y
         pip install ${{ needs.ods_tools.outputs.whl_filename }}
 
-    - name: Generate OpenAPI
+    - name: Generate OpenAPI (all)
       run: |
-        test -d $(dirname ${{ env.SCHEMA }}) || mkdir -p $(dirname ${{ env.SCHEMA }})
+        test -d $(dirname ${{ env.SCHEMA_ALL }}) || mkdir -p $(dirname ${{ env.SCHEMA_ALL }})
         python ./manage.py migrate
-        python ./manage.py generate_swagger ${{ env.SCHEMA }}
+        python ./manage.py generate_swagger ${{ env.SCHEMA_ALL }}
 
-    - name: Store OpenAPI schema
+    - name: Generate OpenAPI (v1)
+      run: |
+        test -d $(dirname ${{ env.SCHEMA_V1 }}) || mkdir -p $(dirname ${{ env.SCHEMA_V1 }})
+        python ./manage.py migrate
+        python ./manage.py generate_swagger ${{ env.SCHEMA_V1 }}
+      env:
+        OASIS_GEN_SWAGGER_V1: 1
+
+    - name: Generate OpenAPI (v2)
+      run: |
+        test -d $(dirname ${{ env.SCHEMA_V2 }}) || mkdir -p $(dirname ${{ env.SCHEMA_V2 }})
+        python ./manage.py migrate
+        python ./manage.py generate_swagger ${{ env.SCHEMA_V2 }}
+      env:
+        OASIS_GEN_SWAGGER_V2: 1
+
+    - name: Store OpenAPI schema (all)
       uses: actions/upload-artifact@v3
       with:
         name: openapi-schema
-        path: ${{ env.SCHEMA }}
+        path: ${{ env.SCHEMA_ALL }}
+        retention-days: 3
+
+    - name: Store OpenAPI schema (v1)
+      uses: actions/upload-artifact@v3
+      with:
+        name: openapi-schema-v1
+        path: ${{ env.SCHEMA_V1 }}
+        retention-days: 3
+
+    - name: Store OpenAPI schema (v2)
+      uses: actions/upload-artifact@v3
+      with:
+        name: openapi-schema-v2
+        path: ${{ env.SCHEMA_V2 }}
         retention-days: 3
 
     - name: Test Schema

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -367,12 +367,31 @@ jobs:
         name: openapi-schema
         path: ${{ github.workspace }}/
 
+    - name: Download API schema (v1)
+      uses: actions/download-artifact@v3
+      with:
+        name: v1-openapi-schema
+        path: ${{ github.workspace }}/
+
+    - name: Download API schema (v2)
+      uses: actions/download-artifact@v3
+      with:
+        name: v2-openapi-schema
+        path: ${{ github.workspace }}/
+
     - name: Name API schema
       id: api_schema
       run: |
         schema_filename="openapi-schema-${{ env.release_tag }}.json"
+        v1_schema_filename="v1-openapi-schema-${{ env.release_tag }}.json"
+        v2_schema_filename="v2-openapi-schema-${{ env.release_tag }}.json"
+
         mv openapi-schema.json  $schema_filename
-        echo "filename=$schema_filename" >> $GITHUB_OUTPUT
+        mv v1-openapi-schema.json  $v1_schema_filename
+        mv v2-openapi-schema.json  $v2_schema_filename
+        echo "filename_all=$schema_filename" >> $GITHUB_OUTPUT
+        echo "filename_v1=$v1_schema_filename" >> $GITHUB_OUTPUT
+        echo "filename_v2=$v2_schema_filename" >> $GITHUB_OUTPUT
 
     # --- Create Changelog --- #
     - name: Tag Release
@@ -464,17 +483,38 @@ jobs:
         prerelease: ${{ env.pre_release }}
 
     # --- Attach build assest --- #
-    - name: Upload Schema
+    - name: Upload Schema (base)
       id: upload-source-release-asset
       uses: actions/upload-release-asset@v1
       env:
         GITHUB_TOKEN: ${{ secrets.BUILD_GIT_TOKEN }}
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ${{ github.workspace }}/${{ steps.api_schema.outputs.filename }}
-        asset_name: ${{ steps.api_schema.outputs.filename }}
+        asset_path: ${{ github.workspace }}/${{ steps.api_schema.outputs.filename_all }}
+        asset_name: ${{ steps.api_schema.outputs.filename_all }}
         asset_content_type: application/json
 
+    - name: Upload Schema (v1)
+      id: upload-source-release-asset
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.BUILD_GIT_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ${{ github.workspace }}/${{ steps.api_schema.outputs.filename_v1 }}
+        asset_name: ${{ steps.api_schema.outputs.filename_v1 }}
+        asset_content_type: application/json
+
+    - name: Upload Schema (v2)
+      id: upload-source-release-asset
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.BUILD_GIT_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ${{ github.workspace }}/${{ steps.api_schema.outputs.filename_v2 }}
+        asset_name: ${{ steps.api_schema.outputs.filename_v2 }}
+        asset_content_type: application/json
     # --- Slack notify --- #
     - name: slack message vars
       id: slack_vars

--- a/src/server/oasisapi/analyses/v1_api/serializers.py
+++ b/src/server/oasisapi/analyses/v1_api/serializers.py
@@ -38,7 +38,7 @@ class AnalysisListSerializer(serializers.Serializer):
     storage_links = serializers.SerializerMethodField(read_only=True)
 
     class Meta:
-        ref_name = "v1_" + __qualname__.split('.')[0]
+        ref_name = __qualname__.split('.')[0] + 'V1'
 
     @swagger_serializer_method(serializer_or_field=serializers.URLField)
     def get_input_file(self, instance):
@@ -117,7 +117,7 @@ class AnalysisSerializer(serializers.ModelSerializer):
     ns = 'v1-analyses'
 
     class Meta:
-        ref_name = "v1_" + __qualname__.split('.')[0]
+        ref_name = __qualname__.split('.')[0] + 'V1'
         model = Analysis
         fields = (
             'created',
@@ -241,7 +241,7 @@ class AnalysisStorageSerializer(serializers.ModelSerializer):
     summary_levels_file = serializers.SerializerMethodField()
 
     class Meta:
-        ref_name = "v1_" + __qualname__.split('.')[0]
+        ref_name = __qualname__.split('.')[0] + 'V1'
         model = Analysis
         fields = (
             'settings_file',

--- a/src/server/oasisapi/analyses/v2_api/serializers.py
+++ b/src/server/oasisapi/analyses/v2_api/serializers.py
@@ -22,7 +22,6 @@ class AnalysisTaskStatusSerializer(serializers.ModelSerializer):
     error_log = serializers.SerializerMethodField()
 
     class Meta:
-        # ref_name = __qualname__.split('.')[0] + 'V2'
         model = AnalysisTaskStatus
         fields = (
             'id',
@@ -54,9 +53,6 @@ class AnalysisListSerializer(serializers.Serializer):
     """ Read Only Analyses Deserializer for efficiently returning a list of all
         Analyses from DB
     """
-    # class Meta:
-        # ref_name = __qualname__.split('.')[0] + 'V2'
-
     # model fields
     created = serializers.DateTimeField(read_only=True)
     modified = serializers.DateTimeField(read_only=True)
@@ -224,7 +220,6 @@ class AnalysisSerializer(serializers.ModelSerializer):
     status_count = serializers.SerializerMethodField(read_only=True)
 
     class Meta:
-        # ref_name = __qualname__.split('.')[0] + 'V2'
         model = Analysis
         fields = (
             'created',
@@ -409,9 +404,6 @@ class AnalysisSerializer(serializers.ModelSerializer):
 class AnalysisSerializerWebSocket(serializers.Serializer):
     """ Minimal Analysis Infomation needed to send via WebSocket
     """
-    # class Meta:
-        # ref_name = __qualname__.split('.')[0] + 'V2'
-
     # model fields
     name = serializers.CharField(read_only=True)
     id = serializers.IntegerField(read_only=True)
@@ -468,7 +460,6 @@ class AnalysisStorageSerializer(serializers.ModelSerializer):
     summary_levels_file = serializers.SerializerMethodField()
 
     class Meta:
-        # ref_name = __qualname__.split('.')[0] + 'V2'
         model = Analysis
         fields = (
             'settings_file',

--- a/src/server/oasisapi/analyses/v2_api/serializers.py
+++ b/src/server/oasisapi/analyses/v2_api/serializers.py
@@ -22,7 +22,7 @@ class AnalysisTaskStatusSerializer(serializers.ModelSerializer):
     error_log = serializers.SerializerMethodField()
 
     class Meta:
-        ref_name = "v2_" + __qualname__.split('.')[0]
+        # ref_name = __qualname__.split('.')[0] + 'V2'
         model = AnalysisTaskStatus
         fields = (
             'id',
@@ -54,8 +54,8 @@ class AnalysisListSerializer(serializers.Serializer):
     """ Read Only Analyses Deserializer for efficiently returning a list of all
         Analyses from DB
     """
-    class Meta:
-        ref_name = "v2_" + __qualname__.split('.')[0]
+    # class Meta:
+        # ref_name = __qualname__.split('.')[0] + 'V2'
 
     # model fields
     created = serializers.DateTimeField(read_only=True)
@@ -224,7 +224,7 @@ class AnalysisSerializer(serializers.ModelSerializer):
     status_count = serializers.SerializerMethodField(read_only=True)
 
     class Meta:
-        ref_name = "v2_" + __qualname__.split('.')[0]
+        # ref_name = __qualname__.split('.')[0] + 'V2'
         model = Analysis
         fields = (
             'created',
@@ -409,8 +409,8 @@ class AnalysisSerializer(serializers.ModelSerializer):
 class AnalysisSerializerWebSocket(serializers.Serializer):
     """ Minimal Analysis Infomation needed to send via WebSocket
     """
-    class Meta:
-        ref_name = "v2_" + __qualname__.split('.')[0]
+    # class Meta:
+        # ref_name = __qualname__.split('.')[0] + 'V2'
 
     # model fields
     name = serializers.CharField(read_only=True)
@@ -468,7 +468,7 @@ class AnalysisStorageSerializer(serializers.ModelSerializer):
     summary_levels_file = serializers.SerializerMethodField()
 
     class Meta:
-        ref_name = "v2_" + __qualname__.split('.')[0]
+        # ref_name = __qualname__.split('.')[0] + 'V2'
         model = Analysis
         fields = (
             'settings_file',

--- a/src/server/oasisapi/analysis_models/v1_api/serializers.py
+++ b/src/server/oasisapi/analysis_models/v1_api/serializers.py
@@ -13,7 +13,7 @@ class AnalysisModelSerializer(serializers.ModelSerializer):
     ns = 'v1-models'
 
     class Meta:
-        ref_name = "v1_" + __qualname__.split('.')[0]
+        ref_name = __qualname__.split('.')[0] + 'V1'
         model = AnalysisModel
         fields = (
             'id',
@@ -52,7 +52,7 @@ class TemplateSerializer(serializers.ModelSerializer):
     file_url = serializers.SerializerMethodField()
 
     class Meta:
-        ref_name = "v1_" + __qualname__.split('.')[0]
+        ref_name = __qualname__.split('.')[0] + 'V1'
         model = SettingsTemplate
         fields = (
             'id',
@@ -79,7 +79,7 @@ class CreateTemplateSerializer(serializers.ModelSerializer):
     analysis_id = serializers.IntegerField(required=False)
 
     class Meta:
-        ref_name = "v1_" + __qualname__.split('.')[0]
+        ref_name = __qualname__.split('.')[0] + 'V1'
         model = SettingsTemplate
         fields = (
             'id',
@@ -114,7 +114,7 @@ class CreateTemplateSerializer(serializers.ModelSerializer):
 
 class ModelVersionsSerializer(serializers.ModelSerializer):
     class Meta:
-        ref_name = "v1_" + __qualname__.split('.')[0]
+        ref_name = __qualname__.split('.')[0] + 'V1'
         model = AnalysisModel
         fields = (
             'ver_ktools',

--- a/src/server/oasisapi/analysis_models/v2_api/serializers.py
+++ b/src/server/oasisapi/analysis_models/v2_api/serializers.py
@@ -20,7 +20,7 @@ class AnalysisModelSerializer(serializers.ModelSerializer):
     namespace = 'v2-models'
 
     class Meta:
-        ref_name = "v2_" + __qualname__.split('.')[0]
+        # ref_name = __qualname__.split('.')[0] + 'V2'
         model = AnalysisModel
         fields = (
             'id',
@@ -82,7 +82,7 @@ class TemplateSerializer(serializers.ModelSerializer):
     file_url = serializers.SerializerMethodField()
 
     class Meta:
-        ref_name = "v2_" + __qualname__.split('.')[0]
+        # ref_name = __qualname__.split('.')[0] + 'V2'
         model = SettingsTemplate
         fields = (
             'id',
@@ -109,7 +109,7 @@ class CreateTemplateSerializer(serializers.ModelSerializer):
     analysis_id = serializers.IntegerField(required=False)
 
     class Meta:
-        ref_name = "v2_" + __qualname__.split('.')[0]
+        # ref_name = __qualname__.split('.')[0] + 'V2'
         model = SettingsTemplate
         fields = (
             'id',
@@ -145,7 +145,7 @@ class CreateTemplateSerializer(serializers.ModelSerializer):
 class ModelVersionsSerializer(serializers.ModelSerializer):
 
     class Meta:
-        ref_name = "v2_" + __qualname__.split('.')[0]
+        # ref_name = __qualname__.split('.')[0] + 'V2'
         model = AnalysisModel
         fields = (
             'ver_ktools',
@@ -157,7 +157,7 @@ class ModelVersionsSerializer(serializers.ModelSerializer):
 class ModelChunkingConfigSerializer(serializers.ModelSerializer):
 
     class Meta:
-        ref_name = "v2_" + __qualname__.split('.')[0]
+        # ref_name = __qualname__.split('.')[0] + 'V2'
         model = ModelChunkingOptions
         fields = (
             'lookup_strategy',
@@ -199,7 +199,7 @@ class ModelChunkingConfigSerializer(serializers.ModelSerializer):
 class ModelScalingConfigSerializer(serializers.ModelSerializer):
 
     class Meta:
-        ref_name = "v2_" + __qualname__.split('.')[0]
+        # ref_name = __qualname__.split('.')[0] + 'V2'
         model = ModelScalingOptions
         fields = (
             'scaling_strategy',

--- a/src/server/oasisapi/analysis_models/v2_api/serializers.py
+++ b/src/server/oasisapi/analysis_models/v2_api/serializers.py
@@ -20,7 +20,6 @@ class AnalysisModelSerializer(serializers.ModelSerializer):
     namespace = 'v2-models'
 
     class Meta:
-        # ref_name = __qualname__.split('.')[0] + 'V2'
         model = AnalysisModel
         fields = (
             'id',
@@ -82,7 +81,6 @@ class TemplateSerializer(serializers.ModelSerializer):
     file_url = serializers.SerializerMethodField()
 
     class Meta:
-        # ref_name = __qualname__.split('.')[0] + 'V2'
         model = SettingsTemplate
         fields = (
             'id',
@@ -109,7 +107,6 @@ class CreateTemplateSerializer(serializers.ModelSerializer):
     analysis_id = serializers.IntegerField(required=False)
 
     class Meta:
-        # ref_name = __qualname__.split('.')[0] + 'V2'
         model = SettingsTemplate
         fields = (
             'id',
@@ -145,7 +142,6 @@ class CreateTemplateSerializer(serializers.ModelSerializer):
 class ModelVersionsSerializer(serializers.ModelSerializer):
 
     class Meta:
-        # ref_name = __qualname__.split('.')[0] + 'V2'
         model = AnalysisModel
         fields = (
             'ver_ktools',
@@ -157,7 +153,6 @@ class ModelVersionsSerializer(serializers.ModelSerializer):
 class ModelChunkingConfigSerializer(serializers.ModelSerializer):
 
     class Meta:
-        # ref_name = __qualname__.split('.')[0] + 'V2'
         model = ModelChunkingOptions
         fields = (
             'lookup_strategy',
@@ -199,7 +194,6 @@ class ModelChunkingConfigSerializer(serializers.ModelSerializer):
 class ModelScalingConfigSerializer(serializers.ModelSerializer):
 
     class Meta:
-        # ref_name = __qualname__.split('.')[0] + 'V2'
         model = ModelScalingOptions
         fields = (
             'scaling_strategy',

--- a/src/server/oasisapi/data_files/v1_api/serializers.py
+++ b/src/server/oasisapi/data_files/v1_api/serializers.py
@@ -22,7 +22,7 @@ class DataFileListSerializer(serializers.Serializer):
     content_type = serializers.SerializerMethodField(read_only=True)
 
     class Meta:
-        ref_name = "v1_" + __qualname__.split('.')[0]
+        ref_name = __qualname__.split('.')[0] + 'V1'
 
     @swagger_serializer_method(serializer_or_field=serializers.URLField)
     def get_file(self, instance):
@@ -46,7 +46,7 @@ class DataFileSerializer(serializers.ModelSerializer):
     content_type = serializers.SerializerMethodField()
 
     class Meta:
-        ref_name = "v1_" + __qualname__.split('.')[0]
+        ref_name = __qualname__.split('.')[0] + 'V1'
         model = DataFile
         fields = (
             'id',

--- a/src/server/oasisapi/data_files/v2_api/serializers.py
+++ b/src/server/oasisapi/data_files/v2_api/serializers.py
@@ -24,8 +24,8 @@ class DataFileListSerializer(serializers.Serializer):
     stored = serializers.SerializerMethodField(read_only=True)
     content_type = serializers.SerializerMethodField(read_only=True)
 
-    class Meta:
-        ref_name = "v2_" + __qualname__.split('.')[0]
+    # class Meta:
+    #   ref_name = __qualname__.split('.')[0] + 'V2'
 
     @swagger_serializer_method(serializer_or_field=serializers.URLField)
     def get_file(self, instance):
@@ -50,7 +50,7 @@ class DataFileSerializer(serializers.ModelSerializer):
     groups = serializers.SlugRelatedField(many=True, read_only=False, slug_field='name', required=False, queryset=Group.objects.all())
 
     class Meta:
-        ref_name = "v2_" + __qualname__.split('.')[0]
+        # ref_name = __qualname__.split('.')[0] + 'V2'
         model = DataFile
         fields = (
             'id',

--- a/src/server/oasisapi/data_files/v2_api/serializers.py
+++ b/src/server/oasisapi/data_files/v2_api/serializers.py
@@ -24,9 +24,6 @@ class DataFileListSerializer(serializers.Serializer):
     stored = serializers.SerializerMethodField(read_only=True)
     content_type = serializers.SerializerMethodField(read_only=True)
 
-    # class Meta:
-    #   ref_name = __qualname__.split('.')[0] + 'V2'
-
     @swagger_serializer_method(serializer_or_field=serializers.URLField)
     def get_file(self, instance):
         request = self.context.get('request')
@@ -50,7 +47,6 @@ class DataFileSerializer(serializers.ModelSerializer):
     groups = serializers.SlugRelatedField(many=True, read_only=False, slug_field='name', required=False, queryset=Group.objects.all())
 
     class Meta:
-        # ref_name = __qualname__.split('.')[0] + 'V2'
         model = DataFile
         fields = (
             'id',

--- a/src/server/oasisapi/portfolios/v1_api/serializers.py
+++ b/src/server/oasisapi/portfolios/v1_api/serializers.py
@@ -31,7 +31,7 @@ class PortfolioListSerializer(serializers.Serializer):
         Portfolios in DB
     """
     class Meta:
-        ref_name = "v1_" + __qualname__.split('.')[0]
+        ref_name = __qualname__.split('.')[0] + 'V1'
 
     id = serializers.IntegerField(read_only=True)
     name = serializers.CharField(read_only=True)
@@ -102,7 +102,7 @@ class PortfolioSerializer(serializers.ModelSerializer):
     storage_links = serializers.SerializerMethodField()
 
     class Meta:
-        ref_name = "v1_" + __qualname__.split('.')[0]
+        ref_name = __qualname__.split('.')[0] + 'V1'
         model = Portfolio
         fields = (
             'id',
@@ -183,7 +183,7 @@ class PortfolioStorageSerializer(serializers.ModelSerializer):
     reinsurance_scope_file = serializers.SerializerMethodField()
 
     class Meta:
-        ref_name = "v1_" + __qualname__.split('.')[0]
+        ref_name = __qualname__.split('.')[0] + 'V1'
         model = Portfolio
         fields = (
             'location_file',
@@ -378,7 +378,7 @@ class PortfolioStorageSerializer(serializers.ModelSerializer):
 
 class CreateAnalysisSerializer(AnalysisSerializer):
     class Meta(AnalysisSerializer.Meta):
-        ref_name = "v1_" + __qualname__.split('.')[0]
+        ref_name = __qualname__.split('.')[0] + 'V1'
         fields = ['name', 'model']
 
     def __init__(self, portfolio=None, *args, **kwargs):
@@ -406,7 +406,7 @@ class PortfolioValidationSerializer(serializers.ModelSerializer):
     reinsurance_scope_validated = serializers.SerializerMethodField()
 
     class Meta:
-        ref_name = "v1_" + __qualname__.split('.')[0]
+        ref_name = __qualname__.split('.')[0] + 'V1'
         model = Portfolio
         fields = (
             'location_validated',

--- a/src/server/oasisapi/portfolios/v2_api/serializers.py
+++ b/src/server/oasisapi/portfolios/v2_api/serializers.py
@@ -42,8 +42,8 @@ class PortfolioListSerializer(serializers.Serializer):
     storage_links = serializers.SerializerMethodField(read_only=True)
     groups = serializers.SlugRelatedField(many=True, read_only=True, slug_field='name')
 
-    class Meta:
-        ref_name = "v2_" + __qualname__.split('.')[0]
+    # class Meta:
+        # ref_name = __qualname__.split('.')[0] + 'V2'
 
     @swagger_serializer_method(serializer_or_field=serializers.URLField)
     def get_storage_links(self, instance):
@@ -105,7 +105,7 @@ class PortfolioSerializer(serializers.ModelSerializer):
     groups = serializers.SlugRelatedField(many=True, read_only=False, slug_field='name', required=False, queryset=Group.objects.all())
 
     class Meta:
-        ref_name = "v2_" + __qualname__.split('.')[0]
+        # ref_name = __qualname__.split('.')[0] + 'V2'
         model = Portfolio
         fields = (
             'id',
@@ -200,7 +200,7 @@ class PortfolioStorageSerializer(serializers.ModelSerializer):
     reinsurance_scope_file = serializers.SerializerMethodField()
 
     class Meta:
-        ref_name = "v2_" + __qualname__.split('.')[0]
+        # ref_name = __qualname__.split('.')[0] + 'V2'
         model = Portfolio
         fields = (
             'location_file',
@@ -407,7 +407,7 @@ class PortfolioStorageSerializer(serializers.ModelSerializer):
 
 class CreateAnalysisSerializer(AnalysisSerializer):
     class Meta(AnalysisSerializer.Meta):
-        ref_name = "v2_" + __qualname__.split('.')[0]
+        # ref_name = __qualname__.split('.')[0] + 'V2'
         fields = ['name', 'model', 'groups']
 
     def __init__(self, portfolio=None, *args, **kwargs):
@@ -438,7 +438,7 @@ class PortfolioValidationSerializer(serializers.ModelSerializer):
     reinsurance_scope_validated = serializers.SerializerMethodField()
 
     class Meta:
-        ref_name = "v2_" + __qualname__.split('.')[0]
+        # ref_name = __qualname__.split('.')[0] + 'V2'
         model = Portfolio
         fields = (
             'location_validated',

--- a/src/server/oasisapi/portfolios/v2_api/serializers.py
+++ b/src/server/oasisapi/portfolios/v2_api/serializers.py
@@ -42,9 +42,6 @@ class PortfolioListSerializer(serializers.Serializer):
     storage_links = serializers.SerializerMethodField(read_only=True)
     groups = serializers.SlugRelatedField(many=True, read_only=True, slug_field='name')
 
-    # class Meta:
-        # ref_name = __qualname__.split('.')[0] + 'V2'
-
     @swagger_serializer_method(serializer_or_field=serializers.URLField)
     def get_storage_links(self, instance):
         request = self.context.get('request')
@@ -105,7 +102,6 @@ class PortfolioSerializer(serializers.ModelSerializer):
     groups = serializers.SlugRelatedField(many=True, read_only=False, slug_field='name', required=False, queryset=Group.objects.all())
 
     class Meta:
-        # ref_name = __qualname__.split('.')[0] + 'V2'
         model = Portfolio
         fields = (
             'id',
@@ -200,7 +196,6 @@ class PortfolioStorageSerializer(serializers.ModelSerializer):
     reinsurance_scope_file = serializers.SerializerMethodField()
 
     class Meta:
-        # ref_name = __qualname__.split('.')[0] + 'V2'
         model = Portfolio
         fields = (
             'location_file',
@@ -407,7 +402,6 @@ class PortfolioStorageSerializer(serializers.ModelSerializer):
 
 class CreateAnalysisSerializer(AnalysisSerializer):
     class Meta(AnalysisSerializer.Meta):
-        # ref_name = __qualname__.split('.')[0] + 'V2'
         fields = ['name', 'model', 'groups']
 
     def __init__(self, portfolio=None, *args, **kwargs):
@@ -438,7 +432,6 @@ class PortfolioValidationSerializer(serializers.ModelSerializer):
     reinsurance_scope_validated = serializers.SerializerMethodField()
 
     class Meta:
-        # ref_name = __qualname__.split('.')[0] + 'V2'
         model = Portfolio
         fields = (
             'location_validated',

--- a/src/server/oasisapi/queues/serializers.py
+++ b/src/server/oasisapi/queues/serializers.py
@@ -15,9 +15,6 @@ class QueueSerializer(serializers.Serializer):
     worker_count = serializers.IntegerField()
     models = serializers.SerializerMethodField()
 
-    # class Meta:
-        # ref_name = __qualname__.split('.')[0] + 'V2'
-
     @swagger_serializer_method(serializer_or_field=AnalysisModelSerializer(many=True))
     def get_models(self, instance, *args, **kwargs):
         queue_name = instance['name'].removesuffix('-v2')
@@ -28,9 +25,6 @@ class QueueSerializer(serializers.Serializer):
 class WebsocketAnalysesSerializer(serializers.Serializer):
     analysis = serializers.SerializerMethodField()
     updated_tasks = serializers.SerializerMethodField()
-
-    # class Meta:
-        # ref_name = __qualname__.split('.')[0] + 'V2'
 
     @swagger_serializer_method(serializer_or_field=AnalysisSerializerWebSocket())
     def get_analysis(self, instance, *args, **kwargs):
@@ -44,9 +38,6 @@ class WebsocketAnalysesSerializer(serializers.Serializer):
 class WebsocketContentSerializer(serializers.Serializer):
     queue = serializers.SerializerMethodField()
     analyses = serializers.SerializerMethodField()
-
-    # class Meta:
-        # ref_name = __qualname__.split('.')[0] + 'V2'
 
     @swagger_serializer_method(serializer_or_field=QueueSerializer)
     def get_queue(self, instance, *args, **kwargs):
@@ -65,9 +56,6 @@ class WebsocketSerializer(serializers.Serializer):
     type = serializers.CharField()
     status = serializers.CharField()
     content = serializers.SerializerMethodField()
-
-    # class Meta:
-        # ref_name = __qualname__.split('.')[0] + 'V2'
 
     @swagger_serializer_method(serializer_or_field=WebsocketContentSerializer(many=True))
     def get_content(self, instance, *args, **kwargs):

--- a/src/server/oasisapi/queues/serializers.py
+++ b/src/server/oasisapi/queues/serializers.py
@@ -15,8 +15,8 @@ class QueueSerializer(serializers.Serializer):
     worker_count = serializers.IntegerField()
     models = serializers.SerializerMethodField()
 
-    class Meta:
-        ref_name = "v2_" + __qualname__.split('.')[0]
+    # class Meta:
+        # ref_name = __qualname__.split('.')[0] + 'V2'
 
     @swagger_serializer_method(serializer_or_field=AnalysisModelSerializer(many=True))
     def get_models(self, instance, *args, **kwargs):
@@ -29,8 +29,8 @@ class WebsocketAnalysesSerializer(serializers.Serializer):
     analysis = serializers.SerializerMethodField()
     updated_tasks = serializers.SerializerMethodField()
 
-    class Meta:
-        ref_name = "v2_" + __qualname__.split('.')[0]
+    # class Meta:
+        # ref_name = __qualname__.split('.')[0] + 'V2'
 
     @swagger_serializer_method(serializer_or_field=AnalysisSerializerWebSocket())
     def get_analysis(self, instance, *args, **kwargs):
@@ -45,8 +45,8 @@ class WebsocketContentSerializer(serializers.Serializer):
     queue = serializers.SerializerMethodField()
     analyses = serializers.SerializerMethodField()
 
-    class Meta:
-        ref_name = "v2_" + __qualname__.split('.')[0]
+    # class Meta:
+        # ref_name = __qualname__.split('.')[0] + 'V2'
 
     @swagger_serializer_method(serializer_or_field=QueueSerializer)
     def get_queue(self, instance, *args, **kwargs):
@@ -66,8 +66,8 @@ class WebsocketSerializer(serializers.Serializer):
     status = serializers.CharField()
     content = serializers.SerializerMethodField()
 
-    class Meta:
-        ref_name = "v2_" + __qualname__.split('.')[0]
+    # class Meta:
+        # ref_name = __qualname__.split('.')[0] + 'V2'
 
     @swagger_serializer_method(serializer_or_field=WebsocketContentSerializer(many=True))
     def get_content(self, instance, *args, **kwargs):

--- a/src/server/oasisapi/schemas/serializers.py
+++ b/src/server/oasisapi/schemas/serializers.py
@@ -125,8 +125,8 @@ class TaskCountSerializer(serializers.Serializer):
     CANCELLED = serializers.IntegerField()
     ERROR = serializers.IntegerField()
 
-    class Meta:
-        ref_name = "v2_" + __qualname__.split('.')[0]
+    # class Meta:
+    #   ref_name = __qualname__.split('.')[0] + 'V2'
 
     def create(self, validated_data):
         raise NotImplementedError()

--- a/src/server/oasisapi/schemas/serializers.py
+++ b/src/server/oasisapi/schemas/serializers.py
@@ -125,9 +125,6 @@ class TaskCountSerializer(serializers.Serializer):
     CANCELLED = serializers.IntegerField()
     ERROR = serializers.IntegerField()
 
-    # class Meta:
-    #   ref_name = __qualname__.split('.')[0] + 'V2'
-
     def create(self, validated_data):
         raise NotImplementedError()
 

--- a/src/server/oasisapi/settings/base.py
+++ b/src/server/oasisapi/settings/base.py
@@ -79,12 +79,6 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
 
-    #    'django_extensions',
-    'django_filters',
-    'rest_framework',
-    'drf_yasg',
-    'channels',
-    'storages',
 
     'src.server.oasisapi.oidc',
     'src.server.oasisapi.files',
@@ -96,6 +90,15 @@ INSTALLED_APPS = [
     'src.server.oasisapi.info',
     'src.server.oasisapi.queues',
     'django_cleanup.apps.CleanupConfig',
+
+
+    #    'django_extensions',
+    'django_filters',
+    'rest_framework',
+    'drf_yasg',
+    'channels',
+    'storages',
+
 
 ]
 
@@ -176,6 +179,8 @@ REST_FRAMEWORK = {
     ),
     'DATETIME_FORMAT': '%Y-%m-%dT%H:%M:%S.%fZ',
     'DEFAULT_VERSIONING_CLASS': 'rest_framework.versioning.NamespaceVersioning',
+#    'DEFAULT_VERSION': 'v2',
+    'ALLOWED_VERSIONS': ['v1', 'v2'],
 }
 
 # Password validation

--- a/src/server/oasisapi/settings/base.py
+++ b/src/server/oasisapi/settings/base.py
@@ -192,8 +192,6 @@ REST_FRAMEWORK = {
     ),
     'DATETIME_FORMAT': '%Y-%m-%dT%H:%M:%S.%fZ',
     'DEFAULT_VERSIONING_CLASS': 'rest_framework.versioning.NamespaceVersioning',
-#    'DEFAULT_VERSION': 'v2',
-    'ALLOWED_VERSIONS': ['v1', 'v2'],
 }
 
 # Password validation
@@ -222,9 +220,6 @@ if API_AUTH_TYPE == 'keycloak':
 
     # No need to verify our internal self signed keycloak certificate
     OIDC_VERIFY_SSL = False
-
-
-
 
     SWAGGER_SETTINGS = {
         'DEFAULT_GENERATOR_CLASS': DEFAULT_GENERATOR_CLASS,

--- a/src/server/oasisapi/settings/base.py
+++ b/src/server/oasisapi/settings/base.py
@@ -22,6 +22,7 @@ from ....conf import iniconf  # noqa
 from ....common.shared import set_aws_log_level, set_azure_log_level
 from ....conf.base import *
 
+
 IN_TEST = 'test' in sys.argv
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
@@ -188,8 +189,12 @@ REST_FRAMEWORK = {
 
 AUTHENTICATION_BACKENDS = iniconf.settings.get('server', 'auth_backends', fallback='django.contrib.auth.backends.ModelBackend').split(',')
 AUTH_PASSWORD_VALIDATORS = []
-
 API_AUTH_TYPE = iniconf.settings.get('server', 'API_AUTH_TYPE', fallback='')
+
+
+DEFAULT_GENERATOR_CLASS = 'drf_yasg.generators.OpenAPISchemaGenerator'          # Generate All 
+DEFAULT_GENERATOR_CLASS = 'src.server.oasisapi.swagger.CustomGeneratorClassV1'  # generate only V1 endpoints
+DEFAULT_GENERATOR_CLASS = 'src.server.oasisapi.swagger.CustomGeneratorClassV2'  # generate only V2 endpoints
 
 if API_AUTH_TYPE == 'keycloak':
 
@@ -210,7 +215,11 @@ if API_AUTH_TYPE == 'keycloak':
     # No need to verify our internal self signed keycloak certificate
     OIDC_VERIFY_SSL = False
 
+ 
+
+
     SWAGGER_SETTINGS = {
+        'DEFAULT_GENERATOR_CLASS': DEFAULT_GENERATOR_CLASS,
         'USE_SESSION_AUTH': False,
         'SECURITY_DEFINITIONS': {
             "keycloak": {
@@ -237,6 +246,7 @@ else:
     }
 
     SWAGGER_SETTINGS = {
+        'DEFAULT_GENERATOR_CLASS': DEFAULT_GENERATOR_CLASS,
         'DEFAULT_INFO': 'src.server.oasisapi.urls.api_info',
         'LOGIN_URL': reverse_lazy('rest_framework:login'),
         'LOGOUT_URL': reverse_lazy('rest_framework:logout'),

--- a/src/server/oasisapi/settings/base.py
+++ b/src/server/oasisapi/settings/base.py
@@ -34,6 +34,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 IS_UNITTEST = sys.argv[0].endswith('pytest')
 IS_TESTSERVER = len(sys.argv) >= 2 and sys.argv[1] == 'runserver'
+IS_SWAGGER_GEN = len(sys.argv) >= 2 and sys.argv[1] == 'generate_swagger'
 
 if IS_UNITTEST or IS_TESTSERVER:
     # Always set Debug mode when in dev environment
@@ -49,6 +50,17 @@ else:
     DEBUG_TOOLBAR = iniconf.settings.getboolean('server', 'debug_toolbar', fallback=False)
     URL_SUB_PATH = iniconf.settings.getboolean('server', 'URL_SUB_PATH', fallback=True)
     CONSOLE_DEBUG = False
+
+
+# Generate All
+DEFAULT_GENERATOR_CLASS = 'drf_yasg.generators.OpenAPISchemaGenerator'          # Generate All
+if IS_SWAGGER_GEN:
+    # generate only V1 endpoints
+    if iniconf.settings.getboolean('server', 'GEN_SWAGGER_V1', fallback=False):
+        DEFAULT_GENERATOR_CLASS = 'src.server.oasisapi.swagger.CustomGeneratorClassV1'
+    # generate only V2 endpoints
+    if iniconf.settings.getboolean('server', 'GEN_SWAGGER_V2', fallback=False):
+        DEFAULT_GENERATOR_CLASS = 'src.server.oasisapi.swagger.CustomGeneratorClassV2'
 
 # Django 3.2 - the default pri-key field changed to 'BigAutoField.',
 # https://docs.djangoproject.com/en/3.2/releases/3.2/#customizing-type-of-auto-created-primary-keys
@@ -192,10 +204,6 @@ AUTH_PASSWORD_VALIDATORS = []
 API_AUTH_TYPE = iniconf.settings.get('server', 'API_AUTH_TYPE', fallback='')
 
 
-DEFAULT_GENERATOR_CLASS = 'drf_yasg.generators.OpenAPISchemaGenerator'          # Generate All 
-DEFAULT_GENERATOR_CLASS = 'src.server.oasisapi.swagger.CustomGeneratorClassV1'  # generate only V1 endpoints
-DEFAULT_GENERATOR_CLASS = 'src.server.oasisapi.swagger.CustomGeneratorClassV2'  # generate only V2 endpoints
-
 if API_AUTH_TYPE == 'keycloak':
 
     INSTALLED_APPS += (
@@ -215,7 +223,7 @@ if API_AUTH_TYPE == 'keycloak':
     # No need to verify our internal self signed keycloak certificate
     OIDC_VERIFY_SSL = False
 
- 
+
 
 
     SWAGGER_SETTINGS = {

--- a/src/server/oasisapi/swagger.py
+++ b/src/server/oasisapi/swagger.py
@@ -1,8 +1,7 @@
-__all__ = [                                                                                                                    
+__all__ = [
     'CustomGeneratorClassV1',
     'CustomGeneratorClassV2',
-]      
-
+]
 
 from drf_yasg.generators import OpenAPISchemaGenerator
 from django.conf.urls import include, url
@@ -29,19 +28,20 @@ api_v2_urlpatterns = [
 class CustomGeneratorClassV1(OpenAPISchemaGenerator):
     def __init__(self, info, version='', url=None, patterns=None, urlconf=None):
         super().__init__(
-            info=info, 
-            version='v1', 
-            url=url, 
-            patterns=api_v1_urlpatterns, 
+            info=info,
+            version='v1',
+            url=url,
+            patterns=api_v1_urlpatterns,
             urlconf=urlconf
         )
+
 
 class CustomGeneratorClassV2(OpenAPISchemaGenerator):
     def __init__(self, info, version='', url=None, patterns=None, urlconf=None):
         super().__init__(
-            info=info, 
-            version='v2', 
-            url=url, 
-            patterns=api_v2_urlpatterns, 
+            info=info,
+            version='v2',
+            url=url,
+            patterns=api_v2_urlpatterns,
             urlconf=urlconf
         )

--- a/src/server/oasisapi/swagger.py
+++ b/src/server/oasisapi/swagger.py
@@ -1,0 +1,47 @@
+__all__ = [                                                                                                                    
+    'CustomGeneratorClassV1',
+    'CustomGeneratorClassV2',
+]      
+
+
+from drf_yasg.generators import OpenAPISchemaGenerator
+from django.conf.urls import include, url
+
+
+# API v1 Routes
+api_v1_urlpatterns = [
+    url(r'^v1/', include('src.server.oasisapi.analysis_models.v1_api.urls', namespace='v1-models')),
+    url(r'^v1/', include('src.server.oasisapi.portfolios.v1_api.urls', namespace='v1-portfolios')),
+    url(r'^v1/', include('src.server.oasisapi.analyses.v1_api.urls', namespace='v1-analyses')),
+    url(r'^v1/', include('src.server.oasisapi.data_files.v1_api.urls', namespace='v1-files')),
+]
+
+# API v2 Routes
+api_v2_urlpatterns = [
+    url(r'^v2/', include('src.server.oasisapi.analysis_models.v2_api.urls', namespace='v2-models')),
+    url(r'^v2/', include('src.server.oasisapi.analyses.v2_api.urls', namespace='v2-analyses')),
+    url(r'^v2/', include('src.server.oasisapi.portfolios.v2_api.urls', namespace='v2-portfolios')),
+    url(r'^v2/', include('src.server.oasisapi.data_files.v2_api.urls', namespace='v2-files')),
+    url(r'^v2/', include('src.server.oasisapi.queues.urls', namespace='v2-queues')),
+]
+
+
+class CustomGeneratorClassV1(OpenAPISchemaGenerator):
+    def __init__(self, info, version='', url=None, patterns=None, urlconf=None):
+        super().__init__(
+            info=info, 
+            version='v1', 
+            url=url, 
+            patterns=api_v1_urlpatterns, 
+            urlconf=urlconf
+        )
+
+class CustomGeneratorClassV2(OpenAPISchemaGenerator):
+    def __init__(self, info, version='', url=None, patterns=None, urlconf=None):
+        super().__init__(
+            info=info, 
+            version='v2', 
+            url=url, 
+            patterns=api_v2_urlpatterns, 
+            urlconf=urlconf
+        )

--- a/src/server/oasisapi/urls.py
+++ b/src/server/oasisapi/urls.py
@@ -4,7 +4,13 @@ from django.conf.urls.static import static
 from drf_yasg import openapi
 from drf_yasg.views import get_schema_view
 from rest_framework import permissions
-# from rest_framework_nested import routers
+
+from .swagger import (
+    api_v1_urlpatterns, 
+    api_v2_urlpatterns,
+    CustomGeneratorClassV1,
+    CustomGeneratorClassV2,
+)    
 
 if settings.DEBUG_TOOLBAR:
     from django.urls import path
@@ -15,6 +21,9 @@ api_info_description = """
 # Workflow
 The general workflow is as follows
 """
+
+
+
 
 if settings.API_AUTH_TYPE == 'keycloak':
     api_info_description += """
@@ -51,37 +60,11 @@ api_info = openapi.Info(
 )
 
 
-from django.views.generic import TemplateView
-import json
-
-from drf_yasg.generators import OpenAPISchemaGenerator
-
-
-# API v1 Routes
-api_v1_urlpatterns = [
-    url(r'^v1/', include('src.server.oasisapi.analysis_models.v1_api.urls', namespace='v1-models')),
-    url(r'^v1/', include('src.server.oasisapi.portfolios.v1_api.urls', namespace='v1-portfolios')),
-    url(r'^v1/', include('src.server.oasisapi.analyses.v1_api.urls', namespace='v1-analyses')),
-    url(r'^v1/', include('src.server.oasisapi.data_files.v1_api.urls', namespace='v1-files')),
-]
-
-# API v2 Routes
-if not settings.DISABLE_V2_API:
-    api_v2_urlpatterns = [
-        url(r'^v2/', include('src.server.oasisapi.analysis_models.v2_api.urls', namespace='v2-models')),
-        url(r'^v2/', include('src.server.oasisapi.analyses.v2_api.urls', namespace='v2-analyses')),
-        url(r'^v2/', include('src.server.oasisapi.portfolios.v2_api.urls', namespace='v2-portfolios')),
-        url(r'^v2/', include('src.server.oasisapi.data_files.v2_api.urls', namespace='v2-files')),
-        url(r'^v2/', include('src.server.oasisapi.queues.urls', namespace='v2-queues')),
-    ]
-
-
 schema_view = get_schema_view(
     api_info,
     public=True,
     permission_classes=(permissions.AllowAny,),
 )
-
 
 schema_view_v1 = get_schema_view(
     api_info,
@@ -108,8 +91,8 @@ api_urlpatterns = [
     url(r'^', include('src.server.oasisapi.base_urls')),
 ]
 api_urlpatterns += api_v1_urlpatterns
-api_urlpatterns += api_v2_urlpatterns
-
+if not settings.DISABLE_V2_API:
+    api_urlpatterns += api_v2_urlpatterns
 
 urlpatterns = static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 if settings.URL_SUB_PATH:

--- a/src/server/oasisapi/urls.py
+++ b/src/server/oasisapi/urls.py
@@ -6,11 +6,11 @@ from drf_yasg.views import get_schema_view
 from rest_framework import permissions
 
 from .swagger import (
-    api_v1_urlpatterns, 
+    api_v1_urlpatterns,
     api_v2_urlpatterns,
     CustomGeneratorClassV1,
     CustomGeneratorClassV2,
-)    
+)
 
 if settings.DEBUG_TOOLBAR:
     from django.urls import path
@@ -21,9 +21,6 @@ api_info_description = """
 # Workflow
 The general workflow is as follows
 """
-
-
-
 
 if settings.API_AUTH_TYPE == 'keycloak':
     api_info_description += """
@@ -58,36 +55,35 @@ api_info = openapi.Info(
     default_version='v2',
     description=api_info_description,
 )
-
-
-schema_view = get_schema_view(
+schema_view_all = get_schema_view(
     api_info,
     public=True,
     permission_classes=(permissions.AllowAny,),
 )
-
 schema_view_v1 = get_schema_view(
     api_info,
     public=True,
     permission_classes=(permissions.AllowAny,),
-    patterns=api_v1_urlpatterns,
+    generator_class=CustomGeneratorClassV1,
 )
 schema_view_v2 = get_schema_view(
     api_info,
     public=True,
     permission_classes=(permissions.AllowAny,),
-    patterns=api_v2_urlpatterns,
+    generator_class=CustomGeneratorClassV2,
 )
 
-
-# Base Routes (no version)
 api_urlpatterns = [
-    url(r'^(?P<format>\.json|\.yaml)$', schema_view_v1.without_ui(cache_timeout=0), name='schema-json-v1'),
-    #url(r'^(?P<format>\.json|\.yaml)$', schema_view.without_ui(cache_timeout=0), name='schema-json'),
-    url(r'^$', schema_view.with_ui('swagger', cache_timeout=0), name='schema-ui'),
-    url(r'^v1/$', schema_view_v1.with_ui('swagger', cache_timeout=0), name='schema-ui'),
-    url(r'^v2/$', schema_view_v2.with_ui('swagger', cache_timeout=0), name='schema-ui'),
-    #path(r'^$', TemplateView.as_view(template_name='swagger_ui_custom.html'), name='swagger-ui'),
+    # Main Swagger page
+    url(r'^(?P<format>\.json|\.yaml)$', schema_view_all.without_ui(cache_timeout=0), name='schema-json'),
+    url(r'^$', schema_view_all.with_ui('swagger', cache_timeout=0), name='schema-ui'),
+    # V1 only swagger endpoints
+    url(r'^v1/$', schema_view_v1.with_ui('swagger', cache_timeout=0), name='schema-ui-v1'),
+    url(r'^v1/(?P<format>\.json|\.yaml)$', schema_view_v1.without_ui(cache_timeout=0), name='schema-json'),
+    # V2 only swagger endpoints
+    url(r'^v2/$', schema_view_v2.with_ui('swagger', cache_timeout=0), name='schema-ui-v2'),
+    url(r'^v2/(?P<format>\.json|\.yaml)$', schema_view_v2.without_ui(cache_timeout=0), name='schema-json'),
+    # basic urls (auth, server info)
     url(r'^', include('src.server.oasisapi.base_urls')),
 ]
 api_urlpatterns += api_v1_urlpatterns


### PR DESCRIPTION
<!--start_release_notes-->
### Split OpenAPI schemas between v1 and v2 versions of the API
* Added nested swagger pages, this clears up the automatic tagging in DRF-YASG, endpoints listed in the version specific specifications are tagged as `[analyses, analysis-task-statuses, data_files, models, portfolios ..]`. However the main specification is still tags as `[v1, v2]`
 
  - `http://<domain>/`, main OpenAPI specification for **API** (all endpoints shown) 
  - `http://<domain>/v1/`, OpenAPI specification for **v1** endpoints 
  - `http://<domain>/v2/`  OpenAPI specification for **v2** endpoints 
  
* The new specification files are built via GitHub actions and attached as assets to each release. 

* Renamed serializer `ref_names`. Any clashing names are suffixed with **V1**, for example, the analysis return for the `/v1/analyses/` endpoint is now **AnalysisSerializerV1**, while `/v2/analyses/` has been reverted back to **AnalysisSerializer**
<!--end_release_notes-->


#### Example specification files:  
- [openapi-schema.json](https://github.com/OasisLMF/OasisPlatform/files/14084506/openapi-schema.json)
- [openapi-schema-v1.json](https://github.com/OasisLMF/OasisPlatform/files/14084508/openapi-schema-v1.json)
- [openapi-schema-v2.json](https://github.com/OasisLMF/OasisPlatform/files/14084509/openapi-schema-v2.json)