### PR TITLE
Remove pip from 2nd stage server build

### DIFF
--- a/Dockerfile.api_server
+++ b/Dockerfile.api_server
@@ -20,7 +20,7 @@ USER server
 FROM ubuntu:22.04
 RUN apt-get update \
  && apt-get upgrade -y \
- && apt-get install -y --no-install-recommends sudo python3 python3-pip curl libmariadbclient-dev-compat \
+ && apt-get install -y --no-install-recommends sudo python3 python3-pkg-resources curl libmariadbclient-dev-compat \
  && rm -rf /var/lib/apt/lists/
 
 RUN adduser --home /home/server --shell /bin/bash --disabled-password --gecos "" server


### PR DESCRIPTION
<!--start_release_notes-->
### Remove pip from 2nd stage server build
* Fix https://github.com/OasisLMF/OasisPlatform/issues/961
<!--end_release_notes-->