### PR TITLE
Fix broken swagger calls when SUB_PATH_URL=True 

### DIFF
--- a/src/server/oasisapi/swagger.py
+++ b/src/server/oasisapi/swagger.py
@@ -5,6 +5,7 @@ __all__ = [
 
 from drf_yasg.generators import OpenAPISchemaGenerator
 from django.conf.urls import include, url
+from django.conf import settings
 
 
 # API v1 Routes
@@ -24,6 +25,13 @@ api_v2_urlpatterns = [
     url(r'^v2/', include('src.server.oasisapi.queues.urls', namespace='v2-queues')),
 ]
 
+if settings.URL_SUB_PATH:
+    swagger_v1_urlpatterns = [url(r'^api/', include(api_v1_urlpatterns))]
+    swagger_v2_urlpatterns = [url(r'^api/', include(api_v2_urlpatterns))]
+else:
+    swagger_v1_urlpatterns = api_v1_urlpatterns
+    swagger_v2_urlpatterns = api_v2_urlpatterns
+
 
 class CustomGeneratorClassV1(OpenAPISchemaGenerator):
     def __init__(self, info, version='', url=None, patterns=None, urlconf=None):
@@ -31,7 +39,7 @@ class CustomGeneratorClassV1(OpenAPISchemaGenerator):
             info=info,
             version='v1',
             url=url,
-            patterns=api_v1_urlpatterns,
+            patterns=swagger_v1_urlpatterns,
             urlconf=urlconf
         )
 
@@ -42,6 +50,6 @@ class CustomGeneratorClassV2(OpenAPISchemaGenerator):
             info=info,
             version='v2',
             url=url,
-            patterns=api_v2_urlpatterns,
+            patterns=swagger_v2_urlpatterns,
             urlconf=urlconf
         )

--- a/src/server/oasisapi/urls.py
+++ b/src/server/oasisapi/urls.py
@@ -98,7 +98,7 @@ if settings.URL_SUB_PATH:
     urlpatterns += static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
     urlpatterns += [url(r'^api/', include(api_urlpatterns))]
 else:
-    urlpatterns += static(settings.static_debug_url, document_root=settings.static_root)
+    urlpatterns += static(settings.STATIC_DEBUG_URL, document_root=settings.STATIC_ROOT)
     urlpatterns += [url(r'^', include(api_urlpatterns))]
 
 

--- a/src/server/oasisapi/urls.py
+++ b/src/server/oasisapi/urls.py
@@ -50,6 +50,7 @@ api_info_description += """
 7. Run the analysis (post to `/analyses/<pk>/run/`)
 8. Get the outputs (get `/analyses/<pk>/output_file/`)"""
 
+
 api_info = openapi.Info(
     title="Oasis Platform",
     default_version='v2',
@@ -66,12 +67,14 @@ schema_view_v1 = get_schema_view(
     permission_classes=(permissions.AllowAny,),
     generator_class=CustomGeneratorClassV1,
 )
+
 schema_view_v2 = get_schema_view(
     api_info,
     public=True,
     permission_classes=(permissions.AllowAny,),
     generator_class=CustomGeneratorClassV2,
 )
+
 
 api_urlpatterns = [
     # Main Swagger page
@@ -95,8 +98,9 @@ if settings.URL_SUB_PATH:
     urlpatterns += static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
     urlpatterns += [url(r'^api/', include(api_urlpatterns))]
 else:
-    urlpatterns += static(settings.STATIC_DEBUG_URL, document_root=settings.STATIC_ROOT)
+    urlpatterns += static(settings.static_debug_url, document_root=settings.static_root)
     urlpatterns += [url(r'^', include(api_urlpatterns))]
+
 
 if settings.DEBUG_TOOLBAR:
     urlpatterns.append(path('__debug__/', include(debug_toolbar.urls)))


### PR DESCRIPTION
<!--start_release_notes-->
### Fix broken swagger calls when SUB_PATH_URL=True 
When `SUB_PATH_URL=True`  the server uses a prefix url `api/<version>/<end-point>`. 

Fixed calls from new swagger pagers `http://localhost:8000/api/v1/` and `http://localhost:8000/api/v2/` which dropped the `api` prefix in example calls returning `404`. 

<!--end_release_notes-->
