### PR TITLE
Fixes for websocket stability

### DIFF
--- a/src/model_execution_worker/distributed_tasks.py
+++ b/src/model_execution_worker/distributed_tasks.py
@@ -1227,14 +1227,14 @@ def handle_task_failure(*args, sender=None, task_id=None, **kwargs):
         filestore.delete_dir(dir_remote_data)
 
 
-@before_task_publish.connect
-def mark_task_as_queued_receiver(*args, headers=None, body=None, **kwargs):
-    """
-    This receiver is replicated on the server side as it needs to be called from the
-    queueing thread to be triggered
-    """
-    analysis_id = body[1].get('analysis_id')
-    slug = body[1].get('slug')
-
-    if analysis_id and slug:
-        signature('mark_task_as_queued').delay(analysis_id, slug, headers['id'], datetime.now().timestamp())
+#@before_task_publish.connect
+#def mark_task_as_queued_receiver(*args, headers=None, body=None, **kwargs):
+#    """
+#    This receiver is replicated on the server side as it needs to be called from the
+#    queueing thread to be triggered
+#    """
+#    analysis_id = body[1].get('analysis_id')
+#    slug = body[1].get('slug')
+#
+#    if analysis_id and slug:
+#        signature('mark_task_as_queued').delay(analysis_id, slug, headers['id'], datetime.now().timestamp())

--- a/src/model_execution_worker/distributed_tasks.py
+++ b/src/model_execution_worker/distributed_tasks.py
@@ -1225,16 +1225,3 @@ def handle_task_failure(*args, sender=None, task_id=None, **kwargs):
     if not keep_remote_data:
         logging.info(f"deleting remote data, {dir_remote_data}")
         filestore.delete_dir(dir_remote_data)
-
-
-#@before_task_publish.connect
-#def mark_task_as_queued_receiver(*args, headers=None, body=None, **kwargs):
-#    """
-#    This receiver is replicated on the server side as it needs to be called from the
-#    queueing thread to be triggered
-#    """
-#    analysis_id = body[1].get('analysis_id')
-#    slug = body[1].get('slug')
-#
-#    if analysis_id and slug:
-#        signature('mark_task_as_queued').delay(analysis_id, slug, headers['id'], datetime.now().timestamp())

--- a/src/model_execution_worker/distributed_tasks.py
+++ b/src/model_execution_worker/distributed_tasks.py
@@ -15,8 +15,7 @@ import fasteners
 import filelock
 import pandas as pd
 from celery import Celery, signature
-from celery.signals import (before_task_publish, task_failure, task_revoked,
-                            worker_ready)
+from celery.signals import (task_failure, task_revoked, worker_ready)
 from natsort import natsorted
 from oasislmf import __version__ as mdk_version
 from oasislmf.manager import OasisManager

--- a/src/server/oasisapi/analyses/apps.py
+++ b/src/server/oasisapi/analyses/apps.py
@@ -8,9 +8,9 @@ class V1_AnalysesAppConfig(AppConfig):
 class V2_AnalysesAppConfig(AppConfig):
     name = 'src.server.oasisapi.analyses.v2_api'
 
-    def ready(self):
-        from django.db.models.signals import post_save
-        from .v2_api.signal_receivers import task_updated
-        from .models import AnalysisTaskStatus
+    #def ready(self):
+    #    from django.db.models.signals import post_save
+    #    from .v2_api.signal_receivers import task_updated
+    #    from .models import AnalysisTaskStatus
 
-        post_save.connect(task_updated, sender=AnalysisTaskStatus)
+    #    post_save.connect(task_updated, sender=AnalysisTaskStatus)

--- a/src/server/oasisapi/analyses/apps.py
+++ b/src/server/oasisapi/analyses/apps.py
@@ -7,10 +7,3 @@ class V1_AnalysesAppConfig(AppConfig):
 
 class V2_AnalysesAppConfig(AppConfig):
     name = 'src.server.oasisapi.analyses.v2_api'
-
-    #def ready(self):
-    #    from django.db.models.signals import post_save
-    #    from .v2_api.signal_receivers import task_updated
-    #    from .models import AnalysisTaskStatus
-
-    #    post_save.connect(task_updated, sender=AnalysisTaskStatus)

--- a/src/server/oasisapi/analyses/models.py
+++ b/src/server/oasisapi/analyses/models.py
@@ -65,7 +65,8 @@ class AnalysisTaskStatusQuerySet(models.QuerySet):
 
         self._send_socket_messages(statuses)
 
-    #def update(self, **kwargs):
+    # This generates too much WS traffic disableing message per sub-task update
+    # def update(self, **kwargs):
     #    res = super().update(**kwargs)
 
     #    self._send_socket_messages(self)

--- a/src/server/oasisapi/analyses/models.py
+++ b/src/server/oasisapi/analyses/models.py
@@ -65,12 +65,12 @@ class AnalysisTaskStatusQuerySet(models.QuerySet):
 
         self._send_socket_messages(statuses)
 
-    def update(self, **kwargs):
-        res = super().update(**kwargs)
+    #def update(self, **kwargs):
+    #    res = super().update(**kwargs)
 
-        self._send_socket_messages(self)
+    #    self._send_socket_messages(self)
 
-        return res
+    #    return res
 
 
 class AnalysisTaskStatus(models.Model):

--- a/src/server/oasisapi/analyses/models.py
+++ b/src/server/oasisapi/analyses/models.py
@@ -492,6 +492,15 @@ class Analysis(TimeStampedModel):
             self.run_mode = self.run_mode_choices.V2
             task_id = task.apply_async(args=[self.pk, initiator.pk, events_total], priority=self.priority).id
 
+            # TEST 
+            AnalysisTaskStatus.objects.filter(
+                analysis_id=self.pk,
+            ).update(
+                status=AnalysisTaskStatus.status_choices.QUEUED,
+                queue_time=timezone.now(),
+            )
+            
+
         self.run_task_id = task_id
         self.status = self.status_choices.RUN_QUEUED
         self.task_started = timezone.now()
@@ -560,6 +569,14 @@ class Analysis(TimeStampedModel):
         }))
         self.run_mode = self.run_mode_choices.V2
         task_id = task.apply_async(args=[self.pk, initiator.pk, loc_lines, events_total], priority=self.priority).id
+
+        # TEST 
+        AnalysisTaskStatus.objects.filter(
+            analysis_id=self.pk,
+        ).update(
+            status=AnalysisTaskStatus.status_choices.QUEUED,
+            queue_time=timezone.now(),
+        )
 
         self.generate_inputs_task_id = task_id
         self.task_started = timezone.now()
@@ -641,6 +658,14 @@ class Analysis(TimeStampedModel):
             }))
             self.run_mode = self.run_mode_choices.V2
             task_id = task.apply_async(args=[self.pk, initiator.pk, loc_lines], priority=self.priority).id
+
+            # TEST 
+            AnalysisTaskStatus.objects.filter(
+                analysis_id=self.pk,
+            ).update(
+                status=AnalysisTaskStatus.status_choices.QUEUED,
+                queue_time=timezone.now(),
+            )
 
         self.generate_inputs_task_id = task_id
         self.task_started = timezone.now()

--- a/src/server/oasisapi/analyses/models.py
+++ b/src/server/oasisapi/analyses/models.py
@@ -491,11 +491,6 @@ class Analysis(TimeStampedModel):
             }, queue='celery-v2'))
             self.run_mode = self.run_mode_choices.V2
             task_id = task.apply_async(args=[self.pk, initiator.pk, events_total], priority=self.priority).id
-            # Set sub-tasks as queued
-            dt_now = timezone.now()
-            qs = AnalysisTaskStatus.objects.filter(analysis_id=self.pk)
-            qs.update(queue_time=dt_now, status=AnalysisTaskStatus.status_choices.QUEUED)
-
 
         self.run_task_id = task_id
         self.status = self.status_choices.RUN_QUEUED
@@ -565,13 +560,9 @@ class Analysis(TimeStampedModel):
         }))
         self.run_mode = self.run_mode_choices.V2
         task_id = task.apply_async(args=[self.pk, initiator.pk, loc_lines, events_total], priority=self.priority).id
-        # Set sub-tasks as queued
-        dt_now = timezone.now()
-        qs = AnalysisTaskStatus.objects.filter(analysis_id=self.pk)
-        qs.update(queue_time=dt_now, status=AnalysisTaskStatus.status_choices.QUEUED)
 
         self.generate_inputs_task_id = task_id
-        self.task_started = dt_now
+        self.task_started = timezone.now()
         self.task_finished = None
         self.save()
 
@@ -650,13 +641,9 @@ class Analysis(TimeStampedModel):
             }))
             self.run_mode = self.run_mode_choices.V2
             task_id = task.apply_async(args=[self.pk, initiator.pk, loc_lines], priority=self.priority).id
-            # Set sub-tasks as queued
-            dt_now = timezone.now()
-            qs = AnalysisTaskStatus.objects.filter(analysis_id=self.pk)
-            qs.update(queue_time=dt_now, status=AnalysisTaskStatus.status_choices.QUEUED)
 
         self.generate_inputs_task_id = task_id
-        self.task_started = dt_now
+        self.task_started = timezone.now()
         self.task_finished = None
         self.save()
 

--- a/src/server/oasisapi/analyses/models.py
+++ b/src/server/oasisapi/analyses/models.py
@@ -491,15 +491,11 @@ class Analysis(TimeStampedModel):
             }, queue='celery-v2'))
             self.run_mode = self.run_mode_choices.V2
             task_id = task.apply_async(args=[self.pk, initiator.pk, events_total], priority=self.priority).id
+            # Set sub-tasks as queued
+            dt_now = timezone.now()
+            qs = AnalysisTaskStatus.objects.filter(analysis_id=self.pk)
+            qs.update(queue_time=dt_now, status=AnalysisTaskStatus.status_choices.QUEUED)
 
-            # TEST 
-            AnalysisTaskStatus.objects.filter(
-                analysis_id=self.pk,
-            ).update(
-                status=AnalysisTaskStatus.status_choices.QUEUED,
-                queue_time=timezone.now(),
-            )
-            
 
         self.run_task_id = task_id
         self.status = self.status_choices.RUN_QUEUED
@@ -569,17 +565,13 @@ class Analysis(TimeStampedModel):
         }))
         self.run_mode = self.run_mode_choices.V2
         task_id = task.apply_async(args=[self.pk, initiator.pk, loc_lines, events_total], priority=self.priority).id
-
-        # TEST 
-        AnalysisTaskStatus.objects.filter(
-            analysis_id=self.pk,
-        ).update(
-            status=AnalysisTaskStatus.status_choices.QUEUED,
-            queue_time=timezone.now(),
-        )
+        # Set sub-tasks as queued
+        dt_now = timezone.now()
+        qs = AnalysisTaskStatus.objects.filter(analysis_id=self.pk)
+        qs.update(queue_time=dt_now, status=AnalysisTaskStatus.status_choices.QUEUED)
 
         self.generate_inputs_task_id = task_id
-        self.task_started = timezone.now()
+        self.task_started = dt_now
         self.task_finished = None
         self.save()
 
@@ -658,17 +650,13 @@ class Analysis(TimeStampedModel):
             }))
             self.run_mode = self.run_mode_choices.V2
             task_id = task.apply_async(args=[self.pk, initiator.pk, loc_lines], priority=self.priority).id
-
-            # TEST 
-            AnalysisTaskStatus.objects.filter(
-                analysis_id=self.pk,
-            ).update(
-                status=AnalysisTaskStatus.status_choices.QUEUED,
-                queue_time=timezone.now(),
-            )
+            # Set sub-tasks as queued
+            dt_now = timezone.now()
+            qs = AnalysisTaskStatus.objects.filter(analysis_id=self.pk)
+            qs.update(queue_time=dt_now, status=AnalysisTaskStatus.status_choices.QUEUED)
 
         self.generate_inputs_task_id = task_id
-        self.task_started = timezone.now()
+        self.task_started = dt_now
         self.task_finished = None
         self.save()
 

--- a/src/server/oasisapi/analyses/v2_api/signal_receivers.py
+++ b/src/server/oasisapi/analyses/v2_api/signal_receivers.py
@@ -1,17 +1,17 @@
-#from src.server.oasisapi.queues.consumers import send_task_status_message, TaskStatusMessageAnalysisItem, \
-#    TaskStatusMessageItem, build_task_status_message
-#from ...queues.utils import filter_queues_info
-#
-#
-#def task_updated(instance, *args, **kwargs):
-#    # we post all new queues together in a group
-#    if instance.status != instance.status_choices.PENDING:
-#        send_task_status_message(build_task_status_message(
-#            [TaskStatusMessageItem(
-#                queue=q,
-#                analyses=[TaskStatusMessageAnalysisItem(
-#                    analysis=instance.analysis,
-#                    updated_tasks=[instance],
-#                )],
-#            ) for q in filter_queues_info(instance.queue_name)]
-#        ))
+from src.server.oasisapi.queues.consumers import send_task_status_message, TaskStatusMessageAnalysisItem, \
+   TaskStatusMessageItem, build_task_status_message
+from ...queues.utils import filter_queues_info
+
+
+def task_updated(instance, *args, **kwargs):
+   # we post all new queues together in a group
+   if instance.status != instance.status_choices.PENDING:
+       send_task_status_message(build_task_status_message(
+           [TaskStatusMessageItem(
+               queue=q,
+               analyses=[TaskStatusMessageAnalysisItem(
+                   analysis=instance.analysis,
+                   updated_tasks=[instance],
+               )],
+           ) for q in filter_queues_info(instance.queue_name)]
+       ))

--- a/src/server/oasisapi/analyses/v2_api/signal_receivers.py
+++ b/src/server/oasisapi/analyses/v2_api/signal_receivers.py
@@ -1,17 +1,17 @@
 from src.server.oasisapi.queues.consumers import send_task_status_message, TaskStatusMessageAnalysisItem, \
-   TaskStatusMessageItem, build_task_status_message
+    TaskStatusMessageItem, build_task_status_message
 from ...queues.utils import filter_queues_info
 
 
 def task_updated(instance, *args, **kwargs):
-   # we post all new queues together in a group
-   if instance.status != instance.status_choices.PENDING:
-       send_task_status_message(build_task_status_message(
-           [TaskStatusMessageItem(
-               queue=q,
-               analyses=[TaskStatusMessageAnalysisItem(
-                   analysis=instance.analysis,
-                   updated_tasks=[instance],
-               )],
-           ) for q in filter_queues_info(instance.queue_name)]
-       ))
+    # we post all new queues together in a group
+    if instance.status != instance.status_choices.PENDING:
+        send_task_status_message(build_task_status_message(
+            [TaskStatusMessageItem(
+                queue=q,
+                analyses=[TaskStatusMessageAnalysisItem(
+                    analysis=instance.analysis,
+                    updated_tasks=[instance],
+                )],
+            ) for q in filter_queues_info(instance.queue_name)]
+        ))

--- a/src/server/oasisapi/analyses/v2_api/signal_receivers.py
+++ b/src/server/oasisapi/analyses/v2_api/signal_receivers.py
@@ -1,17 +1,17 @@
-from src.server.oasisapi.queues.consumers import send_task_status_message, TaskStatusMessageAnalysisItem, \
-    TaskStatusMessageItem, build_task_status_message
-from ...queues.utils import filter_queues_info
-
-
-def task_updated(instance, *args, **kwargs):
-    # we post all new queues together in a group
-    if instance.status != instance.status_choices.PENDING:
-        send_task_status_message(build_task_status_message(
-            [TaskStatusMessageItem(
-                queue=q,
-                analyses=[TaskStatusMessageAnalysisItem(
-                    analysis=instance.analysis,
-                    updated_tasks=[instance],
-                )],
-            ) for q in filter_queues_info(instance.queue_name)]
-        ))
+#from src.server.oasisapi.queues.consumers import send_task_status_message, TaskStatusMessageAnalysisItem, \
+#    TaskStatusMessageItem, build_task_status_message
+#from ...queues.utils import filter_queues_info
+#
+#
+#def task_updated(instance, *args, **kwargs):
+#    # we post all new queues together in a group
+#    if instance.status != instance.status_choices.PENDING:
+#        send_task_status_message(build_task_status_message(
+#            [TaskStatusMessageItem(
+#                queue=q,
+#                analyses=[TaskStatusMessageAnalysisItem(
+#                    analysis=instance.analysis,
+#                    updated_tasks=[instance],
+#                )],
+#            ) for q in filter_queues_info(instance.queue_name)]
+#        ))

--- a/src/server/oasisapi/analyses/v2_api/tasks.py
+++ b/src/server/oasisapi/analyses/v2_api/tasks.py
@@ -740,6 +740,7 @@ def set_task_status(analysis_pk, task_status, dt):
 @celery_app_v2.task(name='update_task_id')
 def update_task_id(task_update_list):
     dt_now = timezone.now()
+    _, analysis_id, _ = task_update_list[0]
     # Set all pending tasks to queued (only update PENDING to avoid overwriting valid 'STARTED' or 'COMPLETE'
     AnalysisTaskStatus.objects.filter(
         analysis_id=analysis_id,

--- a/src/server/oasisapi/analyses/v2_api/tasks.py
+++ b/src/server/oasisapi/analyses/v2_api/tasks.py
@@ -687,15 +687,6 @@ def handle_task_failure(
         )
 
 
-# @before_task_publish.connect
-# def mark_task_as_queued_receiver(*args, headers=None, body=None, **kwargs):
-#    analysis_id = body[1].get('analysis_id')
-#    slug = body[1].get('slug')
-#
-#    if analysis_id and slug:
-#        mark_task_as_queued(analysis_id, slug, headers['id'], timezone.now().timestamp())
-
-
 @celery_app_v2.task(name='mark_task_as_queued')
 def mark_task_as_queued(analysis_id, slug, task_id, dt):
     AnalysisTaskStatus.objects.filter(

--- a/src/server/oasisapi/analyses/v2_api/tasks.py
+++ b/src/server/oasisapi/analyses/v2_api/tasks.py
@@ -740,9 +740,15 @@ def set_task_status(analysis_pk, task_status, dt):
 
 @celery_app_v2.task(name='update_task_id')
 def update_task_id(task_update_list):
+    dt_now = timezone.now()
+    status =  AnalysisTaskStatus.status_choices.QUEUED
     for task in task_update_list:
         task_id, analysis_id, slug = task
         AnalysisTaskStatus.objects.filter(
             analysis_id=analysis_id,
             slug=slug,
-        ).update(task_id=task_id)
+        ).update(
+            task_id=task_id,
+            status=status,
+            queue_time=dt_now,
+        )

--- a/src/server/oasisapi/analyses/v2_api/tasks.py
+++ b/src/server/oasisapi/analyses/v2_api/tasks.py
@@ -687,8 +687,8 @@ def handle_task_failure(
         )
 
 
-#@before_task_publish.connect
-#def mark_task_as_queued_receiver(*args, headers=None, body=None, **kwargs):
+# @before_task_publish.connect
+# def mark_task_as_queued_receiver(*args, headers=None, body=None, **kwargs):
 #    analysis_id = body[1].get('analysis_id')
 #    slug = body[1].get('slug')
 #

--- a/src/server/oasisapi/analyses/v2_api/tasks.py
+++ b/src/server/oasisapi/analyses/v2_api/tasks.py
@@ -19,7 +19,6 @@ from azure.storage.blob import BlobLeaseClient
 from celery import Task
 from celery import signals
 from celery.result import AsyncResult
-from celery.signals import before_task_publish
 from celery.utils.log import get_task_logger
 from celery import Task
 from celery import signals

--- a/src/server/oasisapi/analyses/v2_api/tasks.py
+++ b/src/server/oasisapi/analyses/v2_api/tasks.py
@@ -688,13 +688,13 @@ def handle_task_failure(
         )
 
 
-@before_task_publish.connect
-def mark_task_as_queued_receiver(*args, headers=None, body=None, **kwargs):
-    analysis_id = body[1].get('analysis_id')
-    slug = body[1].get('slug')
-
-    if analysis_id and slug:
-        mark_task_as_queued(analysis_id, slug, headers['id'], timezone.now().timestamp())
+#@before_task_publish.connect
+#def mark_task_as_queued_receiver(*args, headers=None, body=None, **kwargs):
+#    analysis_id = body[1].get('analysis_id')
+#    slug = body[1].get('slug')
+#
+#    if analysis_id and slug:
+#        mark_task_as_queued(analysis_id, slug, headers['id'], timezone.now().timestamp())
 
 
 @celery_app_v2.task(name='mark_task_as_queued')

--- a/src/server/oasisapi/queues/consumers.py
+++ b/src/server/oasisapi/queues/consumers.py
@@ -92,7 +92,12 @@ def build_all_queue_status_message(analysis_filter=None, message_type='queue_sta
         analyses = Analysis.objects.filter(**analysis_filter)
         queue_names = analyses.values_list('sub_task_statuses__queue_name', flat=True).distinct()
     else:
-        analyses = Analysis.objects.filter(status__in=[Analysis.status_choices.INPUTS_GENERATION_STARTED, Analysis.status_choices.RUN_STARTED])
+        analyses = Analysis.objects.filter(status__in=[
+            Analysis.status_choices.INPUTS_GENERATION_QUEUED, 
+            Analysis.status_choices.INPUTS_GENERATION_STARTED, 
+            Analysis.status_choices.RUN_QUEUED,
+            Analysis.status_choices.RUN_STARTED,
+        ])
         queue_names = None
 
     # filter queues with some nodes or activity

--- a/src/server/oasisapi/queues/consumers.py
+++ b/src/server/oasisapi/queues/consumers.py
@@ -62,6 +62,7 @@ def find_model_from_queue_name(queue_name):
             return m.id
     return None
 
+
 def build_task_status_message(items: List[TaskStatusMessageItem], message_type='queue_status.updated'):
     from src.server.oasisapi.analyses.v2_api.serializers import AnalysisSerializerWebSocket, AnalysisTaskStatusSerializer
     from src.server.oasisapi.queues.serializers import QueueSerializer
@@ -109,7 +110,8 @@ def build_all_queue_status_message(analysis_filter=None, message_type='queue_sta
 
     # filter queues with some nodes or activity
     all_queues = filter_queues_info(queue_names)
-    active_queues = list(q for q in all_queues if (q['worker_count'] or q['pending_count'] or q['running_count'] or q['queued_count'] or q['queue_message_count']))
+    active_queues = list(q for q in all_queues if (q['worker_count'] or q['pending_count']
+                         or q['running_count'] or q['queued_count'] or q['queue_message_count']))
 
     status_message = []
 
@@ -118,8 +120,7 @@ def build_all_queue_status_message(analysis_filter=None, message_type='queue_sta
         if model_id:
             qs_analyses = analyses.filter(**{'model': model_id}).distinct()
         else:
-            qs_analyses = analyses.filter(**{'sub_task_statuses__queue_name': q['name'],}).distinct()
-
+            qs_analyses = analyses.filter(**{'sub_task_statuses__queue_name': q['name'], }).distinct()
 
         status_message.append(TaskStatusMessageItem(
             queue=q,

--- a/src/server/oasisapi/queues/consumers.py
+++ b/src/server/oasisapi/queues/consumers.py
@@ -93,8 +93,8 @@ def build_all_queue_status_message(analysis_filter=None, message_type='queue_sta
         queue_names = analyses.values_list('sub_task_statuses__queue_name', flat=True).distinct()
     else:
         analyses = Analysis.objects.filter(status__in=[
-            Analysis.status_choices.INPUTS_GENERATION_QUEUED, 
-            Analysis.status_choices.INPUTS_GENERATION_STARTED, 
+            Analysis.status_choices.INPUTS_GENERATION_QUEUED,
+            Analysis.status_choices.INPUTS_GENERATION_STARTED,
             Analysis.status_choices.RUN_QUEUED,
             Analysis.status_choices.RUN_STARTED,
         ])


### PR DESCRIPTION
<!--start_release_notes-->
### Fixes for websocket stability
* Added queued analyses objects to  **websocket** output, this is to ensure worker-controller doesn't get into a stuck state 
* Reduced the amount of  **websocket**  messages, sub-task update messages are no longer published. A large number of messages causes instability between the `oasis-websocket` and `worker-controller` pods
* Fixed V1 analysis not showing up in the **websocket** output
<!--end_release_notes-->
