### PR TITLE
Fix/985 pandas 2 key gen

### DIFF
--- a/requirements-server.txt
+++ b/requirements-server.txt
@@ -214,7 +214,7 @@ packaging==23.0
     #   drf-yasg
     #   fastparquet
     #   ods-tools
-pandas==1.5.3
+pandas==2.2.1
     # via
     #   -r requirements-server.in
     #   fastparquet
@@ -304,7 +304,9 @@ typing-extensions==4.5.0
     #   oasis-data-manager
     #   twisted
 tzdata==2023.3
-    # via celery
+    # via
+    #   celery
+    #   pandas
 uritemplate==4.1.1
     # via
     #   coreapi

--- a/requirements-server.txt
+++ b/requirements-server.txt
@@ -214,7 +214,7 @@ packaging==23.0
     #   drf-yasg
     #   fastparquet
     #   ods-tools
-pandas==2.2.1
+pandas==2.0.3
     # via
     #   -r requirements-server.in
     #   fastparquet

--- a/requirements-worker.txt
+++ b/requirements-worker.txt
@@ -155,7 +155,7 @@ packaging==23.0
     #   geopandas
     #   ods-tools
     #   pytest
-pandas==1.5.3
+pandas==2.2.1
     # via
     #   fastparquet
     #   geopandas
@@ -248,7 +248,9 @@ typing-extensions==4.5.0
     #   azure-storage-blob
     #   oasis-data-manager
 tzdata==2023.3
-    # via celery
+    # via
+    #   celery
+    #   pandas
 urllib3==1.26.15
     # via
     #   botocore

--- a/requirements-worker.txt
+++ b/requirements-worker.txt
@@ -155,7 +155,7 @@ packaging==23.0
     #   geopandas
     #   ods-tools
     #   pytest
-pandas==2.2.1
+pandas==2.0.3
     # via
     #   fastparquet
     #   geopandas

--- a/requirements.txt
+++ b/requirements.txt
@@ -352,7 +352,7 @@ packaging==23.0
     #   pyproject-api
     #   pytest
     #   tox
-pandas==2.2.1
+pandas==2.0.3
     # via
     #   -r ./requirements-server.in
     #   fastparquet

--- a/requirements.txt
+++ b/requirements.txt
@@ -352,7 +352,7 @@ packaging==23.0
     #   pyproject-api
     #   pytest
     #   tox
-pandas==1.5.3
+pandas==2.2.1
     # via
     #   -r ./requirements-server.in
     #   fastparquet
@@ -557,7 +557,9 @@ typing-extensions==4.5.0
     #   oasis-data-manager
     #   twisted
 tzdata==2023.3
-    # via celery
+    # via
+    #   celery
+    #   pandas
 uritemplate==4.1.1
     # via
     #   coreapi

--- a/src/model_execution_worker/distributed_tasks.py
+++ b/src/model_execution_worker/distributed_tasks.py
@@ -14,6 +14,7 @@ from datetime import datetime
 import fasteners
 import filelock
 import pandas as pd
+import numpy as np
 from celery import Celery, signature
 from celery.signals import (task_failure, task_revoked, worker_ready)
 from natsort import natsorted
@@ -735,7 +736,7 @@ def prepare_keys_file_chunk(
         )
 
         location_df = load_location_data(params['oed_location_csv'])
-        location_df = pd.np.array_split(location_df, num_chunks)[chunk_idx]
+        location_df = np.array_split(location_df, num_chunks)[chunk_idx]
         location_df.reset_index(drop=True, inplace=True)
 
         chunk_keys_fp = os.path.join(chunk_target_dir, 'keys.csv')


### PR DESCRIPTION
**IMPORTANT: Please attach or create an issue after submitting a Pull Request.

<!--start_release_notes-->
### Fix for pandas 2.0.0+ and v2 keys generation
Worker code is using an outdated pandas api which breaks with pandas 2.0.0 or greater 
<!--end_release_notes-->
