### PR TITLE
Only use a single channel connect when fetching queue states

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -215,15 +215,6 @@ services:
     ports:
       - 5672:5672
       - 15672:15672
-  flower:
-    restart: always
-    image: mher/flower:0.9.7
-    command: ['flower', '--broker=amqp://rabbit:rabbit@rabbit:5672', '--port=5555']
-    ports:
-      - 5555:5555
-    links:
-     - celery-db
-     - broker
   channel-layer:
     restart: always
     image: redis:5.0.7
@@ -240,3 +231,12 @@ services:
      - OASIS_ENVIRONMENT=oasis_localhost
     ports:
      - 8080:3838
+  portainer:
+   restart: always
+   image: portainer/portainer:latest
+   ports:
+     - 8002:8002
+     - 9000:9000
+   volumes:
+     - /var/run/docker.sock:/var/run/docker.sock
+     - ./portainer_data:/data portainer/portainer        

--- a/src/server/oasisapi/queues/utils.py
+++ b/src/server/oasisapi/queues/utils.py
@@ -73,7 +73,6 @@ def get_queues_info() -> List[QueueInfo]:
         ]
         chan.close()
 
-
     # get the stats of the running and queued tasks
     pending = reduce(
         lambda current, value: _add_to_dict(current, value['queue_name'], value['count']),

--- a/src/server/oasisapi/queues/utils.py
+++ b/src/server/oasisapi/queues/utils.py
@@ -10,20 +10,14 @@ from src.server.oasisapi.celery_app_v2 import v2 as celery_app_v2
 QueueInfo = Dict[str, int]
 
 
-def _get_queue_consumers(queue_name):
-    with celery_app_v2.pool.acquire(block=True) as conn:
-        chan = conn.channel()
-        name, message_count, consumers = chan.queue_declare(queue=queue_name, passive=True)
-        chan.close()
-        return consumers
+def _get_queue_consumers(queue_name, channel):
+    name, message_count, consumers = channel.queue_declare(queue=queue_name, passive=True)
+    return consumers
 
 
-def _get_queue_message_count(queue_name):
-    with celery_app_v2.pool.acquire(block=True) as conn:
-        chan = conn.channel()
-        name, message_count, consumers = chan.queue_declare(queue=queue_name, passive=True)
-        chan.close()
-        return message_count
+def _get_queue_message_count(queue_name, channel):
+    name, message_count, consumers = channel.queue_declare(queue=queue_name, passive=True)
+    return message_count
 
 
 def _add_to_dict(d, k, v):
@@ -65,16 +59,20 @@ def get_queues_info() -> List[QueueInfo]:
     from src.server.oasisapi.analyses.models import AnalysisTaskStatus
 
     # setup an entry for every element in the broker
-    res = [
-        {
-            'name': q,
-            'pending_count': 0,
-            'queued_count': 0,
-            'running_count': 0,
-            'queue_message_count': _get_queue_message_count(q),
-            'worker_count': _get_queue_consumers(q),
-        } for q in _get_broker_queue_names()
-    ]
+    with celery_app_v2.pool.acquire(block=True) as conn:
+        chan = conn.channel()
+        res = [
+            {
+                'name': q,
+                'pending_count': 0,
+                'queued_count': 0,
+                'running_count': 0,
+                'queue_message_count': _get_queue_message_count(q, chan),
+                'worker_count': _get_queue_consumers(q, chan),
+            } for q in _get_broker_queue_names()
+        ]
+        chan.close()
+
 
     # get the stats of the running and queued tasks
     pending = reduce(


### PR DESCRIPTION
<!--start_release_notes-->
### Only use a single channel connection when fetching queue states
* Fix for https://github.com/OasisLMF/OasisPlatform/issues/989 
<!--end_release_notes-->
