### PR TITLE
Logging fixes for workers 

### DIFF
--- a/.github/workflows/test-images.yml
+++ b/.github/workflows/test-images.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
     branches:
       - main
-      - stable**  
+      - stable**
   workflow_dispatch:
     inputs:
       last_release:
@@ -163,7 +163,7 @@ jobs:
       worker_api_ver: 'v1'
       debug_mode: 1
       pytest_opts: "--docker-compose=./docker/plat2-v2.docker-compose.yml "
-      storage_suffix: '-all-checks'
+      storage_suffix: '-all-checks-v1'
 
   all_checks_v2:
     name: V2 all checks
@@ -179,7 +179,7 @@ jobs:
       worker_api_ver: 'v2'
       debug_mode: 1
       pytest_opts: "--docker-compose=./docker/plat2-v2.docker-compose.yml "
-      storage_suffix: '-all-checks'
+      storage_suffix: '-all-checks-v2'
 
   storage_s3_v1:
     name: V1 Storage Compatibility (S3)
@@ -195,7 +195,7 @@ jobs:
       worker_api_ver: 'v1'
       debug_mode: 1
       pytest_opts: "--docker-compose=./docker/plat2-v2.s3.docker-compose.yml ${{ needs.setup.outputs.pytest_opts }}"
-      storage_suffix: '_s3'
+      storage_suffix: '_s3-v1'
 
   storage_s3_v2:
     name: V2 Storage Compatibility (S3)
@@ -211,7 +211,7 @@ jobs:
       worker_api_ver: 'v2'
       debug_mode: 1
       pytest_opts: "--docker-compose=./docker/plat2-v2.s3.docker-compose.yml ${{ needs.setup.outputs.pytest_opts }}"
-      storage_suffix: '_s3'
+      storage_suffix: '_s3-v2'
 
   worker_debian:
     name: Worker Debian

--- a/kubernetes/worker-controller/src/oasis_client.py
+++ b/kubernetes/worker-controller/src/oasis_client.py
@@ -64,7 +64,6 @@ class OasisClient:
                 self.token_expire_time = time.time() + round(data['expires_in'] / 2)
 
     async def get_access_token(self) -> str:
-
         """
         Returns the access token - authentication will be made if there is none or it as expired.
 

--- a/src/model_execution_worker/distributed_tasks.py
+++ b/src/model_execution_worker/distributed_tasks.py
@@ -57,7 +57,7 @@ app.config_from_object(celery_conf)
 logger.info("Started worker")
 debug_worker = settings.getboolean('worker', 'DEBUG', fallback=False)
 if debug_worker:
-    logger.setLevel('DEBUG')
+    logging.getLogger().setLevel('INFO')
 
 # Quiet sub-loggers
 logging.getLogger('billiard').setLevel('INFO')
@@ -365,16 +365,6 @@ class InvalidInputsException(OasisException):
 class MissingModelDataException(OasisException):
     def __init__(self, model_data_dir):
         super(MissingModelDataException, self).__init__('Model data not found: {}'.format(model_data_dir))
-
-
-@contextmanager
-def get_lock():
-    lock = fasteners.InterProcessLock(settings.get('worker', 'LOCK_FILE'))
-    gotten = lock.acquire(blocking=False, timeout=settings.getfloat('worker', 'LOCK_TIMEOUT_IN_SECS'))
-    yield gotten
-
-    if gotten:
-        lock.release()
 
 
 def get_oasislmf_config_path(model_id=None):

--- a/src/model_execution_worker/distributed_tasks.py
+++ b/src/model_execution_worker/distributed_tasks.py
@@ -485,7 +485,7 @@ def prepare_input_generation_params(
 
     gen_files_params = OasisManager()._params_generate_files(**lookup_params)
     pre_hook_params = OasisManager()._params_exposure_pre_analysis(**lookup_params)
-    params = paths_to_absolute_paths({**gen_files_params, **pre_hook_params})
+    params = paths_to_absolute_paths({**gen_files_params, **pre_hook_params}, config_path)
 
     params['log_location'] = filestore.put(kwargs.get('log_filename'))
     params['verbose'] = debug_worker
@@ -862,7 +862,7 @@ def prepare_losses_generation_params(
 
     gen_losses_params = OasisManager()._params_generate_losses(**run_params)
     post_hook_params = OasisManager()._params_post_analysis(**run_params)
-    params = paths_to_absolute_paths({**gen_losses_params, **post_hook_params})
+    params = paths_to_absolute_paths({**gen_losses_params, **post_hook_params}, config_path)
 
     params['log_location'] = filestore.put(kwargs.get('log_filename'))
     params['verbose'] = debug_worker

--- a/src/model_execution_worker/distributed_tasks.py
+++ b/src/model_execution_worker/distributed_tasks.py
@@ -482,11 +482,10 @@ def prepare_input_generation_params(
     config_path = get_oasislmf_config_path(settings, model_id)
     config = get_json(config_path)
     lookup_params = {**{k: v for k, v in config.items() if not k.startswith('oed_')}, **params}
-    paths_to_absolute_paths(lookup_params)
 
     gen_files_params = OasisManager()._params_generate_files(**lookup_params)
     pre_hook_params = OasisManager()._params_exposure_pre_analysis(**lookup_params)
-    params = {**gen_files_params, **pre_hook_params}
+    params = paths_to_absolute_paths({**gen_files_params, **pre_hook_params})
 
     params['log_location'] = filestore.put(kwargs.get('log_filename'))
     params['verbose'] = debug_worker
@@ -549,12 +548,12 @@ def prepare_keys_file_chunk(
         Path(chunk_target_dir).mkdir(parents=True, exist_ok=True)
 
         _, lookup = OasisLookupFactory.create(
-            lookup_config_fp=params['lookup_config_json'],
-            model_keys_data_path=params['lookup_data_dir'],
-            model_version_file_path=params['model_version_csv'],
-            lookup_module_path=params['lookup_module_path'],
-            complex_lookup_config_fp=params['lookup_complex_config_json'],
-            user_data_dir=params['user_data_dir'],
+            lookup_config_fp=params.get('lookup_config_json', None),
+            model_keys_data_path=params.get('lookup_data_dir', None),
+            model_version_file_path=params.get('model_version_csv', None),
+            lookup_module_path=params.get('lookup_module_path', None),
+            complex_lookup_config_fp=params.get('lookup_complex_config_json', None),
+            user_data_dir=params.get('user_data_dir', None),
             output_directory=chunk_target_dir,
         )
 
@@ -860,11 +859,10 @@ def prepare_losses_generation_params(
     config_path = get_oasislmf_config_path(settings, model_id)
     config = get_json(config_path)
     run_params = {**config, **params}
-    paths_to_absolute_paths(run_params)
 
     gen_losses_params = OasisManager()._params_generate_losses(**run_params)
     post_hook_params = OasisManager()._params_post_analysis(**run_params)
-    params = {**gen_losses_params, **post_hook_params}
+    params = paths_to_absolute_paths({**gen_losses_params, **post_hook_params})
 
     params['log_location'] = filestore.put(kwargs.get('log_filename'))
     params['verbose'] = debug_worker

--- a/src/model_execution_worker/distributed_tasks.py
+++ b/src/model_execution_worker/distributed_tasks.py
@@ -435,7 +435,8 @@ def keys_generation_task(fn):
 
     def run(self, params, *args, run_data_uuid=None, analysis_id=None, **kwargs):
         kwargs['log_filename'] = os.path.join(TASK_LOG_DIR, f"{run_data_uuid}_{kwargs.get('slug')}.log")
-        with LoggingTaskContext(logging.getLogger(), log_filename=kwargs['log_filename']):
+        log_level = 'DEBUG' if debug_worker else 'INFO'
+        with LoggingTaskContext(logging.getLogger(), log_filename=kwargs['log_filename'], level=log_level):
             log_task_entry(kwargs.get('slug'), self.request.id, analysis_id)
 
             if isinstance(params, list):
@@ -822,7 +823,8 @@ def loss_generation_task(fn):
 
     def run(self, params, *args, run_data_uuid=None, analysis_id=None, **kwargs):
         kwargs['log_filename'] = os.path.join(TASK_LOG_DIR, f"{run_data_uuid}_{kwargs.get('slug')}.log")
-        with LoggingTaskContext(logging.getLogger(), log_filename=kwargs['log_filename']):
+        log_level = 'DEBUG' if debug_worker else 'INFO'
+        with LoggingTaskContext(logging.getLogger(), log_filename=kwargs['log_filename'], level=log_level):
             log_task_entry(kwargs.get('slug'), self.request.id, analysis_id)
             if isinstance(params, list):
                 for p in params:

--- a/src/model_execution_worker/distributed_tasks.py
+++ b/src/model_execution_worker/distributed_tasks.py
@@ -29,6 +29,7 @@ from pathlib2 import Path
 from ..common.data import ORIGINAL_FILENAME, STORED_FILENAME
 from ..conf import celeryconf_v2 as celery_conf
 from ..conf.iniconf import settings
+from .utils import LoggingTaskContext
 from .backends.aws_storage import AwsObjectStore
 from .backends.azure_storage import AzureObjectStore
 from .storage_manager import BaseStorageConnector
@@ -70,33 +71,6 @@ elif selected_storage in ['azure']:
     filestore = AzureObjectStore(settings)
 else:
     raise OasisException('Invalid value for STORAGE_TYPE: {}'.format(selected_storage))
-
-
-class LoggingTaskContext:
-    """ Adds a file log handler to the root logger and pushes a copy all logs to
-        the 'log_filename'
-
-        Docs: https://docs.python.org/3/howto/logging-cookbook.html#using-a-context-manager-for-selective-logging
-    """
-
-    def __init__(self, logger, log_filename, level=None, close=True):
-        self.logger = logger
-        self.level = level
-        self.log_filename = log_filename
-        self.close = close
-        self.handler = logging.FileHandler(log_filename)
-
-    def __enter__(self):
-        if self.level:
-            self.handler.setLevel(self.level)
-        if self.handler:
-            self.logger.addHandler(self.handler)
-
-    def __exit__(self, et, ev, tb):
-        if self.handler:
-            self.logger.removeHandler(self.handler)
-        if self.handler and self.close:
-            self.handler.close()
 
 
 class TemporaryDir(object):

--- a/src/model_execution_worker/distributed_tasks.py
+++ b/src/model_execution_worker/distributed_tasks.py
@@ -944,7 +944,6 @@ def generate_losses_output(self, params, analysis_id=None, slug=None, **kwargs):
     if res.get('post_analysis_module', None):
         OasisManager().post_analysis(**res)
 
-    res['bash_trace'] = ""
     return {
         **res,
         'output_location': filestore.put(os.path.join(res['model_run_dir'], 'output'), arcname='output'),

--- a/src/model_execution_worker/distributed_tasks.py
+++ b/src/model_execution_worker/distributed_tasks.py
@@ -899,13 +899,11 @@ def generate_losses_chunk(self, params, chunk_idx, num_chunks, analysis_id=None,
         current_chunk_id = None
         max_chunk_id = -1
         work_dir = 'work'
-        #log_dir = 'log'
     else:
         # Run a single ktools pipe
         current_chunk_id = chunk_idx + 1
         max_chunk_id = num_chunks
         work_dir = f'{current_chunk_id}.work'
-        #log_dir = os.path.join('log', str(current_chunk_id))
 
     chunk_params = {
         **params,
@@ -953,12 +951,14 @@ def generate_losses_output(self, params, analysis_id=None, slug=None, **kwargs):
     OasisManager().generate_losses_output(**res)
     if res.get('post_analysis_module', None):
         OasisManager().post_analysis(**res)
-        
-    # collect run logs 
+
+    # collect run logs
     abs_log_dir = os.path.join(res['model_run_dir'], 'log')
     Path(abs_log_dir).mkdir(exist_ok=True, parents=True)
     for p in params:
-        filestore.extract(p['chunk_log_location'], os.path.join(abs_log_dir, f'{p["process_number"]}-chunk'), p['storage_subdir'])
+        with TemporaryDir() as d:
+            filestore.extract(p['chunk_log_location'], d, p['storage_subdir'])
+            merge_dirs(d, abs_log_dir)
 
     return {
         **res,

--- a/src/model_execution_worker/tasks.py
+++ b/src/model_execution_worker/tasks.py
@@ -331,11 +331,11 @@ def start_analysis(analysis_settings, input_location, complex_data_files=None, *
 
         # Create and log params
         run_params = {**config, **task_params}
-        paths_to_absolute_paths(run_params)
-        log_params(run_params, kwargs)
+        params = paths_to_absolute_paths(run_params)
+        log_params(params, kwargs)
 
         # Run generate losses
-        OasisManager().generate_oasis_losses(**run_params)
+        OasisManager().generate_oasis_losses(**params)
 
         # Ktools log Tar file
         traceback_location = filestore.put(kwargs['log_filename'])
@@ -428,8 +428,8 @@ def generate_input(self,
         config_path = get_oasislmf_config_path(settings)
         config = get_json(config_path)
         lookup_params = {**{k: v for k, v in config.items() if not k.startswith('oed_')}, **task_params}
-        paths_to_absolute_paths(lookup_params)
-        log_params(lookup_params, kwargs, exclude_keys=[
+        params = paths_to_absolute_paths(lookup_params)
+        log_params(params, kwargs, exclude_keys=[
             'profile_loc',
             'profile_loc_json',
             'profile_acc',
@@ -443,7 +443,7 @@ def generate_input(self,
         ])
 
         try:
-            OasisManager().generate_oasis_files(**lookup_params)
+            OasisManager().generate_oasis_files(**params)
             returncode = 0
         except Exception as e:
             logger.error(e)

--- a/src/model_execution_worker/tasks.py
+++ b/src/model_execution_worker/tasks.py
@@ -214,7 +214,8 @@ def V1_task_logger(fn):
         kwargs = {
             'log_filename': os.path.join(TASK_LOG_DIR, f"analysis_{analysis_pk}_{self.request.id}.log")
         }
-        with LoggingTaskContext(logging.getLogger(), log_filename=kwargs['log_filename'], level='DEBUG'):
+        log_level = 'DEBUG' if debug_worker else 'INFO'
+        with LoggingTaskContext(logging.getLogger(), log_filename=kwargs['log_filename'], level=log_level):
             logger.info(f'====== {fn.__name__} '.ljust(90, '='))
             return fn(self, analysis_pk, *args, **kwargs)
 

--- a/src/model_execution_worker/tasks.py
+++ b/src/model_execution_worker/tasks.py
@@ -505,7 +505,6 @@ def generate_input(self,
     #logging.info("args: {}".format(str(locals())))
     logging.info(str(get_worker_versions()))
 
-    raise ValueError('test')
     # Check if this task was re-queued from a lost worker
     check_worker_lost(self, analysis_pk)
 

--- a/src/model_execution_worker/tasks.py
+++ b/src/model_execution_worker/tasks.py
@@ -331,8 +331,9 @@ def start_analysis(analysis_settings, input_location, complex_data_files=None, *
 
         # Create and log params
         run_params = {**config, **task_params}
-        params = paths_to_absolute_paths(run_params)
-        log_params(params, kwargs)
+        params = paths_to_absolute_paths(run_params, config_path)
+        if debug_worker:
+            log_params(params, kwargs)
 
         # Run generate losses
         OasisManager().generate_oasis_losses(**params)
@@ -428,19 +429,20 @@ def generate_input(self,
         config_path = get_oasislmf_config_path(settings)
         config = get_json(config_path)
         lookup_params = {**{k: v for k, v in config.items() if not k.startswith('oed_')}, **task_params}
-        params = paths_to_absolute_paths(lookup_params)
-        log_params(params, kwargs, exclude_keys=[
-            'profile_loc',
-            'profile_loc_json',
-            'profile_acc',
-            'profile_fm_agg',
-            'profile_fm_agg_json',
-            'fm_aggregation_profile',
-            'accounts_profile',
-            'oed_hierarchy',
-            'exposure_profile',
-            'lookup_config',
-        ])
+        params = paths_to_absolute_paths(lookup_params, config_path)
+        if debug_worker:
+            log_params(params, kwargs, exclude_keys=[
+                'profile_loc',
+                'profile_loc_json',
+                'profile_acc',
+                'profile_fm_agg',
+                'profile_fm_agg_json',
+                'fm_aggregation_profile',
+                'accounts_profile',
+                'oed_hierarchy',
+                'exposure_profile',
+                'lookup_config',
+            ])
 
         try:
             OasisManager().generate_oasis_files(**params)

--- a/src/model_execution_worker/tests/test_tasks.py
+++ b/src/model_execution_worker/tests/test_tasks.py
@@ -1,7 +1,6 @@
 import os
-import subprocess
-import json
 import tarfile
+import json
 from unittest import TestCase
 from contextlib import contextmanager
 
@@ -14,10 +13,10 @@ from mock import patch, Mock
 # from mock import ANY
 from pathlib2 import Path
 
-from src.conf.iniconf import SettingsPatcher, settings
+from src.conf.iniconf import SettingsPatcher
 # from src.model_execution_worker.storage_manager import MissingInputsException
 from src.model_execution_worker.tasks import start_analysis, InvalidInputsException, \
-    start_analysis_task, get_oasislmf_config_path
+    start_analysis_task
 
 
 # from oasislmf.utils.status import OASIS_TASK_STATUS

--- a/src/model_execution_worker/utils.py
+++ b/src/model_execution_worker/utils.py
@@ -36,6 +36,7 @@ class LoggingTaskContext:
     def __init__(self, logger, log_filename, level=None, close=True):
         self.logger = logger
         self.level = level
+        self.prev_level = logger.level
         self.log_filename = log_filename
         self.close = close
         self.handler = logging.FileHandler(log_filename)
@@ -43,10 +44,13 @@ class LoggingTaskContext:
     def __enter__(self):
         if self.level:
             self.handler.setLevel(self.level)
+            self.logger.setLevel(self.level)
         if self.handler:
             self.logger.addHandler(self.handler)
 
     def __exit__(self, et, ev, tb):
+        if self.level:
+            self.logger.setLevel(self.prev_level)
         if self.handler:
             self.logger.removeHandler(self.handler)
         if self.handler and self.close:

--- a/src/model_execution_worker/utils.py
+++ b/src/model_execution_worker/utils.py
@@ -1,10 +1,22 @@
 __all__ = [
     'LoggingTaskContext',
-    'log_params'
+    'log_params',
+    'paths_to_absolute_paths',
+    'TemporaryDir',
+    'get_oasislmf_config_path',
+    'get_model_settings',
+    'get_worker_versions',
+    'InvalidInputsException',
+    'MissingModelDataException',
+    'prepare_complex_model_file_inputs',
 ]
 
 import logging
 import json
+import os
+import tempfile
+import shutil
+import subprocess
 
 class LoggingTaskContext:
     """ Adds a file log handler to the root logger and pushes a copy all logs to
@@ -41,3 +53,149 @@ def log_params(params, kwargs, exclude_keys=[]):
         json.dumps(print_params, indent=2),
         json.dumps(kwargs, indent=2),
     ))
+
+
+def paths_to_absolute_paths(dictionary):
+    if not isinstance(dictionary, dict):
+        raise ValueError("Input must be a dictionary.")
+
+    for key, value in dictionary.items():
+        if isinstance(value, str) and os.path.exists(value):
+            # If the value is a string and exists as a path, convert it to absolute path
+            dictionary[key] = os.path.abspath(value)
+        elif value is None:
+            del dictionary[key]
+    return dictionary
+
+
+class TemporaryDir(object):
+    """Context manager for mkdtemp() with option to persist"""
+
+    def __init__(self, persist=False, basedir=None):
+        self.persist = persist
+        self.basedir = basedir
+
+        if basedir:
+            os.makedirs(basedir, exist_ok=True)
+
+    def __enter__(self):
+        self.name = tempfile.mkdtemp(dir=self.basedir)
+        return self.name
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        if not self.persist and os.path.isdir(self.name):
+            shutil.rmtree(self.name)
+
+
+def get_oasislmf_config_path(model_id=None):
+    """ Search for the oasislmf confiuration file
+    """
+    conf_path = None
+    model_root = settings.get('worker', 'model_data_directory', fallback='/home/worker/model')
+
+    # 1: Explicit location
+    conf_path = Path(settings.get('worker', 'oasislmf_config', fallback=""))
+    if conf_path.is_file():
+        return str(conf_path)
+
+    # 2: try 'model specific conf'
+    if model_id:
+        conf_path = Path(model_root, '{}-oasislmf.json'.format(model_id))
+        if conf_path.is_file():
+            return str(conf_path)
+
+    # 3: Try generic model conf
+    conf_path = Path(model_root, 'oasislmf.json')
+    if conf_path.is_file():
+        return str(conf_path)
+
+    # 4: check compatibility look for older model mount
+    conf_path = Path('/var/oasis', 'oasislmf.json')
+    if conf_path.is_file():
+        return str(conf_path)
+
+    # 5: warn and return fallback
+    logger.warning("WARNING: 'oasislmf.json' Configuration file not found")
+    return str(Path(model_root, 'oasislmf.json'))
+
+
+def get_model_settings():
+    """ Read the settings file from the path OASIS_MODEL_SETTINGS
+        returning the contents as a python dicself.t (none if not found)
+    """
+    settings_data = None
+    settings_fp = settings.get('worker', 'MODEL_SETTINGS_FILE', fallback=None)
+    try:
+        if os.path.isfile(settings_fp):
+            with open(settings_fp) as f:
+                settings_data = json.load(f)
+    except Exception as e:
+        logger.error("Failed to load Model settings: {}".format(e))
+
+    return settings_data
+
+
+def get_worker_versions():
+    """ Search and return the versions of Oasis components
+    """
+    ktool_ver_str = subprocess.getoutput('fmcalc -v')
+    plat_ver_file = '/home/worker/VERSION'
+
+    if os.path.isfile(plat_ver_file):
+        with open(plat_ver_file, 'r') as f:
+            plat_ver_str = f.read().strip()
+    else:
+        plat_ver_str = ""
+
+    return {
+        "oasislmf": mdk_version,
+        "ktools": ktool_ver_str,
+        "platform": plat_ver_str
+    }
+
+
+class InvalidInputsException(OasisException):
+    def __init__(self, input_archive):
+        super(InvalidInputsException, self).__init__('Inputs location not a tarfile: {}'.format(input_archive))
+
+
+class MissingModelDataException(OasisException):
+    def __init__(self, model_data_path):
+        super(MissingModelDataException, self).__init__('Model data not found: {}'.format(model_data_path))
+
+
+def prepare_complex_model_file_inputs(complex_model_files, run_directory):
+    """Places the specified complex model files in the run_directory.
+
+    The unique upload filenames are converted back to the original upload names, so that the
+    names match any input configuration file.
+
+    On Linux, the files are symlinked, whereas on Windows the files are simply copied.
+
+    Args:
+        complex_model_files (list of complex_model_data_file): List of dicts giving the files
+            to make available.
+        run_directory (str): Model inputs directory to place the files in.
+
+    Returns:
+        None.
+
+    """
+    for cmf in complex_model_files:
+        stored_fn = cmf[STORED_FILENAME]
+        orig_fn = cmf[ORIGINAL_FILENAME]
+
+        if filestore._is_locally_stored(stored_fn):
+            # If refrence is local filepath check that it exisits and copy/symlink
+            from_path = filestore.filepath(stored_fn)
+            to_path = os.path.join(run_directory, orig_fn)
+            if os.name == 'nt':
+                logger.info(f'complex_model_file: copy {from_path} to {to_path}')
+                shutil.copy(from_path, to_path)
+            else:
+                logger.info(f'complex_model_file: link {from_path} to {to_path}')
+                os.symlink(from_path, to_path)
+        else:
+            # If reference is a remote, then download the file & rename to 'original_filename'
+            fpath = filestore.get(stored_fn, run_directory)
+            shutil.move(fpath, os.path.join(run_directory, orig_fn))

--- a/src/model_execution_worker/utils.py
+++ b/src/model_execution_worker/utils.py
@@ -1,0 +1,43 @@
+__all__ = [
+    'LoggingTaskContext',
+    'log_params'
+]
+
+import logging
+import json
+
+class LoggingTaskContext:
+    """ Adds a file log handler to the root logger and pushes a copy all logs to
+        the 'log_filename'
+
+        Docs: https://docs.python.org/3/howto/logging-cookbook.html#using-a-context-manager-for-selective-logging
+    """
+
+    def __init__(self, logger, log_filename, level=None, close=True):
+        self.logger = logger
+        self.level = level
+        self.log_filename = log_filename
+        self.close = close
+        self.handler = logging.FileHandler(log_filename)
+
+    def __enter__(self):
+        if self.level:
+            self.handler.setLevel(self.level)
+        if self.handler:
+            self.logger.addHandler(self.handler)
+
+    def __exit__(self, et, ev, tb):
+        if self.handler:
+            self.logger.removeHandler(self.handler)
+        if self.handler and self.close:
+            self.handler.close()
+
+
+def log_params(params, kwargs, exclude_keys=[]):
+    if isinstance(params, list):
+        params = params[0]
+    print_params = {k: params[k] for k in set(list(params.keys())) - set(exclude_keys)}
+    logging.info('task params: \nparams={}, \nkwargs={}'.format(
+        json.dumps(print_params, indent=2),
+        json.dumps(kwargs, indent=2),
+    ))

--- a/src/model_execution_worker/utils.py
+++ b/src/model_execution_worker/utils.py
@@ -33,13 +33,14 @@ class LoggingTaskContext:
         Docs: https://docs.python.org/3/howto/logging-cookbook.html#using-a-context-manager-for-selective-logging
     """
 
-    def __init__(self, logger, log_filename, level=None, close=True):
+    def __init__(self, logger, log_filename, level=None, close=True, delete_on_exit=True):
         self.logger = logger
         self.level = level
         self.prev_level = logger.level
         self.log_filename = log_filename
         self.close = close
         self.handler = logging.FileHandler(log_filename)
+        self.delete_on_exit = delete_on_exit
 
     def __enter__(self):
         if self.level:
@@ -55,6 +56,8 @@ class LoggingTaskContext:
             self.logger.removeHandler(self.handler)
         if self.handler and self.close:
             self.handler.close()
+        if os.path.isfile(self.log_filename) and self.delete_on_exit:
+            os.remove(self.log_filename)
 
 
 def log_params(params, kwargs, exclude_keys=[]):

--- a/src/model_execution_worker/utils.py
+++ b/src/model_execution_worker/utils.py
@@ -17,6 +17,7 @@ import os
 import tempfile
 import shutil
 import subprocess
+from copy import deepcopy
 
 from pathlib2 import Path
 from oasislmf import __version__ as mdk_version
@@ -66,13 +67,14 @@ def paths_to_absolute_paths(dictionary):
     if not isinstance(dictionary, dict):
         raise ValueError("Input must be a dictionary.")
 
+    params = deepcopy(dictionary)
     for key, value in dictionary.items():
         if isinstance(value, str) and os.path.exists(value):
             # If the value is a string and exists as a path, convert it to absolute path
-            dictionary[key] = os.path.abspath(value)
+            params[key] = os.path.abspath(value)
         elif value is None:
-            del dictionary[key]
-    return dictionary
+            del params[key]
+    return params
 
 
 class TemporaryDir(object):

--- a/src/model_execution_worker/utils.py
+++ b/src/model_execution_worker/utils.py
@@ -63,15 +63,19 @@ def log_params(params, kwargs, exclude_keys=[]):
     ))
 
 
-def paths_to_absolute_paths(dictionary):
+def paths_to_absolute_paths(dictionary, config_path=''):
+    basedir = os.path.dirname(config_path)
     if not isinstance(dictionary, dict):
         raise ValueError("Input must be a dictionary.")
 
     params = deepcopy(dictionary)
     for key, value in dictionary.items():
-        if isinstance(value, str) and os.path.exists(value):
-            # If the value is a string and exists as a path, convert it to absolute path
-            params[key] = os.path.abspath(value)
+        # If the value is a string and exists as a path, convert it to absolute path
+        if isinstance(value, str):
+            path_value = os.path.join(basedir, value)
+            if os.path.exists(path_value):
+                params[key] = os.path.abspath(path_value)
+        # if value is 'None' remote it
         elif value is None:
             del params[key]
     return params

--- a/src/server/oasisapi/analyses/v2_api/tasks.py
+++ b/src/server/oasisapi/analyses/v2_api/tasks.py
@@ -505,7 +505,7 @@ def record_input_files(self, result, analysis_id=None, initiator_id=None, run_da
         tmp_file.seek(0)
         setattr(analysis, 'input_generation_traceback_file', RelatedFile.objects.create(
             file=File(tmp_file, name=random_filename),
-            filename=f'analysis_{analysis_id}_worker_traceback.txt',
+            filename=f'analysis_{analysis_id}_generation_traceback.txt',
             content_type='text/plain',
             creator=get_user_model().objects.get(pk=initiator_id),
         ))
@@ -540,7 +540,7 @@ def record_losses_files(self, result, analysis_id=None, initiator_id=None, slug=
         tmp_file.seek(0)
         setattr(analysis, 'run_traceback_file', RelatedFile.objects.create(
             file=File(tmp_file, name=random_filename),
-            filename=f'analysis_{analysis_id}_worker_traceback.txt',
+            filename=f'analysis_{analysis_id}_run_traceback.txt',
             content_type='text/plain',
             creator=get_user_model().objects.get(pk=initiator_id),
         ))

--- a/src/server/oasisapi/analyses/v2_api/tasks.py
+++ b/src/server/oasisapi/analyses/v2_api/tasks.py
@@ -490,9 +490,25 @@ def record_input_files(self, result, analysis_id=None, initiator_id=None, run_da
     analysis.summary_levels_file = store_file(summary_levels_fp, 'application/json', initiator,
                                               filename=f'analysis_{analysis_id}_exposure_summary_levels.json')
 
-    # if log_location:
-    #    analysis.input_generation_traceback_file = store_file(log_location, 'text/plain', initiator)
-    #    logger.info(analysis.input_generation_traceback_file)
+    # group sub-task logs and write to trace file
+    random_filename = '{}.txt'.format(uuid.uuid4().hex)
+    with TemporaryFile() as tmp_file:
+        # Write Error logs
+        subtask_qs = analysis.sub_task_statuses.filter(
+            status__in=[AnalysisTaskStatus.status_choices.COMPLETED]
+        )
+        for subtask in subtask_qs:
+            if hasattr(subtask.output_log, 'read'):
+                tmp_file.write(f'\n--- Subtask {subtask.id}, {subtask.slug} ---\n'.encode('utf-8'))
+                tmp_file.write(subtask.output_log.read())
+
+        tmp_file.seek(0)
+        setattr(analysis, traceback_property, RelatedFile.objects.create(
+            file=File(tmp_file, name=random_filename),
+            filename=f'analysis_{analysis_id}_worker_traceback.txt',
+            content_type='text/plain',
+            creator=get_user_model().objects.get(pk=initiator_id),
+        ))
 
     analysis.save()
     return result
@@ -671,7 +687,6 @@ def handle_task_failure(
             subtask_qs = analysis.sub_task_statuses.filter(
                 status__in=[AnalysisTaskStatus.status_choices.ERROR]
             )
-            from celery.contrib import rdb; rdb.set_trace()
             for subtask in subtask_qs:
                 if hasattr(subtask.error_log, 'read'):
                     tmp_file.write(f'\n--- Subtask {subtask.id}, {subtask.slug} ---\n'.encode('utf-8'))

--- a/src/server/oasisapi/analyses/v2_api/tasks.py
+++ b/src/server/oasisapi/analyses/v2_api/tasks.py
@@ -503,7 +503,7 @@ def record_input_files(self, result, analysis_id=None, initiator_id=None, run_da
                 tmp_file.write(subtask.output_log.read())
 
         tmp_file.seek(0)
-        setattr(analysis, traceback_property, RelatedFile.objects.create(
+        setattr(analysis, 'input_generation_traceback_file', RelatedFile.objects.create(
             file=File(tmp_file, name=random_filename),
             filename=f'analysis_{analysis_id}_worker_traceback.txt',
             content_type='text/plain',
@@ -674,7 +674,6 @@ def handle_task_failure(
         analysis = Analysis.objects.get(pk=analysis_id)
         analysis.status = failure_status
         analysis.task_finished = timezone.now()
-        #from celery.contrib import rdb; rdb.set_trace()
 
         random_filename = '{}.txt'.format(uuid.uuid4().hex)
         with TemporaryFile() as tmp_file:

--- a/src/server/oasisapi/analyses/v2_api/tasks.py
+++ b/src/server/oasisapi/analyses/v2_api/tasks.py
@@ -546,7 +546,7 @@ def record_losses_files(self, result, analysis_id=None, initiator_id=None, slug=
         ))
 
     # Store logs and output
-    analysis.run_log_file = store_file(result['log_location'], 'application/gzip', initiator, filename=f'analysis_{analysis_id}_logs.tar.gz')
+    analysis.run_log_file = store_file(result['run_logs'], 'application/gzip', initiator, filename=f'analysis_{analysis_id}_logs.tar.gz')
     analysis.output_file = store_file(result['output_location'], 'application/gzip', initiator, filename=f'analysis_{analysis_id}_output.tar.gz')
 
     analysis.save()


### PR DESCRIPTION
<!--start_release_notes-->
### Logging fixes for v1 workers 
* Fixed worker monitor failing to handle raised Exceptions - [#993](https://github.com/OasisLMF/OasisPlatform/issues/993)
* Fixed input generation logs lost on OOM  - [#798](https://github.com/OasisLMF/OasisPlatform/issues/798)
* Fixed `oasislmf.json` with `analysis_settings` set causing run errors = [#971](https://github.com/OasisLMF/OasisPlatform/issues/971)

### Logging fixes for v2 workers 
* Fixed missing ktools `run_log_file` not stored in `V2` loss generation runs - [#664](https://github.com/OasisLMF/OasisPlatform/issues/664)
* Fixed Subtask error logs are not available under analysis, all sub-tasks marked as `ERROR` will store their logs in `input_generation_traceback_file` or `run_traceback_file` - [#784](https://github.com/OasisLMF/OasisPlatform/issues/784)


> **Warning:** Keys generation needs [PR #1474](https://github.com/OasisLMF/OasisLMF/pull/1474) to work
<!--end_release_notes-->


- [x] Debug logging not working
- [x] apply logging for loss generation
- [x] test cancellation works as intended 
- [x] https://github.com/OasisLMF/OasisPlatform/issues/784
- [x] Fix and update unittesting for model workers
- [x] Update log file names based on run step (input gen / lossees) 
- [x] test complex_model_files
- [x] Fix missing run logs (v2 losses)  

