### PR TITLE
Fixes for task Cancellation Handling 

### DIFF
--- a/src/model_execution_worker/distributed_tasks.py
+++ b/src/model_execution_worker/distributed_tasks.py
@@ -691,7 +691,7 @@ def write_input_files(self, params, run_data_uuid=None, analysis_id=None, initia
     # clear out user-data,
     # these files should not be sorted in the generated inputs tar
     if params['user_data_dir'] is not None:
-        shutil.rmtree(params['user_data_dir'])
+        shutil.rmtree(params['user_data_dir'], ignore_errors=True)
 
     return {
         'lookup_error_location': filestore.put(os.path.join(params['target_dir'], 'keys-errors.csv')),

--- a/src/model_execution_worker/utils.py
+++ b/src/model_execution_worker/utils.py
@@ -104,7 +104,7 @@ class TemporaryDir(object):
 
     def __exit__(self, exc_type, exc_value, traceback):
         if not self.persist and os.path.isdir(self.name):
-            shutil.rmtree(self.name)
+            shutil.rmtree(self.name, ignore_errors=True)
 
 
 def get_oasislmf_config_path(settings, model_id=None):

--- a/src/server/oasisapi/analyses/models.py
+++ b/src/server/oasisapi/analyses/models.py
@@ -575,8 +575,9 @@ class Analysis(TimeStampedModel):
         self.save()
 
     def cancel_subtasks(self):
-        cancel_tasks = self.v2_cancel_subtasks_signature
-        task_id = cancel_tasks.apply_async(args=[self.pk], priority=1).id
+        if self.run_mode == self.run_mode_choices.V2:
+            cancel_tasks = self.v2_cancel_subtasks_signature
+            task_id = cancel_tasks.apply_async(args=[self.pk], priority=1).id
 
     def generate_inputs(self, initiator, run_mode_override=None):
         valid_choices = [

--- a/src/server/oasisapi/analyses/v1_api/tasks.py
+++ b/src/server/oasisapi/analyses/v1_api/tasks.py
@@ -456,17 +456,19 @@ def record_run_analysis_failure(analysis_pk, initiator_pk, traceback):
         analysis = Analysis.objects.get(pk=analysis_pk)
         analysis.status = Analysis.status_choices.RUN_ERROR
         analysis.task_finished = timezone.now()
-        analysis.save()
 
-        random_filename = '{}.txt'.format(uuid.uuid4().hex)
-        with TemporaryFile() as tmp_file:
-            tmp_file.write(traceback.encode('utf-8'))
-            analysis.run_traceback_file = RelatedFile.objects.create(
-                file=File(tmp_file, name=random_filename),
-                filename=f'analysis_{analysis_pk}_run_traceback.txt',
-                content_type='text/plain',
-                creator=get_user_model().objects.get(pk=initiator_pk),
-            )
+        if traceback:
+            random_filename = '{}.txt'.format(uuid.uuid4().hex)
+            with TemporaryFile() as tmp_file:
+                tmp_file.write(traceback.encode('utf-8'))
+                analysis.run_traceback_file = RelatedFile.objects.create(
+                    file=File(tmp_file, name=random_filename),
+                    filename=f'analysis_{analysis_pk}_run_traceback.txt',
+                    content_type='text/plain',
+                    creator=get_user_model().objects.get(pk=initiator_pk),
+                )
+        else:
+            logging.error('Could not extract traceback')
 
         # remove the current command log file
         if analysis.run_log_file:
@@ -488,17 +490,19 @@ def record_generate_input_failure(analysis_pk, initiator_pk, traceback):
         analysis = Analysis.objects.get(pk=analysis_pk)
         analysis.status = Analysis.status_choices.INPUTS_GENERATION_ERROR
         analysis.task_finished = timezone.now()
-        analysis.save()
 
-        random_filename = '{}.txt'.format(uuid.uuid4().hex)
-        with TemporaryFile() as tmp_file:
-            tmp_file.write(traceback.encode('utf-8'))
-            analysis.input_generation_traceback_file = RelatedFile.objects.create(
-                file=File(tmp_file, name=random_filename),
-                filename=f'analysis_{analysis_pk}_generation_traceback.txt',
-                content_type='text/plain',
-                creator=get_user_model().objects.get(pk=initiator_pk),
-            )
+        if traceback:
+            random_filename = '{}.txt'.format(uuid.uuid4().hex)
+            with TemporaryFile() as tmp_file:
+                tmp_file.write(traceback.encode('utf-8'))
+                analysis.input_generation_traceback_file = RelatedFile.objects.create(
+                    file=File(tmp_file, name=random_filename),
+                    filename=f'analysis_{analysis_pk}_generation_traceback.txt',
+                    content_type='text/plain',
+                    creator=get_user_model().objects.get(pk=initiator_pk),
+                )
+        else:
+            logging.error('Could not extract traceback')
 
         analysis.save()
     except Exception as e:

--- a/src/server/oasisapi/analyses/v2_api/tasks.py
+++ b/src/server/oasisapi/analyses/v2_api/tasks.py
@@ -684,7 +684,9 @@ def handle_task_failure(
         from ..models import Analysis
 
         analysis = Analysis.objects.get(pk=analysis_id)
-        analysis.status = failure_status
+        if analysis.status not in [analysis.status_choices.INPUTS_GENERATION_CANCELLED,
+                                   analysis.status_choices.RUN_CANCELLED]:
+            analysis.status = failure_status
         analysis.task_finished = timezone.now()
 
         random_filename = '{}.txt'.format(uuid.uuid4().hex)


### PR DESCRIPTION
<!--start_release_notes-->
### Fixes for task cancellation handling
Minor fixes to improve task cancellation
* Skip `cancel_subtasks` when cancellation is called on a `V1` analysis. Shouldn't cause issues if called but is also not needed. 
* Fixed issue marking `V2` analysis as `ERROR` when celery cord reports back a link error with `Task Terminated` 
* Fixed `V1 worker-monitor` throwing an error when trackback is not set.
* Fixed `V1 worker` raising error when removing a temp dir fails.   

<!--end_release_notes-->
