### PR TITLE
Remove DB migration env on websocket

### DIFF
--- a/kubernetes/charts/oasis-platform/templates/oasis_server.yaml
+++ b/kubernetes/charts/oasis-platform/templates/oasis_server.yaml
@@ -99,8 +99,6 @@ spec:
             {{- include "h.celeryDbVars" . | indent 12}}
             {{- include "h.brokerVars" . | indent 12 }}
             {{- include "h.channelLayerVars" . | indent 12 }}
-            - name: STARTUP_RUN_MIGRATIONS
-              value: "true"
             - name: OASIS_DEBUG
               value: "1"
             - name: OASIS_URL_SUB_PATH


### PR DESCRIPTION
<!--start_release_notes-->
### Remove DB migration env on websocket
Fixed - Django Migration should only happen in one container
<!--end_release_notes-->
