### PR TITLE
Fix namespace issue when called from analysis serializer

### DIFF
--- a/src/server/oasisapi/data_files/models.py
+++ b/src/server/oasisapi/data_files/models.py
@@ -42,11 +42,12 @@ class DataFile(TimeStampedModel):
         return 'DataFile_{}'.format(self.file)
 
     def _update_ns(self, request=None):
-        """ WORKAROUND - this is needed for when a copy request is issued
-                         from the portfolio view '/{ver}/portfolios/{id}/create_analysis/'
+        """ WORKAROUND
+        this is needed for when a list request is issued
+        from the analyses or analysis_model views '/{ver}/analyses/{id}/data_files/'
 
-                         The inncorrect namespace '{ver}-portfolios' is inherited from the
-                         original request. This needs to be replaced with '{ver}-analyses'
+        The inncorrect namespace '{ver}-analyses' is inherited from the
+        original request. This needs to be replaced with '{ver}-files'
         """
         if not request:
             return None

--- a/src/server/oasisapi/data_files/models.py
+++ b/src/server/oasisapi/data_files/models.py
@@ -41,6 +41,20 @@ class DataFile(TimeStampedModel):
     def __str__(self):
         return 'DataFile_{}'.format(self.file)
 
+    def _update_ns(self, request=None):
+        """ WORKAROUND - this is needed for when a copy request is issued
+                         from the portfolio view '/{ver}/portfolios/{id}/create_analysis/'
+
+                         The inncorrect namespace '{ver}-portfolios' is inherited from the
+                         original request. This needs to be replaced with '{ver}-analyses'
+        """
+        if not request:
+            return None
+        ns_ver, ns_view = request.version.split('-')
+        if ns_view != 'files':
+            request.version = f'{ns_ver}-files'
+        return request
+
     def get_filename(self):
         if self.file:
             return self.file.filename
@@ -61,4 +75,4 @@ class DataFile(TimeStampedModel):
 
     def get_absolute_data_file_url(self, request=None, namespace=None):
         override_ns = f'{namespace}:' if namespace else ''
-        return reverse(f'{override_ns}data-file-content', kwargs={'pk': self.pk}, request=request)
+        return reverse(f'{override_ns}data-file-content', kwargs={'pk': self.pk}, request=self._update_ns(request))


### PR DESCRIPTION
<!--start_release_notes-->
### Fix DataFiles namespace issue when called by analyses serializer
Fixed issue where the endpoints `/analyses/{id}/data_files/` and `/models/{id}/data_files/` failed with:
```
Exception Type: NoReverseMatch at /api/v2/analyses/{id}/data_files/
Exception Value: Reverse for 'data-file-content' not found. 'data-file-content' is not a valid view function or pattern name.
```

This comes from the the namespace value in **request.version**, which should read `'v2-files'` and not `'v2-analyses'`.
<!--end_release_notes-->
