### PR TITLE
Add a guard around run_log_file in v2 worker monitor

### DIFF
--- a/src/server/oasisapi/analyses/v2_api/tasks.py
+++ b/src/server/oasisapi/analyses/v2_api/tasks.py
@@ -546,7 +546,9 @@ def record_losses_files(self, result, analysis_id=None, initiator_id=None, slug=
         ))
 
     # Store logs and output
-    analysis.run_log_file = store_file(result['run_logs'], 'application/gzip', initiator, filename=f'analysis_{analysis_id}_logs.tar.gz')
+    if result.get('run_logs', None):
+        analysis.run_log_file = store_file(result['run_logs'], 'application/gzip', initiator, filename=f'analysis_{analysis_id}_logs.tar.gz')
+
     analysis.output_file = store_file(result['output_location'], 'application/gzip', initiator, filename=f'analysis_{analysis_id}_output.tar.gz')
 
     analysis.save()


### PR DESCRIPTION
**IMPORTANT: Please attach or create an issue after submitting a Pull Request.

<!--start_release_notes-->
### Add a guard around run_log_file in v2 worker monitor
... Release notes description / summary 
... Any text between these two tags will be automatically pulled into the platform release notes 
<!--end_release_notes-->
