### PR TITLE
Workaround for file caching issue

### DIFF
--- a/src/server/oasisapi/analyses/v1_api/tasks.py
+++ b/src/server/oasisapi/analyses/v1_api/tasks.py
@@ -381,7 +381,8 @@ def record_run_analysis_result(res, analysis_pk, initiator_pk):
         analysis.run_log_file = store_file(log_location, 'application/gzip', initiator, filename=f'{task_id}_analysis_{analysis_pk}_logs.tar.gz')
     # record the error file
     if traceback_location:
-        analysis.run_traceback_file = store_file(traceback_location, 'text/plain', initiator, filename=f'{task_id}_analysis_{analysis_pk}_run_traceback.txt')
+        analysis.run_traceback_file = store_file(traceback_location, 'text/plain', initiator,
+                                                 filename=f'{task_id}_analysis_{analysis_pk}_run_traceback.txt')
     analysis.save()
 
 
@@ -403,7 +404,7 @@ def record_generate_input_result(result, analysis_pk, initiator_pk):
 
     analysis = Analysis.objects.get(pk=analysis_pk)
     initiator = get_user_model().objects.get(pk=initiator_pk)
-    task_id = analysis.generate_inputs_task_id ## add check to make sure id is set??
+    task_id = analysis.generate_inputs_task_id  # add check to make sure id is set??
 
     # Remove previous output
     delete_prev_output(analysis, [

--- a/src/server/oasisapi/analyses/v2_api/tasks.py
+++ b/src/server/oasisapi/analyses/v2_api/tasks.py
@@ -482,9 +482,12 @@ def record_input_files(self, result, analysis_id=None, initiator_id=None, run_da
     initiator = get_user_model().objects.get(pk=initiator_id)
 
     analysis.status = Analysis.status_choices.READY
-    analysis.input_file = store_file(input_location, 'application/gzip', initiator, filename=f'{analysis.generate_inputs_task_id}_analysis_{analysis_id}_inputs.tar.gz')
-    analysis.lookup_errors_file = store_file(lookup_error_fp, 'text/csv', initiator, filename=f'{analysis.generate_inputs_task_id}_analysis_{analysis_id}_keys-errors.csv')
-    analysis.lookup_success_file = store_file(lookup_success_fp, 'text/csv', initiator, filename=f'{analysis.generate_inputs_task_id}_analysis_{analysis_id}_gul_summary_map.csv')
+    analysis.input_file = store_file(input_location, 'application/gzip', initiator,
+                                     filename=f'{analysis.generate_inputs_task_id}_analysis_{analysis_id}_inputs.tar.gz')
+    analysis.lookup_errors_file = store_file(lookup_error_fp, 'text/csv', initiator,
+                                             filename=f'{analysis.generate_inputs_task_id}_analysis_{analysis_id}_keys-errors.csv')
+    analysis.lookup_success_file = store_file(lookup_success_fp, 'text/csv', initiator,
+                                              filename=f'{analysis.generate_inputs_task_id}_analysis_{analysis_id}_gul_summary_map.csv')
     analysis.lookup_validation_file = store_file(lookup_validation_fp, 'application/json', initiator,
                                                  filename=f'{analysis.generate_inputs_task_id}_analysis_{analysis_id}_exposure_summary_report.json')
     analysis.summary_levels_file = store_file(summary_levels_fp, 'application/json', initiator,
@@ -547,9 +550,11 @@ def record_losses_files(self, result, analysis_id=None, initiator_id=None, slug=
 
     # Store logs and output
     if result.get('run_logs', None):
-        analysis.run_log_file = store_file(result['run_logs'], 'application/gzip', initiator, filename=f'{analysis.run_task_id}_analysis_{analysis_id}_logs.tar.gz')
+        analysis.run_log_file = store_file(result['run_logs'], 'application/gzip', initiator,
+                                           filename=f'{analysis.run_task_id}_analysis_{analysis_id}_logs.tar.gz')
 
-    analysis.output_file = store_file(result['output_location'], 'application/gzip', initiator, filename=f'{analysis.run_task_id}_analysis_{analysis_id}_output.tar.gz')
+    analysis.output_file = store_file(result['output_location'], 'application/gzip', initiator,
+                                      filename=f'{analysis.run_task_id}_analysis_{analysis_id}_output.tar.gz')
 
     # remove then store raw files.
     analysis.raw_output_files.all().delete()

--- a/src/server/oasisapi/analyses/v2_api/tasks.py
+++ b/src/server/oasisapi/analyses/v2_api/tasks.py
@@ -254,7 +254,7 @@ class LogTaskError(Task):
                         tmp_file.write(traceback_msg.encode('utf-8'))
                         analysis.input_generation_traceback_file = RelatedFile.objects.create(
                             file=File(tmp_file, name=random_filename),
-                            filename=f'analysis_{analysis_pk}_generation_traceback.txt',
+                            filename=f'{analysis.generate_inputs_task_id}_analysis_{analysis_pk}_generation_traceback.txt',
                             content_type='text/plain',
                             creator=initiator,
                         )
@@ -264,7 +264,7 @@ class LogTaskError(Task):
                         tmp_file.write(traceback_msg.encode('utf-8'))
                         analysis.run_traceback_file = RelatedFile.objects.create(
                             file=File(tmp_file, name=random_filename),
-                            filename=f'analysis_{analysis_pk}_run_traceback.txt',
+                            filename=f'{analysis.run_task_id}_analysis_{analysis_pk}_run_traceback.txt',
                             content_type='text/plain',
                             creator=initiator,
                         )
@@ -482,13 +482,13 @@ def record_input_files(self, result, analysis_id=None, initiator_id=None, run_da
     initiator = get_user_model().objects.get(pk=initiator_id)
 
     analysis.status = Analysis.status_choices.READY
-    analysis.input_file = store_file(input_location, 'application/gzip', initiator, filename=f'analysis_{analysis_id}_inputs.tar.gz')
-    analysis.lookup_errors_file = store_file(lookup_error_fp, 'text/csv', initiator, filename=f'analysis_{analysis_id}_keys-errors.csv')
-    analysis.lookup_success_file = store_file(lookup_success_fp, 'text/csv', initiator, filename=f'analysis_{analysis_id}_gul_summary_map.csv')
+    analysis.input_file = store_file(input_location, 'application/gzip', initiator, filename=f'{analysis.generate_inputs_task_id}_analysis_{analysis_id}_inputs.tar.gz')
+    analysis.lookup_errors_file = store_file(lookup_error_fp, 'text/csv', initiator, filename=f'{analysis.generate_inputs_task_id}_analysis_{analysis_id}_keys-errors.csv')
+    analysis.lookup_success_file = store_file(lookup_success_fp, 'text/csv', initiator, filename=f'{analysis.generate_inputs_task_id}_analysis_{analysis_id}_gul_summary_map.csv')
     analysis.lookup_validation_file = store_file(lookup_validation_fp, 'application/json', initiator,
-                                                 filename=f'analysis_{analysis_id}_exposure_summary_report.json')
+                                                 filename=f'{analysis.generate_inputs_task_id}_analysis_{analysis_id}_exposure_summary_report.json')
     analysis.summary_levels_file = store_file(summary_levels_fp, 'application/json', initiator,
-                                              filename=f'analysis_{analysis_id}_exposure_summary_levels.json')
+                                              filename=f'{analysis.generate_inputs_task_id}_analysis_{analysis_id}_exposure_summary_levels.json')
 
     # group sub-task logs and write to trace file
     random_filename = '{}.txt'.format(uuid.uuid4().hex)
@@ -505,7 +505,7 @@ def record_input_files(self, result, analysis_id=None, initiator_id=None, run_da
         tmp_file.seek(0)
         setattr(analysis, 'input_generation_traceback_file', RelatedFile.objects.create(
             file=File(tmp_file, name=random_filename),
-            filename=f'analysis_{analysis_id}_generation_traceback.txt',
+            filename=f'{analysis.generate_inputs_task_id}_analysis_{analysis_id}_generation_traceback.txt',
             content_type='text/plain',
             creator=get_user_model().objects.get(pk=initiator_id),
         ))
@@ -540,16 +540,16 @@ def record_losses_files(self, result, analysis_id=None, initiator_id=None, slug=
         tmp_file.seek(0)
         setattr(analysis, 'run_traceback_file', RelatedFile.objects.create(
             file=File(tmp_file, name=random_filename),
-            filename=f'analysis_{analysis_id}_run_traceback.txt',
+            filename=f'{analysis.run_task_id}_analysis_{analysis_id}_run_traceback.txt',
             content_type='text/plain',
             creator=get_user_model().objects.get(pk=initiator_id),
         ))
 
     # Store logs and output
     if result.get('run_logs', None):
-        analysis.run_log_file = store_file(result['run_logs'], 'application/gzip', initiator, filename=f'analysis_{analysis_id}_logs.tar.gz')
+        analysis.run_log_file = store_file(result['run_logs'], 'application/gzip', initiator, filename=f'{analysis.run_task_id}_analysis_{analysis_id}_logs.tar.gz')
 
-    analysis.output_file = store_file(result['output_location'], 'application/gzip', initiator, filename=f'analysis_{analysis_id}_output.tar.gz')
+    analysis.output_file = store_file(result['output_location'], 'application/gzip', initiator, filename=f'{analysis.run_task_id}_analysis_{analysis_id}_output.tar.gz')
 
     # remove then store raw files.
     analysis.raw_output_files.all().delete()
@@ -715,7 +715,7 @@ def handle_task_failure(
             tmp_file.seek(0)
             setattr(analysis, traceback_property, RelatedFile.objects.create(
                 file=File(tmp_file, name=random_filename),
-                filename=f'analysis_{analysis_id}_worker_traceback.txt',
+                filename=f'{run_data_uuid}_analysis_{analysis_id}_worker_traceback.txt',
                 content_type='text/plain',
                 creator=get_user_model().objects.get(pk=initiator_id),
             ))


### PR DESCRIPTION
<!--start_release_notes-->
### Workaround for file caching issue
Unsure all created filenames are unique by appending the celery task UUID to the name.  Using the format `{UUID}_analysis_{ID}_{FILENAME}`
<!--end_release_notes-->

![Screenshot from 2024-05-15 14-39-17](https://github.com/OasisLMF/OasisPlatform/assets/9889973/24357514-4d9b-4605-8e12-8fa6dc04e798)

![Screenshot from 2024-05-15 14-42-27](https://github.com/OasisLMF/OasisPlatform/assets/9889973/c6d88f5d-c16a-4ed5-aa5c-82a6d8e55086)

> **Note:** The subtask log files take the celery's subtask id, so its different from the main celery canvas id stored when trigging the execution. 

- [ ] Add fallback to create a new UUID if analysis is missing assigned celery task id 

