### PR TITLE
Azure Postgres Flexible server support   

### DIFF
--- a/kubernetes/charts/oasis-platform/templates/keycloak.yaml
+++ b/kubernetes/charts/oasis-platform/templates/keycloak.yaml
@@ -98,6 +98,10 @@ spec:
           ports:
             - containerPort: {{ .Values.keycloak.port }}
           env:
+            {{- if (.Values.azure).secretProvider }}
+            - name: KC_DB_URL_PROPERTIES
+              value: "?sslmode=verify-full&sslcert=root.crt"
+            {{- end }}
             - name: KC_LOGLEVEL
               value: DEBUG
             - name: PROXY_ADDRESS_FORWARDING
@@ -172,12 +176,24 @@ spec:
             - name: realm-config
               mountPath: /opt/keycloak/data/import/oasis-realm.json
               subPath: oasis
+            - name: azure-keycloak-cert
+              mountPath: /opt/keycloak/.postgresql/root.crt
+              subPath: keycloak-cert-file
+              readOnly: true  
 
       volumes:
         - name: realm-config
           configMap:
             name: {{ $realmSecretName }}
 {{- if (.Values.azure).secretProvider }}
+        - name: azure-keycloak-cert
+          csi:
+            driver: secrets-store.csi.k8s.io
+            readOnly: true
+            volumeAttributes:
+              secretProviderClass: "azure-secret-provider"
+              objectName: "keycloak-cert-file"
+              objectType: "secret"
         - name: azure-secret-provider
           csi:
             driver: secrets-store.csi.k8s.io

--- a/kubernetes/charts/oasis-platform/templates/keycloak.yaml
+++ b/kubernetes/charts/oasis-platform/templates/keycloak.yaml
@@ -98,10 +98,12 @@ spec:
           ports:
             - containerPort: {{ .Values.keycloak.port }}
           env:
-            {{- if (.Values.azure).secretProvider }}
+           {{- if (.Values.azure).secretProvider }}
+           {{- if hasKey .Values.azure.secretProvider.secrets "keycloak-cert" }}
             - name: KC_DB_URL_PROPERTIES
               value: "?sslmode=verify-full&sslcert=root.crt"
-            {{- end }}
+           {{- end }}
+           {{- end }}
             - name: KC_LOGLEVEL
               value: DEBUG
             - name: PROXY_ADDRESS_FORWARDING
@@ -176,16 +178,21 @@ spec:
             - name: realm-config
               mountPath: /opt/keycloak/data/import/oasis-realm.json
               subPath: oasis
+            {{- if (.Values.azure).secretProvider }}
+            {{- if hasKey .Values.azure.secretProvider.secrets "keycloak-cert" }}
             - name: azure-keycloak-cert
               mountPath: /opt/keycloak/.postgresql/root.crt
               subPath: keycloak-cert-file
-              readOnly: true  
+              readOnly: true
+            {{- end }}
+            {{- end }}
 
       volumes:
         - name: realm-config
           configMap:
             name: {{ $realmSecretName }}
-{{- if (.Values.azure).secretProvider }}
+    {{- if (.Values.azure).secretProvider }}
+      {{- if hasKey .Values.azure.secretProvider.secrets "keycloak-cert" }}
         - name: azure-keycloak-cert
           csi:
             driver: secrets-store.csi.k8s.io
@@ -194,10 +201,11 @@ spec:
               secretProviderClass: "azure-secret-provider"
               objectName: "keycloak-cert-file"
               objectType: "secret"
+      {{- end }}
         - name: azure-secret-provider
           csi:
             driver: secrets-store.csi.k8s.io
             readOnly: true
             volumeAttributes:
               secretProviderClass: "azure-secret-provider"
-{{- end }}
+    {{- end }}


### PR DESCRIPTION
<!--start_release_notes-->
### Azure Postgres Flexible server support   
Added option to mount Keycloak certificate (from MS) to support Postgres Flexible server deployments 
<!--end_release_notes-->


- [x] needs an extra check, only mount if Azure & also PostgresFlex is being used 
- [x] Test deployment using minikube & azure + flexible server  