### PR TITLE
Minor bug fixes for worker and server

### DIFF
--- a/src/model_execution_worker/tasks.py
+++ b/src/model_execution_worker/tasks.py
@@ -456,7 +456,7 @@ def generate_input(self,
                 os.path.join(oasis_files_dir, 'analysis_settings.json')
             )
         if complex_data_files:
-            prepare_complex_model_file_inputs(complex_data_files, input_data_dir)
+            prepare_complex_model_file_inputs(complex_data_files, input_data_dir, filestore)
             task_params['user_data_dir'] = input_data_dir
 
         config_path = get_oasislmf_config_path(settings)

--- a/src/server/oasisapi/analysis_models/v2_api/serializers.py
+++ b/src/server/oasisapi/analysis_models/v2_api/serializers.py
@@ -229,7 +229,11 @@ class ModelScalingConfigSerializer(serializers.ModelSerializer):
 
         # Check that `worker_count_min` < `worker_count_max`
         m_id = self.context['request'].parser_context['kwargs']['pk']
-        current_val = ModelScalingOptions.objects.get(id=m_id)
+        try:
+            current_val = ModelScalingOptions.objects.get(id=m_id)
+        except ModelScalingOptions.DoesNotExist:
+            # create a default config object for validation
+            current_val = ModelScalingOptions()
 
         wrk_min = self.initial_data.get('worker_count_min', current_val.worker_count_min)
         wrk_max = self.initial_data.get('worker_count_max', current_val.worker_count_max)


### PR DESCRIPTION
<!--start_release_notes-->
### Minor bug fixes for worker and server 
* Fixed Scaling configuration validation error (Server 500) when model is missing its default `ModelScalingOptions` object  
* Fixed missing `filestore` arg in call to **prepare_complex_model_file_inputs( .. )**
<!--end_release_notes-->
