### PR TITLE
 CI - Disable external docker images scanning 

### DIFF
--- a/.github/workflows/scan-external.yml
+++ b/.github/workflows/scan-external.yml
@@ -1,10 +1,6 @@
 name: External Vulnerability Scanning
 
 on:
-  pull_request:
-    branches:
-      - stable**
-
   workflow_dispatch:
     inputs:
       cve_severity:


### PR DESCRIPTION
**IMPORTANT: Please attach or create an issue after submitting a Pull Request.

<!--start_release_notes-->
### CI - Disable external docker images scanning 
Switched the external image scans to manual only. 
This almost always fails, since external images are out of our control. 
<!--end_release_notes-->
