### PR TITLE
Backport 1.28.x -  Fixed missing call to param update method - V1 Workers (#1045)

### DIFF
--- a/requirements-server.txt
+++ b/requirements-server.txt
@@ -118,7 +118,7 @@ drf-yasg==1.21.5
     # via -r requirements-server.in
 greenlet==2.0.2
     # via sqlalchemy
-gunicorn==20.1.0
+gunicorn==22.0.0
     # via -r requirements-server.in
 hyperlink==21.0.0
     # via
@@ -173,6 +173,7 @@ ods-tools==3.1.4
 packaging==23.0
     # via
     #   drf-yasg
+    #   gunicorn
     #   ods-tools
 pandas==1.5.3
     # via
@@ -196,7 +197,7 @@ pycparser==2.21
     # via cffi
 pyjwt==2.6.0
     # via djangorestframework-simplejwt
-pymysql==1.1.0
+pymysql==1.1.1
     # via -r requirements-server.in
 pyopenssl==24.0.0
     # via twisted
@@ -236,7 +237,7 @@ six==1.16.0
     #   service-identity
 sqlalchemy==2.0.5.post1
     # via -r requirements-server.in
-sqlparse==0.4.4
+sqlparse==0.5.0
     # via
     #   django
     #   django-debug-toolbar

--- a/requirements-worker.txt
+++ b/requirements-worker.txt
@@ -156,7 +156,7 @@ pyarrow==14.0.1
     # via oasislmf
 pycparser==2.21
     # via cffi
-pymysql==1.1.0
+pymysql==1.1.1
     # via -r requirements-worker.in
 pyproj==3.4.1
     # via geopandas

--- a/requirements.txt
+++ b/requirements.txt
@@ -199,7 +199,7 @@ geopandas==0.12.2
     # via oasislmf
 greenlet==2.0.2
     # via sqlalchemy
-gunicorn==20.1.0
+gunicorn==22.0.0
     # via -r ./requirements-server.in
 hyperlink==21.0.0
     # via
@@ -288,6 +288,7 @@ packaging==23.0
     #   drf-yasg
     #   fastparquet
     #   geopandas
+    #   gunicorn
     #   ods-tools
     #   pyproject-api
     #   pytest
@@ -337,7 +338,7 @@ pyflakes==3.0.1
     # via flake8
 pyjwt==2.6.0
     # via djangorestframework-simplejwt
-pymysql==1.1.0
+pymysql==1.1.1
     # via
     #   -r ./requirements-server.in
     #   -r ./requirements-worker.in
@@ -428,7 +429,7 @@ sqlalchemy==2.0.5.post1
     # via
     #   -r ./requirements-server.in
     #   -r ./requirements-worker.in
-sqlparse==0.4.4
+sqlparse==0.5.0
     # via
     #   django
     #   django-debug-toolbar

--- a/src/model_execution_worker/tasks.py
+++ b/src/model_execution_worker/tasks.py
@@ -284,7 +284,6 @@ def start_analysis(analysis_settings, input_location, complex_data_files=None, *
 
     """
     # Check that the input archive exists and is valid
-    filestore = get_filestore(settings)
     from oasislmf.manager import OasisManager
 
     logger.info("args: {}".format(str(locals())))
@@ -397,7 +396,6 @@ def generate_input(self,
 
     # Start Oasis file generation
     notify_api_status(analysis_pk, 'INPUTS_GENERATION_STARTED')
-    filestore = get_filestore(settings)
     from oasislmf.manager import OasisManager
 
     # filestore.media_root = settings.get('worker', 'MEDIA_ROOT')

--- a/src/model_execution_worker/tasks.py
+++ b/src/model_execution_worker/tasks.py
@@ -17,7 +17,6 @@ from celery.utils.log import get_task_logger
 from celery.signals import worker_ready
 from celery.exceptions import WorkerLostError, Terminated
 
-from oasislmf.manager import OasisManager
 from oasislmf.utils.data import get_json
 from oasislmf.utils.exceptions import OasisException
 from oasislmf.utils.status import OASIS_TASK_STATUS

--- a/src/model_execution_worker/tasks.py
+++ b/src/model_execution_worker/tasks.py
@@ -284,6 +284,9 @@ def start_analysis(analysis_settings, input_location, complex_data_files=None, *
 
     """
     # Check that the input archive exists and is valid
+    filestore = get_filestore(settings)
+    from oasislmf.manager import OasisManager
+
     logger.info("args: {}".format(str(locals())))
     logger.info(str(get_worker_versions()))
     tmpdir_persist = settings.getboolean('worker', 'KEEP_RUN_DIR', fallback=False)
@@ -330,7 +333,10 @@ def start_analysis(analysis_settings, input_location, complex_data_files=None, *
 
         # Create and log params
         run_params = {**config, **task_params}
-        params = paths_to_absolute_paths(run_params, config_path)
+        gen_losses_params = OasisManager()._params_generate_losses(**run_params)
+        post_hook_params = OasisManager()._params_post_analysis(**run_params)
+        params = paths_to_absolute_paths({**gen_losses_params, **post_hook_params}, config_path)
+
         if debug_worker:
             log_params(params, kwargs)
 
@@ -391,7 +397,10 @@ def generate_input(self,
 
     # Start Oasis file generation
     notify_api_status(analysis_pk, 'INPUTS_GENERATION_STARTED')
-    filestore.media_root = settings.get('worker', 'MEDIA_ROOT')
+    filestore = get_filestore(settings)
+    from oasislmf.manager import OasisManager
+
+    # filestore.media_root = settings.get('worker', 'MEDIA_ROOT')
     tmpdir_persist = settings.getboolean('worker', 'KEEP_RUN_DIR', fallback=False)
     tmpdir_base = settings.get('worker', 'BASE_RUN_DIR', fallback=None)
 
@@ -432,7 +441,11 @@ def generate_input(self,
         config_path = get_oasislmf_config_path(settings)
         config = get_json(config_path)
         lookup_params = {**{k: v for k, v in config.items() if not k.startswith('oed_')}, **task_params}
-        params = paths_to_absolute_paths(lookup_params, config_path)
+
+        gen_files_params = OasisManager()._params_generate_files(**lookup_params)
+        pre_hook_params = OasisManager()._params_exposure_pre_analysis(**lookup_params)
+        params = paths_to_absolute_paths({**gen_files_params, **pre_hook_params}, config_path)
+
         if debug_worker:
             log_params(params, kwargs, exclude_keys=[
                 'profile_loc',

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -109,21 +109,26 @@ class StartAnalysis(TestCase):
                 def fake_run_dir(*args, **kwargs):
                     yield run_dir
 
-                with patch('src.model_execution_worker.tasks.OasisManager', Mock(return_value=cmd_instance)) as cmd_mock, \
+                with patch('oasislmf.manager.OasisManager.generate_oasis_losses', Mock(return_value='mocked result')) as cmd_mock, \
                         patch('src.model_execution_worker.tasks.get_worker_versions', Mock(return_value='')), \
                         patch('src.model_execution_worker.tasks.filestore.compress') as tarfile, \
                         patch('src.model_execution_worker.tasks.TASK_LOG_DIR', log_dir), \
                         patch('src.model_execution_worker.tasks.TemporaryDir', fake_run_dir):
 
-                    cmd_instance.generate_oasis_losses.return_value = "mocked result"  # Mock the return value
                     output_location, log_location, error_location, returncode = start_analysis(
                         os.path.join(media_root, 'analysis_settings.json'),
                         os.path.join(media_root, 'location.tar'),
                         log_filename=log_file,
                     )
-                    expected_params = {**params, **{"analysis_settings_json": os.path.join(media_root, 'analysis_settings.json')}}
-                    cmd_instance.generate_oasis_losses.assert_called_once_with(**expected_params)
-                    tarfile.assert_called_once_with(os.path.join(media_root, output_location), os.path.join(run_dir, 'output'), 'output')
+
+                    cmd_mock.assert_called_once()
+                    called_args = cmd_mock.call_args.kwargs
+                    self.assertEqual(called_args.get('oasis_files_dir', None), params.get('oasis_files_dir'))
+                    self.assertEqual(called_args.get('model_run_dir', None), params.get('model_run_dir'))
+                    self.assertEqual(called_args.get('ktools_fifo_relative', None), params.get('ktools_fifo_relative'))
+                    self.assertEqual(called_args.get('verbose', None), params.get('verbose'))
+                    self.assertEqual(called_args.get('analysis_settings.json', None), params.get('analysis_settings.json'))
+                    tarfile.assert_called_once_with(mock.ANY, os.path.join(run_dir, 'output'), 'output')
 
 
 class StartAnalysisTask(TestCase):

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -128,7 +128,7 @@ class StartAnalysis(TestCase):
                     self.assertEqual(called_args.get('ktools_fifo_relative', None), params.get('ktools_fifo_relative'))
                     self.assertEqual(called_args.get('verbose', None), params.get('verbose'))
                     self.assertEqual(called_args.get('analysis_settings.json', None), params.get('analysis_settings.json'))
-                    tarfile.assert_called_once_with(mock.ANY, os.path.join(run_dir, 'output'), 'output')
+                    tarfile.assert_called_once_with(ANY, os.path.join(run_dir, 'output'), 'output')
 
 
 class StartAnalysisTask(TestCase):


### PR DESCRIPTION
<!--start_release_notes-->
### Backport 1.28.x -  Fixed missing call to param update method - V1 Workers (#1045)
Added missing param compatibility call, this checks for older parameter names in `oasislmf.json` and updates when found. 
<!--end_release_notes-->
