### PR TITLE
Fix autoscaling ramping down when new analysis run is triggered  

### DIFF
--- a/src/model_execution_worker/distributed_tasks.py
+++ b/src/model_execution_worker/distributed_tasks.py
@@ -535,12 +535,6 @@ def pre_analysis_hook(self,
             # OED has been loaded and check in this step, disable check in file gen
             # This is in case pre-exposure func has added non-standard cols to the file.
             params['check_oed'] = False
-
-        # remove any pre-loaded files (only affects this worker)
-        oed_files = {v for k, v in params.items() if k.startswith('oed_') and isinstance(v, str)}
-        for filepath in oed_files:
-            if Path(filepath).exists():
-                os.remove(filepath)
     else:
         logger.info('pre_analysis_hook: SKIPPING, param "exposure_pre_analysis_module" not set')
     params['log_location'] = filestore.put(kwargs.get('log_filename'))

--- a/src/server/oasisapi/analyses/models.py
+++ b/src/server/oasisapi/analyses/models.py
@@ -65,7 +65,7 @@ class AnalysisTaskStatusQuerySet(models.QuerySet):
         statuses = self.bulk_create(objs)
 
         send_task_status_message(build_all_queue_status_message())
-        #self._send_socket_messages(statuses)
+        # self._send_socket_messages(statuses)
 
     # This generates too much WS traffic disableing message per sub-task update
     # def update(self, **kwargs):

--- a/src/server/oasisapi/analyses/models.py
+++ b/src/server/oasisapi/analyses/models.py
@@ -18,7 +18,7 @@ from rest_framework.reverse import reverse
 from src.server.oasisapi.celery_app_v1 import v1 as celery_app_v1
 from src.server.oasisapi.celery_app_v2 import v2 as celery_app_v2
 from src.server.oasisapi.queues.consumers import send_task_status_message, TaskStatusMessageItem, \
-    TaskStatusMessageAnalysisItem, build_task_status_message
+    TaskStatusMessageAnalysisItem, build_task_status_message, build_all_queue_status_message
 from ..analysis_models.models import AnalysisModel, ModelChunkingOptions
 from ..data_files.models import DataFile
 from ..files.models import RelatedFile, file_storage_link
@@ -64,7 +64,8 @@ class AnalysisTaskStatusQuerySet(models.QuerySet):
         """
         statuses = self.bulk_create(objs)
 
-        self._send_socket_messages(statuses)
+        send_task_status_message(build_all_queue_status_message())
+        #self._send_socket_messages(statuses)
 
     # This generates too much WS traffic disableing message per sub-task update
     # def update(self, **kwargs):

--- a/src/server/oasisapi/queues/consumers.py
+++ b/src/server/oasisapi/queues/consumers.py
@@ -101,8 +101,10 @@ def build_all_queue_status_message(analysis_filter=None, message_type='queue_sta
         queue_names = analyses.values_list('sub_task_statuses__queue_name', flat=True).distinct()
     else:
         analyses = Analysis.objects.filter(status__in=[
+            Analysis.status_choices.NEW,
             Analysis.status_choices.INPUTS_GENERATION_QUEUED,
             Analysis.status_choices.INPUTS_GENERATION_STARTED,
+            Analysis.status_choices.READY,
             Analysis.status_choices.RUN_QUEUED,
             Analysis.status_choices.RUN_STARTED,
         ])


### PR DESCRIPTION
<!--start_release_notes-->
### Fix autoscaling ramping down when new analysis run is triggered  
* Fixed issue with auto-scaler send full queue state to web-socket when an analysis is submitted (not a filtered list)
* Fixed bug in pre-analysis hook causing custom oed spec to be removed 
<!--end_release_notes-->
