### PR TITLE
Fix keycloak when running with Postgres Flexible server

### DIFF
--- a/kubernetes/charts/oasis-platform/templates/keycloak.yaml
+++ b/kubernetes/charts/oasis-platform/templates/keycloak.yaml
@@ -101,7 +101,7 @@ spec:
            {{- if (.Values.azure).secretProvider }}
            {{- if hasKey .Values.azure.secretProvider.secrets "keycloak-cert" }}
             - name: KC_DB_URL_PROPERTIES
-              value: "?sslmode=verify-full&sslcert=root.crt"
+              value: "?sslmode=require&sslcert=root.crt"
            {{- end }}
            {{- end }}
             - name: KC_LOGLEVEL


### PR DESCRIPTION
<!--start_release_notes-->
### Fix keycloak when running with Postgres Flexible server
Helm chart adjustment for running OasisAzureDeployment with https://github.com/OasisLMF/OasisAzureDeployment/pull/23
<!--end_release_notes-->
