### PR TITLE
Accept settings JSON on analysis or model creation 

### DIFF
--- a/src/server/oasisapi/analyses/v2_api/serializers.py
+++ b/src/server/oasisapi/analyses/v2_api/serializers.py
@@ -36,7 +36,6 @@ def create_settings_file(data, user):
         )
 
 
-
 class AnalysisTaskStatusSerializer(serializers.ModelSerializer):
     output_log = serializers.SerializerMethodField()
     error_log = serializers.SerializerMethodField()

--- a/src/server/oasisapi/analyses/v2_api/serializers.py
+++ b/src/server/oasisapi/analyses/v2_api/serializers.py
@@ -84,6 +84,7 @@ class AnalysisListSerializer(serializers.Serializer):
     task_started = serializers.DateTimeField(read_only=True)
     task_finished = serializers.DateTimeField(read_only=True)
     complex_model_data_files = serializers.PrimaryKeyRelatedField(many=True, read_only=True)
+    priority = serializers.IntegerField(read_only=True)
 
     # Groups - inherited from portfolio
     groups = serializers.SerializerMethodField(read_only=True)

--- a/src/server/oasisapi/analyses/v2_api/viewsets.py
+++ b/src/server/oasisapi/analyses/v2_api/viewsets.py
@@ -263,9 +263,9 @@ class AnalysisViewSet(VerifyGroupAccessModelViewSet):
         return super().get_queryset().select_related(*self.file_action_types).prefetch_related('complex_model_data_files')
 
     def get_serializer_class(self):
-        if self.action in ['create', 'options', 'update', 'partial_update', 'retrieve']:
+        if self.action in ['create', 'options', 'update', 'partial_update']:
             return super().get_serializer_class()
-        elif self.action in ['list']:
+        elif self.action in ['list', 'retrieve']:
             return AnalysisListSerializer
         elif self.action == 'copy':
             return AnalysisCopySerializer

--- a/src/server/oasisapi/analysis_models/v2_api/serializers.py
+++ b/src/server/oasisapi/analysis_models/v2_api/serializers.py
@@ -92,7 +92,6 @@ class AnalysisModelSerializer(serializers.ModelSerializer):
             'groups',
             'run_mode',
         )
-        create_only_fields = ('settings',)
 
     def validate(self, attrs):
 
@@ -134,17 +133,10 @@ class AnalysisModelSerializer(serializers.ModelSerializer):
         instance.save()
         return instance
 
-
     @swagger_serializer_method(serializer_or_field=ModelParametersSerializer)
     def get_settings(self, instance):
         request = self.context.get('request')
         return instance.get_absolute_settings_url(request=request, namespace=self.namespace)
-
-
-    #@swagger_serializer_method(serializer_or_field=serializers.URLField)
-    #def get_settings(self, instance):
-    #    request = self.context.get('request')
-    #    return instance.get_absolute_settings_url(request=request, namespace=self.namespace)
 
     @swagger_serializer_method(serializer_or_field=serializers.URLField)
     def get_versions(self, instance):

--- a/src/server/oasisapi/analysis_models/v2_api/serializers.py
+++ b/src/server/oasisapi/analysis_models/v2_api/serializers.py
@@ -12,6 +12,43 @@ from ...permissions.group_auth import validate_and_update_groups, validate_data_
 from ...schemas.serializers import ModelParametersSerializer, AnalysisSettingsSerializer
 
 
+
+class AnalysisModelListSerializer(serializers.Serializer):
+    """ Read Only Model Deserializer for efficiently returning a list of all 
+        entries in DB
+    """
+    id = serializers.IntegerField(read_only=True)
+    name = serializers.CharField(read_only=True)
+    created = serializers.DateTimeField(read_only=True)
+    modified = serializers.DateTimeField(read_only=True)
+    settings = serializers.SerializerMethodField()
+    versions = serializers.SerializerMethodField()
+    scaling_configuration = serializers.SerializerMethodField()
+    chunking_configuration = serializers.SerializerMethodField()
+    groups = serializers.SlugRelatedField(many=True, read_only=False, slug_field='name', required=False, queryset=Group.objects.all())
+    settings = serializers.SerializerMethodField()
+
+    @swagger_serializer_method(serializer_or_field=serializers.URLField)
+    def get_settings(self, instance):
+        request = self.context.get('request')
+        return instance.get_absolute_settings_url(request=request, namespace=self.namespace)
+
+    @swagger_serializer_method(serializer_or_field=serializers.URLField)
+    def get_versions(self, instance):
+        request = self.context.get('request')
+        return instance.get_absolute_versions_url(request=request, namespace=self.namespace)
+
+    @swagger_serializer_method(serializer_or_field=serializers.URLField)
+    def get_scaling_configuration(self, instance):
+        request = self.context.get('request')
+        return instance.get_absolute_scaling_configuration_url(request=request, namespace=self.namespace)
+
+    @swagger_serializer_method(serializer_or_field=serializers.URLField)
+    def get_chunking_configuration(self, instance):
+        request = self.context.get('request')
+        return instance.get_absolute_chunking_configuration_url(request=request, namespace=self.namespace)
+
+
 class AnalysisModelSerializer(serializers.ModelSerializer):
     settings = serializers.SerializerMethodField()
     versions = serializers.SerializerMethodField()

--- a/src/server/oasisapi/analysis_models/v2_api/serializers.py
+++ b/src/server/oasisapi/analysis_models/v2_api/serializers.py
@@ -35,7 +35,9 @@ class AnalysisModelListSerializer(serializers.Serializer):
         entries in DB
     """
     id = serializers.IntegerField(read_only=True)
-    name = serializers.CharField(read_only=True)
+    supplier_id = serializers.CharField(read_only=True)
+    model_id = serializers.CharField(read_only=True)
+    version_id = serializers.CharField(read_only=True)
     created = serializers.DateTimeField(read_only=True)
     modified = serializers.DateTimeField(read_only=True)
     settings = serializers.SerializerMethodField()
@@ -44,6 +46,7 @@ class AnalysisModelListSerializer(serializers.Serializer):
     chunking_configuration = serializers.SerializerMethodField()
     groups = serializers.SlugRelatedField(many=True, read_only=False, slug_field='name', required=False, queryset=Group.objects.all())
     settings = serializers.SerializerMethodField()
+    namespace = 'v2-models'
 
     @swagger_serializer_method(serializer_or_field=serializers.URLField)
     def get_settings(self, instance):

--- a/src/server/oasisapi/analysis_models/v2_api/serializers.py
+++ b/src/server/oasisapi/analysis_models/v2_api/serializers.py
@@ -46,6 +46,7 @@ class AnalysisModelListSerializer(serializers.Serializer):
     chunking_configuration = serializers.SerializerMethodField()
     groups = serializers.SlugRelatedField(many=True, read_only=False, slug_field='name', required=False, queryset=Group.objects.all())
     settings = serializers.SerializerMethodField()
+    run_mode = serializers.CharField(read_only=True)
     namespace = 'v2-models'
 
     @swagger_serializer_method(serializer_or_field=serializers.URLField)

--- a/src/server/oasisapi/analysis_models/v2_api/viewsets.py
+++ b/src/server/oasisapi/analysis_models/v2_api/viewsets.py
@@ -14,6 +14,7 @@ from rest_framework.settings import api_settings
 from ..models import AnalysisModel, SettingsTemplate
 from .serializers import (
     AnalysisModelSerializer,
+    AnalysisModelListSerializer,
     ModelVersionsSerializer,
     CreateTemplateSerializer,
     TemplateSerializer,
@@ -194,6 +195,8 @@ class AnalysisModelViewSet(VerifyGroupAccessModelViewSet):
     def get_serializer_class(self):
         if self.action in ['resource_file', 'set_resource_file']:
             return RelatedFileSerializer
+        elif self.action in ['list', 'retrieve']:
+            return AnalysisModelListSerializer
         elif self.action in ['data_files']:
             return DataFileSerializer
         elif self.action in ['versions']:


### PR DESCRIPTION
<!--start_release_notes-->
### Accept settings JSON on analysis or model creation  
`Models` and `Analyses` **V2 endpoints** now accept settings json on **POST** and **PATCH** calls via an optional `'settings: { .. json ..}'` field. These are validated before the new object is created,  if valid the settings are loaded into the newly created (or updated) instance. 

### Example Analysis (POST / PATCH)
```
{
  "name": "string",
  "portfolio": 1,
  "model": 1,
  "settings": {
    "model_name_id": "PiWind",
    "model_supplier_id": "OasisLMF",
    "gul_threshold": 0,
    "gul_output": true,
    "model_settings": {
        "event_set": "p",
        "event_occurrence_id": "lt"
    },
    "gul_summaries": [
        {"id": 1, "eltcalc": true}
    ],
    "il_output": false,
    "il_summaries": [],
    "ri_output": 'foo',
    "ri_summaries": []
  }
}
```

### Example Model (POST / PATCH)
```
{
  "supplier_id": "OasisLMF",
  "model_id": "PiWind",
  "version_id": "ver",
  "settings": {  
    "model_settings":{
        "event_set":{
            "name": "Event Set",
            "desc": "Piwind Event Set selection",
            "default": "p",
            "options":[
                {"id":"p", "desc": "Probabilistic", "number_of_events": 1447}
            ]
         },
        "event_occurrence_id":{
            "name": "Occurrence Set",
            "desc": "PiWind Occurrence selection",
            "default": "lt",
            "options":[
                {"id":"lt", "desc": "Long Term"}
            ]
        }
     },
    "lookup_settings":{},
    "model_default_samples" :10
  }
}
```

<!--end_release_notes-->
