### PR TITLE
Ensure ConfigParser has required sections when not set in conf.ini file

### DIFF
--- a/src/conf/iniconf.py
+++ b/src/conf/iniconf.py
@@ -40,12 +40,22 @@ class Settings(ConfigParser):
         super(Settings, self).__init__(*args, **kwargs)
 
         ini_files = [os.path.join(os.path.dirname(__file__), os.pardir, os.pardir, 'conf.ini')]
-
         specified_ini = os.environ.get('OASIS_INI_PATH', None)
         if specified_ini and os.path.exists(specified_ini):
             ini_files.append(specified_ini)
-
         self.read(ini_files)
+
+        # make sure required sections exist
+        required_sections = [
+            'celery',
+            'server',
+            'worker',
+            'worker.model_data',
+            'worker.default_reader_engine_options'
+        ]
+        for sec in required_sections:
+            if not self.has_section(sec):
+                self.add_section(sec)
 
     def _section_to_env_prefix(self, section):
         return '_'.join(section.split('.')).upper()


### PR DESCRIPTION
<!--start_release_notes-->
### Ensure ConfigParser has required sections when not set in conf.ini file
Fix added - if sections are not set in a workers config file, environment variable will still load correctly.
<!--end_release_notes-->
