### PR TITLE
Use version 2 of the API on api ls commands

### DIFF
--- a/kubernetes/scripts/api/api.sh
+++ b/kubernetes/scripts/api/api.sh
@@ -27,16 +27,16 @@ case $CMD in
   "ls")
     case "$ANALYSIS_ID" in
       "p"|"portfolio"|"portfolios")
-        curlf -X GET "${API_URL}/v1/portfolios/" | jq -r '.[] | "\(.id) - \(.name)\r\t\t\t\tgroups: \(.groups | join (","))"' | sort -n
+        curlf -X GET "${API_URL}/v2/portfolios/" | jq -r '.[] | "\(.id) - \(.name)\r\t\t\t\tgroups: \(.groups | join (","))"' | sort -n
       ;;
       "m"|"model"|"models")
-        curlf -X GET "${API_URL}/v1/models/" | jq -r '.[] | "\(.id) - \(.supplier_id)-\(.model_id)-\(.version_id)\r\t\t\t\tgroups: \(.groups | join (","))"' | sort -n
+        curlf -X GET "${API_URL}/v2/models/" | jq -r '.[] | "\(.id) - \(.supplier_id)-\(.model_id)-\(.version_id)\r\t\t\t\tgroups: \(.groups | join (","))"' | sort -n
       ;;
       "df"|"data-files"|"datafiles")
-        curlf -X GET "${API_URL}/v1/data_files/" | jq -r '.[] | "\(.id) - \(.filename)\r\t\t\t\tgroups: \(.groups | join (","))"'| sort -n
+        curlf -X GET "${API_URL}/v2/data_files/" | jq -r '.[] | "\(.id) - \(.filename)\r\t\t\t\tgroups: \(.groups | join (","))"'| sort -n
       ;;
       *)
-        curlf -X GET "${API_URL}/v1/analyses/" | jq -r '.[] | "\(.id) - \(.status) - \(.name)\r\t\t\t\t\t\tportfolio: \(.portfolio)\tmodel: \(.model)\tgroups: \(.groups | join (","))"' | sort -n
+        curlf -X GET "${API_URL}/v2/analyses/" | jq -r '.[] | "\(.id) - \(.status) - \(.name)\r\t\t\t\t\t\tportfolio: \(.portfolio)\tmodel: \(.model)\tgroups: \(.groups | join (","))"' | sort -n
       ;;
     esac
   ;;

--- a/kubernetes/scripts/api/setup_env.sh
+++ b/kubernetes/scripts/api/setup_env.sh
@@ -24,23 +24,24 @@ else
 fi
 
 echo "Updating model chunking configuration..."
-cat << EOF | curlf -X POST "${API_URL}/v1/models/${PIWIND_VERSION}/chunking_configuration/" -H "Content-Type: application/json" -d @- | jq .
+cat << EOF | curlf -X POST "${API_URL}/v2/models/${PIWIND_VERSION}/chunking_configuration/" -H "Content-Type: application/json" -d @- | jq .
 {
   "strategy": "FIXED_CHUNKS",
+  "loss_strategy": "FIXED_CHUNKS",
   "dynamic_locations_per_lookup": 10000,
-  "dynamic_events_per_analysis": 1,
+  "dynamic_events_per_analysis": 100,
   "fixed_analysis_chunks": 10,
-  "fixed_lookup_chunks": 10
+  "fixed_lookup_chunks": 5
 }
 EOF
 
 echo "Updating model scaling configuration..."
-cat << EOF | curlf -X POST "${API_URL}/v1/models/${PIWIND_VERSION}/scaling_configuration/" -H "Content-Type: application/json" -d @- | jq .
+cat << EOF | curlf -X POST "${API_URL}/v2/models/${PIWIND_VERSION}/scaling_configuration/" -H "Content-Type: application/json" -d @- | jq .
 {
   "scaling_strategy": "FIXED_WORKERS",
   "worker_count_fixed": 1,
-  "worker_count_max": 4,
-  "chunks_per_worker": 2
+  "worker_count_max": 10,
+  "chunks_per_worker": 10
 }
 EOF
 


### PR DESCRIPTION
Groups property is being used on:
- portfolios
- models
- data_files
- analyses

But v1 of the API does not return property groups. Only v2 does.

After checking the swagger, updating to v2 seems better than removing groups from the sanitization of the returned body.

Using API v2 for:
- /models/${PIWIND_VERSION}/chunking_configuration
- /models/${PIWIND_VERSION}/scaling_configuration

Version 1 of the API lacks these methods. Using same configs as in the local files next to /meta-data/model_settings.json