### PR TITLE
Fix to handle exceptions which can't be serialized by celery

### DIFF
--- a/src/model_execution_worker/distributed_tasks.py
+++ b/src/model_execution_worker/distributed_tasks.py
@@ -448,6 +448,7 @@ def keys_generation_task(fn):
             except Exception as error:
                 # fallback only needed if celery can't serialize the exception
                 logger.exception("Error occured in 'keys_generation_task':")
+                raise error
 
     return run
 
@@ -863,6 +864,7 @@ def loss_generation_task(fn):
             except Exception as error:
                 # fallback only needed if celery can't serialize the exception
                 logger.exception("Error occured in 'loss_generation_task':")
+                raise error
 
     return run
 

--- a/src/model_execution_worker/distributed_tasks.py
+++ b/src/model_execution_worker/distributed_tasks.py
@@ -443,8 +443,11 @@ def keys_generation_task(fn):
                                    task_slug=kwargs.get('slug'),
                                    error_state='INPUTS_GENERATION_ERROR'
                                    )
-
-            return fn(self, params, *args, analysis_id=analysis_id, run_data_uuid=run_data_uuid, **kwargs)
+            try:
+                return fn(self, params, *args, analysis_id=analysis_id, run_data_uuid=run_data_uuid, **kwargs)
+            except Exception as error:
+                # fallback only needed if celery can't serialize the exception
+                logger.exception("Error occured in 'keys_generation_task':")
 
     return run
 
@@ -855,7 +858,11 @@ def loss_generation_task(fn):
                                    task_slug=kwargs.get('slug'),
                                    error_state='RUN_ERROR'
                                    )
-            return fn(self, params, *args, analysis_id=analysis_id, **kwargs)
+            try:
+                return fn(self, params, *args, analysis_id=analysis_id, **kwargs)
+            except Exception as error:
+                # fallback only needed if celery can't serialize the exception
+                logger.exception("Error occured in 'loss_generation_task':")
 
     return run
 

--- a/src/server/oasisapi/analyses/v2_api/tasks.py
+++ b/src/server/oasisapi/analyses/v2_api/tasks.py
@@ -378,6 +378,10 @@ def _traceback_from_errback_args(*args):
             logging.error('Could not extract traceback')
             return ''
 
+    if tb is None:
+        logging.error('traceback returned is None')
+        return ''
+
     return tb
 
 


### PR DESCRIPTION
<!--start_release_notes-->
### Fix to handle exceptions which can't be serialized by celery
* Celery can fail to log exceptions which are not pickable or json-serializable. Added exception logging within the V2 worker task file in case this happens (workaround). 
* Added check in worker-monitor v2 to make sure the trackback from sub-tasks is not set to `None` 
<!--end_release_notes-->
