### PR TITLE
Fix API spec - return for create & update for 'analyses' and 'model'

### DIFF
--- a/src/server/oasisapi/analyses/v2_api/viewsets.py
+++ b/src/server/oasisapi/analyses/v2_api/viewsets.py
@@ -183,7 +183,10 @@ class AnalysisTaskFilter(TimeStampedFilter):
 
 # https://stackoverflow.com/questions/62572389/django-drf-yasg-how-to-add-description-to-tags
 
-@method_decorator(name='list', decorator=swagger_auto_schema(responses={200: AnalysisSerializer(many=True)}))
+@method_decorator(name='list', decorator=swagger_auto_schema(responses={200: AnalysisListSerializer(many=True)}))
+@method_decorator(name='create', decorator=swagger_auto_schema(responses={200: AnalysisListSerializer()}))
+@method_decorator(name='update', decorator=swagger_auto_schema(responses={200: AnalysisListSerializer()}))
+@method_decorator(name='partial_update', decorator=swagger_auto_schema(responses={200: AnalysisListSerializer()}))
 class AnalysisViewSet(VerifyGroupAccessModelViewSet):
     """
     list:

--- a/src/server/oasisapi/analysis_models/v2_api/serializers.py
+++ b/src/server/oasisapi/analysis_models/v2_api/serializers.py
@@ -47,6 +47,7 @@ class AnalysisModelListSerializer(serializers.Serializer):
     groups = serializers.SlugRelatedField(many=True, read_only=False, slug_field='name', required=False, queryset=Group.objects.all())
     settings = serializers.SerializerMethodField()
     run_mode = serializers.CharField(read_only=True)
+    data_files = serializers.PrimaryKeyRelatedField(many=True, read_only=True)
     namespace = 'v2-models'
 
     @swagger_serializer_method(serializer_or_field=serializers.URLField)

--- a/src/server/oasisapi/analysis_models/v2_api/viewsets.py
+++ b/src/server/oasisapi/analysis_models/v2_api/viewsets.py
@@ -152,6 +152,10 @@ class SettingsTemplateViewSet(viewsets.ModelViewSet):
         return handle_json_data(self.get_object(), 'file', request, AnalysisSettingsSerializer)
 
 
+@method_decorator(name='list', decorator=swagger_auto_schema(responses={200: AnalysisModelListSerializer(many=True)}))
+@method_decorator(name='create', decorator=swagger_auto_schema(responses={200: AnalysisModelListSerializer()}))
+@method_decorator(name='update', decorator=swagger_auto_schema(responses={200: AnalysisModelListSerializer()}))
+@method_decorator(name='partial_update', decorator=swagger_auto_schema(responses={200: AnalysisModelListSerializer()}))
 class AnalysisModelViewSet(VerifyGroupAccessModelViewSet):
     """
     list:


### PR DESCRIPTION
<!--start_release_notes-->
### Fix API spec - return from create & update for 'analyses' and 'model'
Corrected the returns from `/analyses/`  and `/model/` so that the settings resources are `settings: <URL-to-file>` and not    `settings: <JSON>`  

**Note:** This is the same behaviour as release prior to   https://github.com/OasisLMF/OasisPlatform/pull/1067
<!--end_release_notes-->
