### PR TITLE
Fix/api responses v2

### DIFF
--- a/src/server/oasisapi/analyses/v2_api/viewsets.py
+++ b/src/server/oasisapi/analyses/v2_api/viewsets.py
@@ -253,7 +253,7 @@ class AnalysisViewSet(VerifyGroupAccessModelViewSet):
                          'cancel_analysis_run']
 
     # queryset = Analysis.objects.all().select_related(*file_action_types).prefetch_related('complex_model_data_files')
-    serializer_class = AnalysisSerializer
+    serializer_class = AnalysisListSerializer
     filterset_class = AnalysisFilter
 
     group_access_model = Analysis
@@ -267,9 +267,9 @@ class AnalysisViewSet(VerifyGroupAccessModelViewSet):
 
     def get_serializer_class(self):
         if self.action in ['create', 'options', 'update', 'partial_update']:
-            return super().get_serializer_class()
+            return AnalysisSerializer
         elif self.action in ['list', 'retrieve']:
-            return AnalysisListSerializer
+            return super().get_serializer_class()
         elif self.action == 'copy':
             return AnalysisCopySerializer
         elif self.action == 'data_files':
@@ -292,7 +292,7 @@ class AnalysisViewSet(VerifyGroupAccessModelViewSet):
         else:
             return api_settings.DEFAULT_PARSER_CLASSES
 
-    @swagger_auto_schema(responses={200: AnalysisSerializer}, manual_parameters=[RUN_MODE_PARAM])
+    @swagger_auto_schema(responses={200: AnalysisListSerializer}, manual_parameters=[RUN_MODE_PARAM])
     @action(methods=['post'], detail=True)
     def run(self, request, pk=None, version=None):
         """
@@ -304,9 +304,9 @@ class AnalysisViewSet(VerifyGroupAccessModelViewSet):
         run_mode_override = request.GET.get('run_mode_override', None)
         verify_user_is_in_obj_groups(request.user, obj.model, 'You are not allowed to run this model')
         obj.run(request.user, run_mode_override=run_mode_override)
-        return Response(AnalysisSerializer(instance=obj, context=self.get_serializer_context()).data)
+        return Response(AnalysisListSerializer(instance=obj, context=self.get_serializer_context()).data)
 
-    @swagger_auto_schema(responses={200: AnalysisSerializer})
+    @swagger_auto_schema(responses={200: AnalysisListSerializer})
     @action(methods=['post'], detail=True)
     def generate_and_run(self, request, pk=None, version=None):
         """
@@ -317,9 +317,9 @@ class AnalysisViewSet(VerifyGroupAccessModelViewSet):
         obj = self.get_object()
         verify_user_is_in_obj_groups(request.user, obj.model, 'You are not allowed to run this model')
         obj.generate_and_run(request.user)
-        return Response(AnalysisSerializer(instance=obj, context=self.get_serializer_context()).data)
+        return Response(AnalysisListSerializer(instance=obj, context=self.get_serializer_context()).data)
 
-    @swagger_auto_schema(responses={200: AnalysisSerializer})
+    @swagger_auto_schema(responses={200: AnalysisListSerializer})
     @action(methods=['post'], detail=True)
     def cancel(self, request, pk=None, version=None):
         """
@@ -330,9 +330,9 @@ class AnalysisViewSet(VerifyGroupAccessModelViewSet):
         verify_user_is_in_obj_groups(request.user, obj.model, 'You are not allowed to cancel this model')
         obj.cancel_subtasks()
         obj.cancel_any()
-        return Response(AnalysisSerializer(instance=obj, context=self.get_serializer_context()).data)
+        return Response(AnalysisListSerializer(instance=obj, context=self.get_serializer_context()).data)
 
-    @swagger_auto_schema(responses={200: AnalysisSerializer})
+    @swagger_auto_schema(responses={200: AnalysisListSerializer})
     @action(methods=['post'], detail=True)
     def cancel_analysis_run(self, request, pk=None, version=None):
         """
@@ -342,9 +342,9 @@ class AnalysisViewSet(VerifyGroupAccessModelViewSet):
         verify_user_is_in_obj_groups(request.user, obj.model, 'You are not allowed to cancel this model')
         obj.cancel_subtasks()
         obj.cancel_analysis()
-        return Response(AnalysisSerializer(instance=obj, context=self.get_serializer_context()).data)
+        return Response(AnalysisListSerializer(instance=obj, context=self.get_serializer_context()).data)
 
-    @swagger_auto_schema(responses={200: AnalysisSerializer}, manual_parameters=[RUN_MODE_PARAM])
+    @swagger_auto_schema(responses={200: AnalysisListSerializer}, manual_parameters=[RUN_MODE_PARAM])
     @action(methods=['post'], detail=True)
     def generate_inputs(self, request, pk=None, version=None):
         """
@@ -355,9 +355,9 @@ class AnalysisViewSet(VerifyGroupAccessModelViewSet):
         run_mode_override = request.GET.get('run_mode_override', None)
         verify_user_is_in_obj_groups(request.user, obj.model, 'You are not allowed to run this model')
         obj.generate_inputs(request.user, run_mode_override=run_mode_override)
-        return Response(AnalysisSerializer(instance=obj, context=self.get_serializer_context()).data)
+        return Response(AnalysisListSerializer(instance=obj, context=self.get_serializer_context()).data)
 
-    @swagger_auto_schema(responses={200: AnalysisSerializer})
+    @swagger_auto_schema(responses={200: AnalysisListSerializer})
     @action(methods=['post'], detail=True)
     def cancel_generate_inputs(self, request, pk=None, version=None):
         """
@@ -367,7 +367,7 @@ class AnalysisViewSet(VerifyGroupAccessModelViewSet):
         verify_user_is_in_obj_groups(request.user, obj.model, 'You are not allowed to cancel this model')
         obj.cancel_subtasks()
         obj.cancel_generate_inputs()
-        return Response(AnalysisSerializer(instance=obj, context=self.get_serializer_context()).data)
+        return Response(AnalysisListSerializer(instance=obj, context=self.get_serializer_context()).data)
 
     @action(methods=['post'], detail=True)
     def copy(self, request, pk=None, version=None):

--- a/src/server/oasisapi/queues/serializers.py
+++ b/src/server/oasisapi/queues/serializers.py
@@ -2,7 +2,7 @@ from drf_yasg.utils import swagger_serializer_method
 from rest_framework import serializers
 
 from src.server.oasisapi.analysis_models.models import AnalysisModel
-from src.server.oasisapi.analysis_models.v2_api.serializers import AnalysisModelSerializer
+from src.server.oasisapi.analysis_models.v2_api.serializers import AnalysisModelListSerializer
 from src.server.oasisapi.analyses.v2_api.serializers import AnalysisSerializerWebSocket, AnalysisTaskStatusSerializer
 
 
@@ -15,11 +15,11 @@ class QueueSerializer(serializers.Serializer):
     worker_count = serializers.IntegerField()
     models = serializers.SerializerMethodField()
 
-    @swagger_serializer_method(serializer_or_field=AnalysisModelSerializer(many=True))
+    @swagger_serializer_method(serializer_or_field=AnalysisModelListSerializer(many=True))
     def get_models(self, instance, *args, **kwargs):
         queue_name = instance['name'].removesuffix('-v2')
         models = [m for m in AnalysisModel.objects.all() if str(m) == queue_name]
-        return AnalysisModelSerializer(instance=models, many=True).data
+        return AnalysisModelListSerializer(instance=models, many=True).data
 
 
 class WebsocketAnalysesSerializer(serializers.Serializer):


### PR DESCRIPTION
<!--start_release_notes-->
### Fix api responses v2
More fixes to align `Analysis` with `AnalysisList`
<!--end_release_notes-->

```
Analysislist-> string complexfile ids but Analysis -> int ids


/analyses/{id}/cancel_analysis_run/ post returns Analysis
/analyses/{id}/cancel_generate_inputs/ post returns Analysis

/analyses/{id}/generate_and_run/ post returns Analysis

/analyses/{id}/generate_inputs/ post returns Analysis
/analyses/{id}/run/ post returns Analysis

 Queue -> models -> AnalysisModel not AnalysisModelList
```
