### PR TITLE
Dont set analyses state as RUN_ERROR on run submit validation issues

### DIFF
--- a/src/server/oasisapi/analyses/models.py
+++ b/src/server/oasisapi/analyses/models.py
@@ -484,8 +484,6 @@ class Analysis(TimeStampedModel):
                             errors['model_settings_file'] = [f"Option 'number_of_events' is not set for event_set = '{events_selected}'"]
 
         if errors:
-            self.status = self.status_choices.RUN_ERROR
-            self.save()
             raise ValidationError(detail=errors)
 
         # Start V1 run
@@ -515,13 +513,6 @@ class Analysis(TimeStampedModel):
         self.task_started = timezone.now()
         self.task_finished = None
         self.save()
-
-    def raise_validate_errors(self, errors, error_state=None):
-        if error_state:
-            self.status = error_state
-            self.save()
-        if errors:
-            raise ValidationError(detail=errors)
 
     def generate_and_run(self, initiator):
         valid_choices = [
@@ -559,7 +550,8 @@ class Analysis(TimeStampedModel):
         events_total = self.get_num_events()
 
         # Raise for error
-        self.raise_validate_errors(errors)
+        if errors:
+            raise ValidationError(detail=errors)
 
         self.status = self.status_choices.INPUTS_GENERATION_QUEUED
         self.lookup_errors_file = None


### PR DESCRIPTION
**IMPORTANT: Please attach or create an issue after submitting a Pull Request.

<!--start_release_notes-->
### Fixed sever setting an analyses to an error state when submitting a bad request. 
Fixed issue where analyses are marked as `RUN_ERROR` but no reason can be found in logs. This can happen due to issue https://github.com/OasisLMF/OasisPlatform/issues/1085. Fixed by not setting ab analyses state to RUN_ERROR on validation issues. 
<!--end_release_notes-->
