### PR TITLE
Fix log storage in results tar files

### DIFF
--- a/src/model_execution_worker/distributed_tasks.py
+++ b/src/model_execution_worker/distributed_tasks.py
@@ -1047,7 +1047,7 @@ def generate_losses_output(self, params, analysis_id=None, slug=None, **kwargs):
     return {
         **res,
         'output_location': filestore.put(output_dir, arcname='output'),
-        'run_logs': filestore.put(logs_dir, arcname='logs'),
+        'run_logs': filestore.put(logs_dir),
         'log_location': filestore.put(kwargs.get('log_filename')),
         'raw_output_locations': {
             r: filestore.put(os.path.join(output_dir, r), arcname=f'output_{r}')

--- a/src/model_execution_worker/distributed_tasks.py
+++ b/src/model_execution_worker/distributed_tasks.py
@@ -951,7 +951,7 @@ def generate_losses_chunk(self, params, chunk_idx, num_chunks, analysis_id=None,
     if num_chunks == 1:
         # Run multiple ktools pipes (based on cpu cores)
         current_chunk_id = None
-        max_chunk_id = -1
+        max_chunk_id = params.get('ktools_num_processes', -1)
         work_dir = 'work'
     else:
         # Run a single ktools pipe

--- a/src/model_execution_worker/tasks.py
+++ b/src/model_execution_worker/tasks.py
@@ -507,7 +507,6 @@ def generate_input(self,
         lookup_validation_fp = next(iter(glob.glob(os.path.join(oasis_files_dir, 'exposure_summary_report.json'))), None)
         summary_levels_fp = next(iter(glob.glob(os.path.join(oasis_files_dir, 'exposure_summary_levels.json'))), None)
 
-
         # Store logs
         traceback = filestore.put(kwargs['log_filename'])
         filestore.get(traceback, os.path.join(oasis_files_dir, 'log', 'v1-generate-oasis-files.txt'))

--- a/src/model_execution_worker/tasks.py
+++ b/src/model_execution_worker/tasks.py
@@ -507,8 +507,12 @@ def generate_input(self,
         lookup_validation_fp = next(iter(glob.glob(os.path.join(oasis_files_dir, 'exposure_summary_report.json'))), None)
         summary_levels_fp = next(iter(glob.glob(os.path.join(oasis_files_dir, 'exposure_summary_levels.json'))), None)
 
-        # Store result files
+
+        # Store logs
         traceback = filestore.put(kwargs['log_filename'])
+        filestore.get(traceback, os.path.join(oasis_files_dir, 'log', 'v1-generate-oasis-files.txt'))
+
+        # Store result files
         lookup_error = filestore.put(lookup_error_fp)
         lookup_success = filestore.put(lookup_success_fp)
         lookup_validation = filestore.put(lookup_validation_fp)


### PR DESCRIPTION
<!--start_release_notes-->
### Fix log storage in result tar files. 
* Fixed log storage for input generation (run_mode=v1). workers now store a copy of run logs in the `input.tar.gz` file. 
* Fixed log storage for input generation (run_mode=v2). Workers copy in each sub-task log file to a `log/` within a the `input.tar.gz` file
* Fixed mismatch between v1 and v2 ktools log stored under `/run_log_file/`,  v2 no longer nests the archive in a `logs` sub-dir.  
<!--end_release_notes-->
