### PR TITLE
Fix params for V1 workers ~ so custom hooks are called

### DIFF
--- a/src/model_execution_worker/tasks.py
+++ b/src/model_execution_worker/tasks.py
@@ -345,9 +345,8 @@ def start_analysis(analysis_settings, input_location, complex_data_files=None, *
 
         # Create and log params
         run_params = {**config, **task_params}
-        gen_losses_params = OasisManager()._params_generate_losses(**run_params)
-        post_hook_params = OasisManager()._params_post_analysis(**run_params)
-        params = paths_to_absolute_paths({**gen_losses_params, **post_hook_params}, config_path)
+        gen_losses_params = OasisManager()._params_generate_oasis_losses(**run_params)
+        params = paths_to_absolute_paths({**gen_losses_params}, config_path)
 
         if debug_worker:
             log_params(params, kwargs)
@@ -469,10 +468,8 @@ def generate_input(self,
         config_path = get_oasislmf_config_path(settings)
         config = config_strip_default_exposure(get_json(config_path))
         lookup_params = {**config, **task_params}
-
-        gen_files_params = OasisManager()._params_generate_files(**lookup_params)
-        pre_hook_params = OasisManager()._params_exposure_pre_analysis(**lookup_params)
-        params = paths_to_absolute_paths({**gen_files_params, **pre_hook_params}, config_path)
+        gen_files_params = OasisManager()._params_generate_oasis_files(**lookup_params)
+        params = paths_to_absolute_paths({**gen_files_params}, config_path)
 
         if debug_worker:
             log_params(params, kwargs, exclude_keys=[


### PR DESCRIPTION
<!--start_release_notes-->
### Fix run params for V1 workers
Needed so that custom hooks are correctly called for workers in run_mode=V1, similar to https://github.com/OasisLMF/OasisPlatform/pull/1087
<!--end_release_notes-->
