### PR TITLE
Relase fix - gen log storage (#1107)

### DIFF
--- a/src/model_execution_worker/distributed_tasks.py
+++ b/src/model_execution_worker/distributed_tasks.py
@@ -725,8 +725,12 @@ def write_input_files(self, params, run_data_uuid=None, analysis_id=None, initia
     # collect logs here before archive is created
     params['log_location'] = filestore.put(kwargs.get('log_filename'))
     params['log_storage'][slug] = params['log_location']
+    log_dir = os.path.join(params['target_dir'], 'log')
+    if not os.path.exists(log_dir):
+        os.makedirs(log_dir)
+
     for log_ref in params['log_storage']:
-        filestore.get(params['log_storage'][log_ref], os.path.join(params['target_dir'], 'log', f'v2-{log_ref}.txt'))
+        filestore.get(params['log_storage'][log_ref], os.path.join(log_dir, f'v2-{log_ref}.txt'))
 
     return {
         'lookup_error_location': filestore.put(os.path.join(params['target_dir'], 'keys-errors.csv')),

--- a/src/model_execution_worker/tasks.py
+++ b/src/model_execution_worker/tasks.py
@@ -506,7 +506,7 @@ def generate_input(self,
 
         # Store logs
         traceback = filestore.put(kwargs['log_filename'])
-        filestore.get(traceback, os.path.join(oasis_files_dir, 'log', 'v1-generate-oasis-files.txt'))
+        filestore.get(traceback, os.path.join(oasis_files_dir, os.path.basename(kwargs['log_filename'])))
 
         # Store result files
         lookup_error = filestore.put(lookup_error_fp)


### PR DESCRIPTION
<!--start_release_notes-->
### Relase fix - gen log storage (#1107)
Worker storage manager between `main` and `stable/2.3.x` is different, fix needed to work with both 
<!--end_release_notes-->
