### PR TITLE
Fixed group mapper class in Keyclock realm config

### DIFF
--- a/kubernetes/charts/oasis-platform/resources/oasis-realm.json
+++ b/kubernetes/charts/oasis-platform/resources/oasis-realm.json
@@ -568,8 +568,8 @@
     "authenticationFlowBindingOverrides" : { },
     "fullScopeAllowed" : true,
     "nodeReRegistrationTimeout" : -1,
-    "defaultClientScopes" : [ "web-origins", "acr", "openid", "roles", "profile", "email" ],
-    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+    "defaultClientScopes" : [ "web-origins", "acr", "openid", "roles", "profile", "email", "microprofile-jwt" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access" ]
   }, {
     "id" : "40223c47-11d9-49e5-a552-197fbbfb21c3",
     "clientId" : "realm-management",
@@ -1158,7 +1158,7 @@
       "id" : "21ae480f-ef05-4436-a9d8-a6089272010a",
       "name" : "groups",
       "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usermodel-realm-role-mapper",
+      "protocolMapper" : "oidc-group-membership-mapper",
       "consentRequired" : false,
       "config" : {
         "multivalued" : "true",

--- a/src/server/oasisapi/oidc/keycloak_auth.py
+++ b/src/server/oasisapi/oidc/keycloak_auth.py
@@ -158,9 +158,13 @@ class KeycloakOIDCAuthenticationBackend(auth.OIDCAuthenticationBackend):
         Persist Keycloak groups as local Django groups.
         """
         keycloak_groups = claims.get('groups', None)
+
         if keycloak_groups is None:
-            msg = 'No group found in claim / user_info'
-            raise SuspiciousOperation(msg)
+            if (user.is_superuser or user.is_staff):
+                keycloak_groups = []
+            else:
+                msg = 'No group found in claim / user_info'
+                raise SuspiciousOperation(msg)
 
         for i, keycloak_group in enumerate(keycloak_groups):
             if keycloak_group.startswith('/'):

--- a/src/server/oasisapi/oidc/keycloak_auth.py
+++ b/src/server/oasisapi/oidc/keycloak_auth.py
@@ -80,8 +80,8 @@ class KeycloakOIDCAuthenticationBackend(auth.OIDCAuthenticationBackend):
         """
 
         user = self.UserModel.objects.create_user(username)
-        self.update_groups(user, claims)
         self.update_roles(user, claims)
+        self.update_groups(user, claims)
         self.create_keycloak_user_id(user, claims.get('sub'))
         return user
 

--- a/src/server/oasisapi/oidc/keycloak_auth.py
+++ b/src/server/oasisapi/oidc/keycloak_auth.py
@@ -157,7 +157,11 @@ class KeycloakOIDCAuthenticationBackend(auth.OIDCAuthenticationBackend):
         """
         Persist Keycloak groups as local Django groups.
         """
-        keycloak_groups = claims.get('groups', [])
+        keycloak_groups = claims.get('groups', None)
+        if keycloak_groups is None:
+            msg = 'No group found in claim / user_info'
+            raise SuspiciousOperation(msg)
+
         for i, keycloak_group in enumerate(keycloak_groups):
             if keycloak_group.startswith('/'):
                 keycloak_groups[i] = keycloak_group[1:]


### PR DESCRIPTION
<!--start_release_notes-->
### Fixed group mapper class in Keyclock realm config
Issue [#1111](https://github.com/OasisLMF/OasisPlatform/issues/1111) - the users group information wasn't included in the JSON Web Token (JWT). This causes OasisAPI objects to be created without any groups attached. 
<!--end_release_notes-->
