### PR TITLE
Added model storage_links endpoint

### DIFF
--- a/src/server/oasisapi/analysis_models/v1_api/serializers.py
+++ b/src/server/oasisapi/analysis_models/v1_api/serializers.py
@@ -48,8 +48,10 @@ class AnalysisModelSerializer(serializers.ModelSerializer):
 
 class AnalysisModelStorageSerializer(serializers.ModelSerializer):
     settings_file = serializers.SerializerMethodField()
+    ns = 'v1-models'
 
     class Meta:
+        ref_name = __qualname__.split('.')[0] + 'V1'
         model = AnalysisModel
         fields = (
             'settings_file',

--- a/src/server/oasisapi/analysis_models/v1_api/serializers.py
+++ b/src/server/oasisapi/analysis_models/v1_api/serializers.py
@@ -5,6 +5,7 @@ from rest_framework.exceptions import ValidationError
 
 from ..models import AnalysisModel, SettingsTemplate
 from ...analyses.models import Analysis
+from ...files.models import file_storage_link
 
 
 class AnalysisModelSerializer(serializers.ModelSerializer):
@@ -43,6 +44,20 @@ class AnalysisModelSerializer(serializers.ModelSerializer):
     def get_versions(self, instance):
         request = self.context.get('request')
         return instance.get_absolute_versions_url(request=request, namespace=self.ns)
+
+
+class AnalysisModelStorageSerializer(serializers.ModelSerializer):
+    settings_file = serializers.SerializerMethodField()
+
+    class Meta:
+        model = AnalysisModel
+        fields = (
+            'settings_file',
+        )
+
+    @swagger_serializer_method(serializer_or_field=serializers.CharField)
+    def get_settings_file(self, instance):
+        return file_storage_link(instance.resource_file, True)
 
 
 class TemplateSerializer(serializers.ModelSerializer):

--- a/src/server/oasisapi/analysis_models/v1_api/viewsets.py
+++ b/src/server/oasisapi/analysis_models/v1_api/viewsets.py
@@ -12,7 +12,13 @@ from rest_framework.response import Response
 from rest_framework.settings import api_settings
 
 from ..models import AnalysisModel, SettingsTemplate
-from .serializers import AnalysisModelSerializer, ModelVersionsSerializer, CreateTemplateSerializer, TemplateSerializer
+from .serializers import (
+    AnalysisModelSerializer,
+    AnalysisModelStorageSerializer,
+    ModelVersionsSerializer,
+    CreateTemplateSerializer,
+    TemplateSerializer,
+)
 
 from ...data_files.v1_api.serializers import DataFileSerializer
 from ...filters import TimeStampedFilter
@@ -192,6 +198,8 @@ class AnalysisModelViewSet(viewsets.ModelViewSet):
             return DataFileSerializer
         elif self.action in ['versions']:
             return ModelVersionsSerializer
+        elif self.action == 'storage_links':
+            return AnalysisModelStorageSerializer
         else:
             return super(AnalysisModelViewSet, self).get_serializer_class()
 
@@ -233,6 +241,15 @@ class AnalysisModelViewSet(viewsets.ModelViewSet):
 
         df_serializer = DataFileSerializer(df, many=True, context=context)
         return Response(df_serializer.data)
+
+    @action(methods=['get'], detail=True)
+    def storage_links(self, request, pk=None, version=None):
+        """
+        get:
+        Gets the analyses storage backed link references, `object keys` or `file paths`
+        """
+        serializer = self.get_serializer(self.get_object())
+        return Response(serializer.data)
 
 
 class ModelSettingsView(viewsets.ModelViewSet):

--- a/src/server/oasisapi/analysis_models/v2_api/serializers.py
+++ b/src/server/oasisapi/analysis_models/v2_api/serializers.py
@@ -13,7 +13,7 @@ from ...permissions.group_auth import validate_and_update_groups, validate_data_
 from ...schemas.serializers import ModelParametersSerializer
 from django.core.files import File
 from tempfile import TemporaryFile
-from ...files.models import RelatedFile
+from ...files.models import RelatedFile, file_storage_link
 
 
 def create_settings_file(data, user):
@@ -28,6 +28,20 @@ def create_settings_file(data, user):
             content_type='application/json',
             creator=user,
         )
+
+
+class AnalysisModelStorageSerializer(serializers.ModelSerializer):
+    settings_file = serializers.SerializerMethodField()
+
+    class Meta:
+        model = AnalysisModel
+        fields = (
+            'settings_file',
+        )
+
+    @swagger_serializer_method(serializer_or_field=serializers.CharField)
+    def get_settings_file(self, instance):
+        return file_storage_link(instance.resource_file, True)
 
 
 class AnalysisModelListSerializer(serializers.Serializer):

--- a/src/server/oasisapi/analysis_models/v2_api/viewsets.py
+++ b/src/server/oasisapi/analysis_models/v2_api/viewsets.py
@@ -15,6 +15,7 @@ from ..models import AnalysisModel, SettingsTemplate
 from .serializers import (
     AnalysisModelSerializer,
     AnalysisModelListSerializer,
+    AnalysisModelStorageSerializer,
     ModelVersionsSerializer,
     CreateTemplateSerializer,
     TemplateSerializer,
@@ -209,6 +210,8 @@ class AnalysisModelViewSet(VerifyGroupAccessModelViewSet):
             return ModelScalingConfigSerializer
         elif self.action in ['chunking_configuration']:
             return ModelChunkingConfigSerializer
+        elif self.action == 'storage_links':
+            return AnalysisModelStorageSerializer
         else:
             return super(AnalysisModelViewSet, self).get_serializer_class()
 
@@ -432,6 +435,15 @@ class AnalysisModelViewSet(VerifyGroupAccessModelViewSet):
 
         df_serializer = DataFileSerializer(df, many=True, context=context)
         return Response(df_serializer.data)
+
+    @action(methods=['get'], detail=True)
+    def storage_links(self, request, pk=None, version=None):
+        """
+        get:
+        Gets the analyses storage backed link references, `object keys` or `file paths`
+        """
+        serializer = self.get_serializer(self.get_object())
+        return Response(serializer.data)
 
 
 class ModelSettingsView(viewsets.ModelViewSet):


### PR DESCRIPTION
<!--start_release_notes-->
### Added model storage_links endpoint
Added the following endpoints to models, `/v1/models/{id}/storage_links/` and `/v2/models/{id}/storage_links/`. 
works in the same way as the other storage_links endpoints on (models and portfolios), returns the real filename or Object Store key of the model settings file. 

**example return** 
```
{
  "settings_file": "82cd9b3e16c44954a1ec98be6554440b.json"
}
```
<!--end_release_notes-->
