### PR TITLE
Add cybermodels support in the OasisAPI - V1 Only

### DIFF
--- a/src/model_execution_worker/tasks.py
+++ b/src/model_execution_worker/tasks.py
@@ -435,8 +435,7 @@ def generate_input(self,
         loc_extention = "".join(pathlib.Path(loc_file).suffixes)
         task_params['oed_location_csv'] = filestore.get(
             loc_file,
-            os.path.join(oasis_files_dir, f'location{loc_extention}'),
-            required=True
+            os.path.join(oasis_files_dir, f'location{loc_extention}')
         )
         if acc_file:
             acc_extention = "".join(pathlib.Path(acc_file).suffixes)

--- a/src/model_execution_worker/tasks.py
+++ b/src/model_execution_worker/tasks.py
@@ -432,11 +432,12 @@ def generate_input(self,
         task_params['model_settings_file'] = model_settings_fp if model_settings_fp and os.path.isfile(model_settings_fp) else None
 
         # Fetch input files
-        loc_extention = "".join(pathlib.Path(loc_file).suffixes)
-        task_params['oed_location_csv'] = filestore.get(
-            loc_file,
-            os.path.join(oasis_files_dir, f'location{loc_extention}')
-        )
+        if loc_file:
+            loc_extention = "".join(pathlib.Path(loc_file).suffixes)
+            task_params['oed_location_csv'] = filestore.get(
+                loc_file,
+                os.path.join(oasis_files_dir, f'location{loc_extention}')
+            )
         if acc_file:
             acc_extention = "".join(pathlib.Path(acc_file).suffixes)
             task_params['oed_accounts_csv'] = filestore.get(

--- a/src/server/oasisapi/analyses/models.py
+++ b/src/server/oasisapi/analyses/models.py
@@ -616,16 +616,22 @@ class Analysis(TimeStampedModel):
         if (self.model.run_mode is None) and (run_mode_override is None):
             errors['model'] = ['Model pk "{}" - "run_mode" must not be null'.format(self.model.id)]
 
-        if not self.portfolio.location_file:
-            if run_mode == self.run_mode_choices.V2:
+        # check for eitehr location or account file if V1
+        if run_mode == self.run_mode_choices.V1:
+            if (not self.portfolio.location_file) and (not self.portfolio.accounts_file):
+                errors['portfolio'] = ['Either "location_file" or "accounts_file" must not be null for run_mode = V1']
+
+        # check for location file if V2
+        if run_mode == self.run_mode_choices.V2:
+            if not self.portfolio.location_file:
                 errors['portfolio'] = ['"location_file" must not be null for run_mode = V2']
-        else:
-            try:
-                loc_lines = self.portfolio.location_file_len()
-            except Exception as e:
-                errors['portfolio'] = [f"Failed to read location file size for chunking: {e}"]
-            if loc_lines < 1:
-                errors['portfolio'] = ['"location_file" must at least one row']
+            else:
+                try:
+                    loc_lines = self.portfolio.location_file_len()
+                except Exception as e:
+                    errors['portfolio'] = [f"Failed to read location file size for chunking: {e}"]
+                if loc_lines < 1:
+                    errors['portfolio'] = ['"location_file" must at least one row']
 
         if errors:
             raise ValidationError(errors)

--- a/src/server/oasisapi/analyses/v1_api/serializers.py
+++ b/src/server/oasisapi/analyses/v1_api/serializers.py
@@ -210,8 +210,8 @@ class AnalysisSerializer(serializers.ModelSerializer):
 
         # Check that portfilio has a location file
         if attrs.get('portfolio'):
-            if not attrs['portfolio'].location_file:
-                raise ValidationError({'portfolio': '"location_file" must not be null'})
+            if (not attrs['portfolio'].location_file) and (not attrs['portfolio'].accounts_file):
+                raise ValidationError({'portfolio': 'either "location_file" or "accounts_file" must not be null'})
 
         # check that model isn't soft-deleted
         if attrs.get('model'):

--- a/src/server/oasisapi/analyses/v1_api/tests/test_analysis_model.py
+++ b/src/server/oasisapi/analyses/v1_api/tests/test_analysis_model.py
@@ -226,7 +226,8 @@ class AnalysisGenerateInputs(WebTestMixin, TestCase):
                     with self.assertRaises(ValidationError) as ex:
                         analysis.generate_inputs(initiator, run_mode_override='V1')
 
-                    self.assertEqual({'portfolio': ['"location_file" must not be null']}, ex.exception.detail)
+                    self.assertEqual(
+                        {'portfolio': ['Either "location_file" or "accounts_file" must not be null for run_mode = V1']}, ex.exception.detail)
 
                     self.assertEqual(Analysis.status_choices.NEW, analysis.status)
                     self.assertFalse(res_factory.revoke_called)

--- a/src/server/oasisapi/analyses/v2_api/serializers.py
+++ b/src/server/oasisapi/analyses/v2_api/serializers.py
@@ -403,8 +403,8 @@ class AnalysisSerializer(serializers.ModelSerializer):
             except ValidationError:
                 raise ValidationError({'portfolio': 'You are not allowed to use this portfolio'})
 
-            if not attrs['portfolio'].location_file:
-                raise ValidationError({'portfolio': '"location_file" must not be null'})
+            if (not attrs['portfolio'].location_file) and (not attrs['portfolio'].accounts_file):
+                raise ValidationError({'portfolio': 'either "location_file" or "accounts_file" must not be null'})
 
         # check that model isn't soft-deleted
         if attrs.get('model'):

--- a/src/server/oasisapi/analyses/v2_api/serializers.py
+++ b/src/server/oasisapi/analyses/v2_api/serializers.py
@@ -403,8 +403,8 @@ class AnalysisSerializer(serializers.ModelSerializer):
             except ValidationError:
                 raise ValidationError({'portfolio': 'You are not allowed to use this portfolio'})
 
-            if (not attrs['portfolio'].location_file) and (not attrs['portfolio'].accounts_file):
-                raise ValidationError({'portfolio': 'either "location_file" or "accounts_file" must not be null'})
+            if not attrs['portfolio'].location_file:
+                raise ValidationError({'portfolio': '"location_file" must not be null'})
 
         # check that model isn't soft-deleted
         if attrs.get('model'):

--- a/src/server/oasisapi/analyses/v2_api/tests/test_analysis_model.py
+++ b/src/server/oasisapi/analyses/v2_api/tests/test_analysis_model.py
@@ -394,7 +394,7 @@ class AnalysisGenerateInputs(WebTestMixin, TestCase):
                     with self.assertRaises(ValidationError) as ex:
                         analysis.generate_inputs(initiator, run_mode_override='V2')
 
-                    self.assertEqual({'portfolio': ['"location_file" must not be null']}, ex.exception.detail)
+                    self.assertEqual({'portfolio': ['"location_file" must not be null for run_mode = V2']}, ex.exception.detail)
 
                     self.assertEqual(Analysis.status_choices.NEW, analysis.status)
                     self.assertFalse(res_factory.revoke_called)

--- a/src/server/oasisapi/portfolios/v1_api/serializers.py
+++ b/src/server/oasisapi/portfolios/v1_api/serializers.py
@@ -384,8 +384,8 @@ class CreateAnalysisSerializer(AnalysisSerializer):
 
     def validate(self, attrs):
         attrs['portfolio'] = self.portfolio
-        if not self.portfolio.location_file:
-            raise ValidationError({'portfolio': '"location_file" must not be null'})
+        if (not self.portfolio.location_file) and (not self.portfolio.accounts_file):
+            raise ValidationError({'portfolio': 'either "location_file" or "accounts_file" must not be null'})
 
         return attrs
 

--- a/src/server/oasisapi/portfolios/v1_api/tests/test_portfolio.py
+++ b/src/server/oasisapi/portfolios/v1_api/tests/test_portfolio.py
@@ -195,7 +195,7 @@ class PortfolioApiCreateAnalysis(WebTestMixin, TestCase):
         )
 
         self.assertEqual(400, response.status_code)
-        self.assertIn('"location_file" must not be null', response.json['portfolio'])
+        self.assertIn('either "location_file" or "accounts_file" must not be null', response.json['portfolio'])
 
     def test_model_is_not_provided___response_is_400(self):
         user = fake_user()

--- a/src/server/oasisapi/portfolios/v2_api/serializers.py
+++ b/src/server/oasisapi/portfolios/v2_api/serializers.py
@@ -405,8 +405,8 @@ class CreateAnalysisSerializer(AnalysisSerializer):
 
     def validate(self, attrs):
         attrs['portfolio'] = self.portfolio
-        if not self.portfolio.location_file:
-            raise ValidationError({'portfolio': '"location_file" must not be null'})
+        if (not self.portfolio.location_file) and (not self.portfolio.accounts_file):
+            raise ValidationError({'portfolio': 'either "location_file" or "accounts_file" must not be null'})
 
         # Validate and update groups parameter
         validate_and_update_groups(self.partial, self.context.get('request').user, attrs)

--- a/src/server/oasisapi/portfolios/v2_api/serializers.py
+++ b/src/server/oasisapi/portfolios/v2_api/serializers.py
@@ -405,8 +405,8 @@ class CreateAnalysisSerializer(AnalysisSerializer):
 
     def validate(self, attrs):
         attrs['portfolio'] = self.portfolio
-        if (not self.portfolio.location_file) and (not self.portfolio.accounts_file):
-            raise ValidationError({'portfolio': 'either "location_file" or "accounts_file" must not be null'})
+        if not self.portfolio.location_file:
+            raise ValidationError({'portfolio': '"location_file" must not be null'})
 
         # Validate and update groups parameter
         validate_and_update_groups(self.partial, self.context.get('request').user, attrs)

--- a/src/server/oasisapi/portfolios/v2_api/tests/test_portfolio.py
+++ b/src/server/oasisapi/portfolios/v2_api/tests/test_portfolio.py
@@ -417,7 +417,7 @@ class PortfolioApiCreateAnalysis(WebTestMixin, TestCase):
         )
 
         self.assertEqual(400, response.status_code)
-        self.assertIn('"location_file" must not be null', response.json['portfolio'])
+        self.assertIn('either "location_file" or "accounts_file" must not be null', response.json['portfolio'])
 
     def test_model_is_not_provided___response_is_400(self):
         user = fake_user()


### PR DESCRIPTION
<!--start_release_notes-->
### Add cybermodels support in the OasisAPI - V1 Only
* Only for `run_mode = V1`  allow input generation to work without posting a location.csv file. 
* Update the check in portfolios to allow execution if **Either** a location or an account file is attached.  
<!--end_release_notes-->
