### PR TITLE
Fixed pip install on model worker images 

### DIFF
--- a/Dockerfile.api_server
+++ b/Dockerfile.api_server
@@ -66,6 +66,7 @@ RUN chown -R server:server /shared-fs \
 
 USER server
 RUN OASIS_API_SECRET_KEY=supersecret python3 manage.py collectstatic --noinput
+ENV PIP_BREAK_SYSTEM_PACKAGES 1
 ENV OASIS_SERVER_DB_ENGINE django.db.backends.mysql
 ENV OASIS_MEDIA_ROOT=/shared-fs
 ENV OASIS_DEBUG=false

--- a/Dockerfile.model_worker
+++ b/Dockerfile.model_worker
@@ -75,6 +75,7 @@ RUN chown -R worker:worker /var/oasis \
 COPY ./VERSION ./
 USER worker
 ENV PATH=/home/worker/.local/bin:$PATH
+ENV PIP_BREAK_SYSTEM_PACKAGES 1
 ENV DEBIAN_FRONTEND=noninteractive
 ENV OASIS_MEDIA_ROOT=/shared-fs
 ENV OASIS_ENV_OVERRIDE=true

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@
 #    pip-compile requirements.in
 #
 adlfs==2024.7.0
-    # via -r ./requirements-worker.in
+    # via -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-worker.in
 aiobotocore==2.15.2
     # via s3fs
 aiohappyeyeballs==2.4.3
@@ -51,7 +51,7 @@ automat==24.8.1
     # via twisted
 azure-core==1.31.0
     # via
-    #   -r ./requirements-worker.in
+    #   -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-worker.in
     #   adlfs
     #   azure-identity
     #   azure-storage-blob
@@ -62,7 +62,7 @@ azure-identity==1.19.0
     # via adlfs
 azure-storage-blob==12.23.1
     # via
-    #   -r ./requirements-worker.in
+    #   -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-worker.in
     #   adlfs
     #   django-storages
 backports-tempfile==1.0
@@ -73,12 +73,12 @@ beautifulsoup4==4.12.3
     # via webtest
 billiard==4.2.1
     # via
-    #   -r ./requirements-worker.in
+    #   -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-worker.in
     #   celery
 boto3==1.35.36
     # via
-    #   -r ./requirements-server.in
-    #   -r ./requirements-worker.in
+    #   -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-server.in
+    #   -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-worker.in
 botocore==1.35.36
     # via
     #   aiobotocore
@@ -90,8 +90,8 @@ cachetools==5.5.0
     # via tox
 celery==5.4.0
     # via
-    #   -r ./requirements-server.in
-    #   -r ./requirements-worker.in
+    #   -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-server.in
+    #   -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-worker.in
     #   django-celery-results
 certifi==2024.8.30
     # via
@@ -104,14 +104,14 @@ cffi==1.17.1
     #   cryptography
 chainmap==1.0.3
     # via
-    #   -r ./requirements-server.in
+    #   -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-server.in
     #   oasislmf
 channels==2.4.0
     # via
-    #   -r ./requirements-server.in
+    #   -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-server.in
     #   channels-redis
 channels-redis==2.4.2
-    # via -r ./requirements-server.in
+    # via -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-server.in
 chardet==5.2.0
     # via
     #   oasislmf
@@ -135,11 +135,11 @@ click-repl==0.3.0
 colorama==0.4.6
     # via tox
 configparser==7.1.0
-    # via -r ./requirements-worker.in
+    # via -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-worker.in
 constantly==23.10.4
     # via twisted
 coreapi==2.3.3
-    # via -r ./requirements-server.in
+    # via -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-server.in
 coreschema==0.0.4
     # via coreapi
 coverage[toml]==7.6.4
@@ -183,40 +183,40 @@ django==3.2.25
     #   model-mommy
     #   mozilla-django-oidc
 django-celery-results==2.5.1
-    # via -r ./requirements-server.in
+    # via -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-server.in
 django-cleanup==9.0.0
-    # via -r ./requirements-server.in
+    # via -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-server.in
 django-debug-toolbar==4.3.0
     # via
-    #   -r ./requirements-server.in
+    #   -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-server.in
     #   -r requirements.in
 django-filter==23.5
-    # via -r ./requirements-server.in
+    # via -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-server.in
 django-model-utils==5.0.0
-    # via -r ./requirements-server.in
+    # via -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-server.in
 django-request-logging==0.7.5
-    # via -r ./requirements-server.in
+    # via -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-server.in
 django-storages[azure]==1.14.4
-    # via -r ./requirements-server.in
+    # via -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-server.in
 django-webtest==1.9.12
     # via -r requirements.in
 djangorestframework==3.14.0
     # via
-    #   -r ./requirements-server.in
+    #   -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-server.in
     #   djangorestframework-simplejwt
     #   drf-nested-routers
     #   drf-yasg
 djangorestframework-simplejwt==5.3.1
-    # via -r ./requirements-server.in
+    # via -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-server.in
 drf-nested-routers==0.94.0
-    # via -r ./requirements-server.in
+    # via -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-server.in
 drf-yasg==1.21.8
-    # via -r ./requirements-server.in
+    # via -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-server.in
 executing==2.1.0
     # via stack-data
 fasteners==0.19
     # via
-    #   -r ./requirements-worker.in
+    #   -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-worker.in
     #   -r requirements.in
 fastparquet==2024.5.0
     # via
@@ -224,7 +224,7 @@ fastparquet==2024.5.0
     #   oasislmf
 filelock==3.16.1
     # via
-    #   -r ./requirements-worker.in
+    #   -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-worker.in
     #   tox
     #   virtualenv
 flake8==7.1.1
@@ -248,7 +248,7 @@ geopandas==1.0.1
 greenlet==3.1.1
     # via sqlalchemy
 gunicorn==23.0.0
-    # via -r ./requirements-server.in
+    # via -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-server.in
 hiredis==3.0.0
     # via aioredis
 httplib2==0.22.0
@@ -289,18 +289,18 @@ jmespath==1.0.1
     #   botocore
 joblib==1.4.2
     # via
-    #   -r ./requirements-server.in
-    #   -r ./requirements-worker.in
+    #   -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-server.in
+    #   -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-worker.in
     #   scikit-learn
 josepy==1.14.0
     # via mozilla-django-oidc
 jsonpickle==3.3.0
-    # via -r ./requirements-server.in
+    # via -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-server.in
 jsonref==1.1.0
     # via ods-tools
 jsonschema==4.23.0
     # via
-    #   -r ./requirements-server.in
+    #   -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-server.in
     #   ods-tools
 jsonschema-specifications==2024.10.1
     # via jsonschema
@@ -309,7 +309,7 @@ kombu==5.4.2
 llvmlite==0.43.0
     # via numba
 markdown==3.7
-    # via -r ./requirements-server.in
+    # via -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-server.in
 markupsafe==3.0.2
     # via jinja2
 matplotlib-inline==0.1.7
@@ -321,7 +321,7 @@ mock==5.1.0
 model-mommy==2.0.0
     # via -r requirements.in
 mozilla-django-oidc==4.0.1
-    # via -r ./requirements-server.in
+    # via -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-server.in
 msal==1.31.0
     # via
     #   azure-datalake-store
@@ -338,9 +338,9 @@ multidict==6.1.0
     #   aiohttp
     #   yarl
 mysqlclient==2.1.1
-    # via -r ./requirements-server.in
+    # via -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-server.in
 natsort==8.4.0
-    # via -r ./requirements-worker.in
+    # via -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-worker.in
 numba==0.60.0
     # via
     #   oasislmf
@@ -362,15 +362,15 @@ numpy==1.26.4
     #   shapely
 oasis-data-manager==0.1.3
     # via
-    #   -r ./requirements-server.in
-    #   -r ./requirements-worker.in
+    #   -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-server.in
+    #   -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-worker.in
     #   oasislmf
     #   ods-tools
 oasislmf[extra]==2.3.9
-    # via -r ./requirements-worker.in
+    # via -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-worker.in
 ods-tools==3.2.7
     # via
-    #   -r ./requirements-server.in
+    #   -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-server.in
     #   oasislmf
 packaging==24.1
     # via
@@ -386,7 +386,7 @@ packaging==24.1
     #   tox
 pandas==2.1.4
     # via
-    #   -r ./requirements-server.in
+    #   -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-server.in
     #   fastparquet
     #   geopandas
     #   oasis-data-manager
@@ -396,8 +396,8 @@ parso==0.8.4
     # via jedi
 pathlib2==2.3.7.post1
     # via
-    #   -r ./requirements-server.in
-    #   -r ./requirements-worker.in
+    #   -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-server.in
+    #   -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-worker.in
 pexpect==4.9.0
     # via ipython
 pip-tools==7.4.1
@@ -420,15 +420,15 @@ propcache==0.2.0
     # via yarl
 psycopg2-binary==2.9.10
     # via
-    #   -r ./requirements-server.in
-    #   -r ./requirements-worker.in
+    #   -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-server.in
+    #   -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-worker.in
 ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.3
     # via stack-data
 pyarrow==17.0.0
     # via
-    #   -r ./requirements-server.in
+    #   -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-server.in
     #   oasislmf
 pyasn1==0.6.1
     # via
@@ -450,8 +450,8 @@ pyjwt[crypto]==2.9.0
     #   msal
 pymysql==1.1.1
     # via
-    #   -r ./requirements-server.in
-    #   -r ./requirements-worker.in
+    #   -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-server.in
+    #   -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-worker.in
 pyogrio==0.10.0
     # via geopandas
 pyopenssl==24.2.1
@@ -470,10 +470,10 @@ pyproject-hooks==1.2.0
     #   build
     #   pip-tools
 pyrabbit==1.1.0
-    # via -r ./requirements-server.in
+    # via -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-server.in
 pytest==8.3.3
     # via
-    #   -r ./requirements-worker.in
+    #   -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-worker.in
     #   -r requirements.in
     #   pytest-cov
     #   pytest-django
@@ -498,8 +498,8 @@ pyyaml==6.0.2
     # via drf-yasg
 redis==5.2.0
     # via
-    #   -r ./requirements-server.in
-    #   -r ./requirements-worker.in
+    #   -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-server.in
+    #   -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-worker.in
 referencing==0.35.1
     # via
     #   jsonschema
@@ -524,7 +524,7 @@ rpds-py==0.20.0
 rtree==1.3.0
     # via oasislmf
 s3fs==2024.10.0
-    # via -r ./requirements-worker.in
+    # via -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-worker.in
 s3transfer==0.10.3
     # via boto3
 scikit-learn==1.5.2
@@ -556,8 +556,8 @@ soupsieve==2.6
     # via beautifulsoup4
 sqlalchemy==2.0.36
     # via
-    #   -r ./requirements-server.in
-    #   -r ./requirements-worker.in
+    #   -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-server.in
+    #   -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-worker.in
 sqlparse==0.5.1
     # via
     #   django
@@ -610,7 +610,7 @@ vine==5.1.0
     #   kombu
 virtualenv==20.27.0
     # via tox
-waitress==3.0.0
+waitress==3.0.1
     # via webtest
 wcwidth==0.2.13
     # via prompt-toolkit
@@ -621,7 +621,7 @@ webtest==3.0.1
 wheel==0.44.0
     # via pip-tools
 whitenoise==6.7.0
-    # via -r ./requirements-server.in
+    # via -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-server.in
 wrapt==1.16.0
     # via aiobotocore
 yarl==1.16.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@
 #    pip-compile requirements.in
 #
 adlfs==2024.7.0
-    # via -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-worker.in
+    # via -r ./requirements-worker.in
 aiobotocore==2.15.2
     # via s3fs
 aiohappyeyeballs==2.4.3
@@ -51,7 +51,7 @@ automat==24.8.1
     # via twisted
 azure-core==1.31.0
     # via
-    #   -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-worker.in
+    #   -r ./requirements-worker.in
     #   adlfs
     #   azure-identity
     #   azure-storage-blob
@@ -62,7 +62,7 @@ azure-identity==1.19.0
     # via adlfs
 azure-storage-blob==12.23.1
     # via
-    #   -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-worker.in
+    #   -r ./requirements-worker.in
     #   adlfs
     #   django-storages
 backports-tempfile==1.0
@@ -73,12 +73,12 @@ beautifulsoup4==4.12.3
     # via webtest
 billiard==4.2.1
     # via
-    #   -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-worker.in
+    #   -r ./requirements-worker.in
     #   celery
 boto3==1.35.36
     # via
-    #   -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-server.in
-    #   -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-worker.in
+    #   -r ./requirements-server.in
+    #   -r ./requirements-worker.in
 botocore==1.35.36
     # via
     #   aiobotocore
@@ -90,8 +90,8 @@ cachetools==5.5.0
     # via tox
 celery==5.4.0
     # via
-    #   -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-server.in
-    #   -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-worker.in
+    #   -r ./requirements-server.in
+    #   -r ./requirements-worker.in
     #   django-celery-results
 certifi==2024.8.30
     # via
@@ -104,14 +104,14 @@ cffi==1.17.1
     #   cryptography
 chainmap==1.0.3
     # via
-    #   -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-server.in
+    #   -r ./requirements-server.in
     #   oasislmf
 channels==2.4.0
     # via
-    #   -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-server.in
+    #   -r ./requirements-server.in
     #   channels-redis
 channels-redis==2.4.2
-    # via -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-server.in
+    # via -r ./requirements-server.in
 chardet==5.2.0
     # via
     #   oasislmf
@@ -135,11 +135,11 @@ click-repl==0.3.0
 colorama==0.4.6
     # via tox
 configparser==7.1.0
-    # via -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-worker.in
+    # via -r ./requirements-worker.in
 constantly==23.10.4
     # via twisted
 coreapi==2.3.3
-    # via -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-server.in
+    # via -r ./requirements-server.in
 coreschema==0.0.4
     # via coreapi
 coverage[toml]==7.6.4
@@ -183,40 +183,40 @@ django==3.2.25
     #   model-mommy
     #   mozilla-django-oidc
 django-celery-results==2.5.1
-    # via -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-server.in
+    # via -r ./requirements-server.in
 django-cleanup==9.0.0
-    # via -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-server.in
+    # via -r ./requirements-server.in
 django-debug-toolbar==4.3.0
     # via
-    #   -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-server.in
+    #   -r ./requirements-server.in
     #   -r requirements.in
 django-filter==23.5
-    # via -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-server.in
+    # via -r ./requirements-server.in
 django-model-utils==5.0.0
-    # via -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-server.in
+    # via -r ./requirements-server.in
 django-request-logging==0.7.5
-    # via -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-server.in
+    # via -r ./requirements-server.in
 django-storages[azure]==1.14.4
-    # via -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-server.in
+    # via -r ./requirements-server.in
 django-webtest==1.9.12
     # via -r requirements.in
 djangorestframework==3.14.0
     # via
-    #   -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-server.in
+    #   -r ./requirements-server.in
     #   djangorestframework-simplejwt
     #   drf-nested-routers
     #   drf-yasg
 djangorestframework-simplejwt==5.3.1
-    # via -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-server.in
+    # via -r ./requirements-server.in
 drf-nested-routers==0.94.0
-    # via -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-server.in
+    # via -r ./requirements-server.in
 drf-yasg==1.21.8
-    # via -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-server.in
+    # via -r ./requirements-server.in
 executing==2.1.0
     # via stack-data
 fasteners==0.19
     # via
-    #   -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-worker.in
+    #   -r ./requirements-worker.in
     #   -r requirements.in
 fastparquet==2024.5.0
     # via
@@ -224,7 +224,7 @@ fastparquet==2024.5.0
     #   oasislmf
 filelock==3.16.1
     # via
-    #   -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-worker.in
+    #   -r ./requirements-worker.in
     #   tox
     #   virtualenv
 flake8==7.1.1
@@ -248,7 +248,7 @@ geopandas==1.0.1
 greenlet==3.1.1
     # via sqlalchemy
 gunicorn==23.0.0
-    # via -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-server.in
+    # via -r ./requirements-server.in
 hiredis==3.0.0
     # via aioredis
 httplib2==0.22.0
@@ -289,18 +289,18 @@ jmespath==1.0.1
     #   botocore
 joblib==1.4.2
     # via
-    #   -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-server.in
-    #   -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-worker.in
+    #   -r ./requirements-server.in
+    #   -r ./requirements-worker.in
     #   scikit-learn
 josepy==1.14.0
     # via mozilla-django-oidc
 jsonpickle==3.3.0
-    # via -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-server.in
+    # via -r ./requirements-server.in
 jsonref==1.1.0
     # via ods-tools
 jsonschema==4.23.0
     # via
-    #   -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-server.in
+    #   -r ./requirements-server.in
     #   ods-tools
 jsonschema-specifications==2024.10.1
     # via jsonschema
@@ -309,7 +309,7 @@ kombu==5.4.2
 llvmlite==0.43.0
     # via numba
 markdown==3.7
-    # via -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-server.in
+    # via -r ./requirements-server.in
 markupsafe==3.0.2
     # via jinja2
 matplotlib-inline==0.1.7
@@ -321,7 +321,7 @@ mock==5.1.0
 model-mommy==2.0.0
     # via -r requirements.in
 mozilla-django-oidc==4.0.1
-    # via -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-server.in
+    # via -r ./requirements-server.in
 msal==1.31.0
     # via
     #   azure-datalake-store
@@ -338,9 +338,9 @@ multidict==6.1.0
     #   aiohttp
     #   yarl
 mysqlclient==2.1.1
-    # via -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-server.in
+    # via -r ./requirements-server.in
 natsort==8.4.0
-    # via -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-worker.in
+    # via -r ./requirements-worker.in
 numba==0.60.0
     # via
     #   oasislmf
@@ -362,15 +362,15 @@ numpy==1.26.4
     #   shapely
 oasis-data-manager==0.1.3
     # via
-    #   -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-server.in
-    #   -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-worker.in
+    #   -r ./requirements-server.in
+    #   -r ./requirements-worker.in
     #   oasislmf
     #   ods-tools
 oasislmf[extra]==2.3.9
-    # via -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-worker.in
+    # via -r ./requirements-worker.in
 ods-tools==3.2.7
     # via
-    #   -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-server.in
+    #   -r ./requirements-server.in
     #   oasislmf
 packaging==24.1
     # via
@@ -386,7 +386,7 @@ packaging==24.1
     #   tox
 pandas==2.1.4
     # via
-    #   -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-server.in
+    #   -r ./requirements-server.in
     #   fastparquet
     #   geopandas
     #   oasis-data-manager
@@ -396,8 +396,8 @@ parso==0.8.4
     # via jedi
 pathlib2==2.3.7.post1
     # via
-    #   -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-server.in
-    #   -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-worker.in
+    #   -r ./requirements-server.in
+    #   -r ./requirements-worker.in
 pexpect==4.9.0
     # via ipython
 pip-tools==7.4.1
@@ -420,15 +420,15 @@ propcache==0.2.0
     # via yarl
 psycopg2-binary==2.9.10
     # via
-    #   -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-server.in
-    #   -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-worker.in
+    #   -r ./requirements-server.in
+    #   -r ./requirements-worker.in
 ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.3
     # via stack-data
 pyarrow==17.0.0
     # via
-    #   -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-server.in
+    #   -r ./requirements-server.in
     #   oasislmf
 pyasn1==0.6.1
     # via
@@ -450,8 +450,8 @@ pyjwt[crypto]==2.9.0
     #   msal
 pymysql==1.1.1
     # via
-    #   -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-server.in
-    #   -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-worker.in
+    #   -r ./requirements-server.in
+    #   -r ./requirements-worker.in
 pyogrio==0.10.0
     # via geopandas
 pyopenssl==24.2.1
@@ -470,10 +470,10 @@ pyproject-hooks==1.2.0
     #   build
     #   pip-tools
 pyrabbit==1.1.0
-    # via -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-server.in
+    # via -r ./requirements-server.in
 pytest==8.3.3
     # via
-    #   -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-worker.in
+    #   -r ./requirements-worker.in
     #   -r requirements.in
     #   pytest-cov
     #   pytest-django
@@ -498,8 +498,8 @@ pyyaml==6.0.2
     # via drf-yasg
 redis==5.2.0
     # via
-    #   -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-server.in
-    #   -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-worker.in
+    #   -r ./requirements-server.in
+    #   -r ./requirements-worker.in
 referencing==0.35.1
     # via
     #   jsonschema
@@ -524,7 +524,7 @@ rpds-py==0.20.0
 rtree==1.3.0
     # via oasislmf
 s3fs==2024.10.0
-    # via -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-worker.in
+    # via -r ./requirements-worker.in
 s3transfer==0.10.3
     # via boto3
 scikit-learn==1.5.2
@@ -556,8 +556,8 @@ soupsieve==2.6
     # via beautifulsoup4
 sqlalchemy==2.0.36
     # via
-    #   -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-server.in
-    #   -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-worker.in
+    #   -r ./requirements-server.in
+    #   -r ./requirements-worker.in
 sqlparse==0.5.1
     # via
     #   django
@@ -621,7 +621,7 @@ webtest==3.0.1
 wheel==0.44.0
     # via pip-tools
 whitenoise==6.7.0
-    # via -r /home/runner/work/OasisPlatform/OasisPlatform/requirements-server.in
+    # via -r ./requirements-server.in
 wrapt==1.16.0
     # via aiobotocore
 yarl==1.16.0


### PR DESCRIPTION
<!--start_release_notes-->
### Fixed pip install on model worker images 
Moving to ubuntu `24.04` uses a version of python with a stricter package manager. Added an env variable to base image as a workaround. 


<!--end_release_notes-->

```
error: externally-managed-environment                                          

× This environment is externally managed
╰─> To install Python packages system-wide, try apt install
    python3-xyz, where xyz is the package you are trying to
    install.

    If you wish to install a non-Debian-packaged Python package,
    create a virtual environment using python3 -m venv path/to/venv.
    Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
    sure you have python3-full installed.

    If you wish to install a non-Debian packaged Python application,
    it may be easiest to use pipx install xyz, which will manage a
    virtual environment for you. Make sure you have pipx installed.

    See /usr/share/doc/python3.12/README.venv for more information.
``` 