### PR TITLE
Split the healthcheck between deep and shallow

### DIFF
--- a/src/server/oasisapi/base_urls.py
+++ b/src/server/oasisapi/base_urls.py
@@ -3,12 +3,13 @@ from django.contrib import admin
 
 from .info.views import PerilcodesView
 from .info.views import ServerInfoView
-from .healthcheck.views import HealthcheckView
+from .healthcheck.views import HealthcheckViewDeep, HealthcheckViewShallow
 
 # app_name = 'base'
 
 urlpatterns = [
-    url(r'^healthcheck/$', HealthcheckView.as_view(), name='healthcheck'),
+    url(r'^healthcheck/$', HealthcheckViewShallow.as_view(), name='healthcheck'),
+    url(r'^healthcheck_connections/$', HealthcheckViewDeep.as_view(), name='healthcheck_deep'),
     url(r'^oed_peril_codes/$', PerilcodesView.as_view(), name='perilcodes'),
     url(r'^server_info/$', ServerInfoView.as_view(), name='serverinfo'),
     url(r'^auth/', include('rest_framework.urls')),

--- a/src/server/oasisapi/healthcheck/tests/test_healthcheck.py
+++ b/src/server/oasisapi/healthcheck/tests/test_healthcheck.py
@@ -3,19 +3,29 @@ from rest_framework.reverse import reverse
 from unittest.mock import patch
 
 from ...auth.tests.fakes import fake_user
-from ..views import HealthcheckView
+from ..views import HealthcheckViewDeep
 
 
 class Healthcheck(WebTest):
 
-    @patch.object(HealthcheckView, 'celery_v1_is_ok', return_value=True)
-    @patch.object(HealthcheckView, 'celery_v2_is_ok', return_value=True)
-    def test_user_is_not_authenticated___response_is_ok(self, mock_celery_v1, mock_celery_v2):
-        response = self.app.get(reverse('healthcheck'))
+    @patch.object(HealthcheckViewDeep, 'celery_v1_is_ok', return_value=True)
+    @patch.object(HealthcheckViewDeep, 'celery_v2_is_ok', return_value=True)
+    def test_user_is_not_authenticated_deep___response_is_ok(self, mock_celery_v1, mock_celery_v2):
+        response = self.app.get(reverse('healthcheck_deep'))
         self.assertEqual(200, response.status_code)
 
-    @patch.object(HealthcheckView, 'celery_v1_is_ok', return_value=True)
-    @patch.object(HealthcheckView, 'celery_v2_is_ok', return_value=True)
-    def test_user_is_authenticated___response_is_ok(self, mock_celery_v1, mock_celery_v2):
+    @patch.object(HealthcheckViewDeep, 'celery_v1_is_ok', return_value=True)
+    @patch.object(HealthcheckViewDeep, 'celery_v2_is_ok', return_value=True)
+    def test_user_is_authenticated_deep___response_is_ok(self, mock_celery_v1, mock_celery_v2):
+        response = self.app.get(reverse('healthcheck_deep'), user=fake_user())
+        self.assertEqual(200, response.status_code)
+
+    def test_user_is_not_authenticated_shallow___response_is_ok(self):
+        response = self.app.get(reverse('healthcheck'))
+
+        self.assertEqual(200, response.status_code)
+
+    def test_user_is_authenticated_shallow___response_is_ok(self):
         response = self.app.get(reverse('healthcheck'), user=fake_user())
+
         self.assertEqual(200, response.status_code)

--- a/src/server/oasisapi/healthcheck/views.py
+++ b/src/server/oasisapi/healthcheck/views.py
@@ -12,9 +12,23 @@ from ..celery_app_v2 import v2 as celery_app_v2
 from ..schemas.custom_swagger import HEALTHCHECK
 
 
-class HealthcheckView(views.APIView):
+class HealthcheckViewShallow(views.APIView):
     """
     Gets the current status of the api
+    """
+
+    http_method_names = ['get']
+    authentication_classes = []
+    permission_classes = []
+
+    @swagger_auto_schema(responses={200: HEALTHCHECK})
+    def get(self, request):
+        return Response({'status': 'OK'})
+
+
+class HealthcheckViewDeep(views.APIView):
+    """
+    Gets the current status of the api, checking the connecting to celery and database 
     """
 
     http_method_names = ['get']

--- a/src/server/oasisapi/healthcheck/views.py
+++ b/src/server/oasisapi/healthcheck/views.py
@@ -1,5 +1,6 @@
 import logging
-
+import time
+import subprocess
 from django.db import connection
 from django.conf import settings as django_settings
 
@@ -40,19 +41,47 @@ class HealthcheckViewDeep(views.APIView):
         """
         Check db and celery connectivity and return a 200 if healthy, 503 if not.
         """
+        logger = logging.getLogger(__name__)
+        logger.info("***************************Begin healthcheck********************************")
         code = status.HTTP_200_OK
         status_text = 'OK'
 
+        logger.info("Starting health check")
+
         if not django_settings.CONSOLE_DEBUG:
+            start_time = time.time()
+
+            celery_v1_start = time.time()
             if not self.celery_v1_is_ok():
                 status_text = 'ERROR - celery v1 down'
                 code = status.HTTP_503_SERVICE_UNAVAILABLE
-            elif not self.celery_v2_is_ok():
+                logger.error("Celery v1 is down (took %.2f seconds)", time.time() - celery_v1_start)
+            else:
+                logger.info("Celery v1 is healthy (took %.2f seconds)", time.time() - celery_v1_start)
+
+            celery_v2_start = time.time()
+            if not self.celery_v2_is_ok():
                 status_text = 'ERROR - celery v2 down'
                 code = status.HTTP_503_SERVICE_UNAVAILABLE
-            elif not self.db_is_ok():
+                logger.error("Celery v2 is down (took %.2f seconds)", time.time() - celery_v2_start)
+            else:
+                logger.info("Celery v2 is healthy (took %.2f seconds)", time.time() - celery_v2_start)
+
+            db_start = time.time()
+            if not self.db_is_ok():
                 status_text = 'ERROR - db down'
                 code = status.HTTP_503_SERVICE_UNAVAILABLE
+                logger.error("Database is down (took %.2f seconds)", time.time() - db_start)
+            else:
+                logger.info("Database is healthy (took %.2f seconds)", time.time() - db_start)
+
+            logger.info("Total health check time: %.2f seconds", time.time() - start_time)
+            # Measure the time taken to print the `top` command output
+            start_time = time.time()
+            logger.info(self.get_top_output())
+            elapsed_time = time.time() - start_time
+            logger.info(f"Time taken to print the result: {elapsed_time:.2f} seconds")
+            logger.info("***************************Finish healthcheck********************************")
 
         return Response({'status': status_text}, code)
 
@@ -100,3 +129,12 @@ class HealthcheckViewDeep(views.APIView):
             logging.error('Database error: %s', e)
             return False
         return True
+
+    import subprocess
+
+    def get_top_output(self):
+        try:
+            # Run the `top` command and capture its output
+            return subprocess.run(['top', '-b', '-n', '1'], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+        except Exception as e:
+            return None


### PR DESCRIPTION
<!--start_release_notes-->
### Split the healthcheck between deep and shallow
if the oasis-server is under load the response time of the celery / DB tests in the heathcheck can cause liveness probes to fail.   

`healthcheck` - shallow test, used to check if the API is responsive 
`healthcheck_connections` - deeper healthcheck which also checks for connections to celery and DB

<!--end_release_notes-->


[example_shallow_healthcheck_loaded.txt](https://github.com/user-attachments/files/20343654/example_shallow_healthcheck_loaded.txt)

[example_deep_healthcheck_overloaded.txt](https://github.com/user-attachments/files/20343656/example_deep_healthcheck_overloaded.txt)

