### PR TITLE
update upload to v3

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -197,7 +197,7 @@ jobs:
 
     - name: Upload scan results to Security tab
       if: ( success() || failure() ) && env.SEVERITY != 'SKIP' && matrix.exit-code == '1'
-      uses: github/codeql-action/upload-sarif@v2
+      uses: github/codeql-action/upload-sarif@v3
       with:
         sarif_file:  ${{ matrix.report }}
 

--- a/.github/workflows/scan-external.yml
+++ b/.github/workflows/scan-external.yml
@@ -91,7 +91,7 @@ jobs:
 
     - name: Upload Trivy scan results to GitHub Security tab
       if: success() || failure()
-      uses: github/codeql-action/upload-sarif@v2
+      uses: github/codeql-action/upload-sarif@v3
       with:
         sarif_file: ${{ matrix.report }}
 

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -98,7 +98,7 @@ jobs:
 
     - name: Upload Trivy scan results to GitHub Security tab
       if: success() || failure()
-      uses: github/codeql-action/upload-sarif@v2
+      uses: github/codeql-action/upload-sarif@v3
       with:
         sarif_file:  ${{ env.REPORT }}
 


### PR DESCRIPTION
<!--start_release_notes-->
### CI fix - uploading found vulnerabilities to github 
fixes the following issue: 
```
Error: CodeQL Action major versions v1 and v2 have been deprecated. Please update all occurrences of the CodeQL Action in your workflow files to v3. For more information, see https://github.blog/changelog/2025-01-10-code-scanning-codeql-action-v2-is-now-deprecated/
```
<!--end_release_notes-->
