### PR TITLE
CI check for server compatibility breaks within a stable version (2.4.x)

### DIFF
--- a/.github/workflows/test-images.yml
+++ b/.github/workflows/test-images.yml
@@ -34,7 +34,7 @@ env:
   pre_release: 'true'  # look for pre-release when testing last released platform version
   semver_major: '2'    # Search for published images but limited to {semvar_major}.x.x
   #semver_minor: '27'   # Search for published images but limited to x.{semvar_minor}.x
-  server_min_supported: '2.4.3'
+  server_min_supported: '2.4.4'
 
 jobs:
   build_images:


### PR DESCRIPTION
**IMPORTANT: Please attach or create an issue after submitting a Pull Request.

<!--start_release_notes-->
### CI check for server compatibility breaks within a stable version (2.4.x)
Added CI check for minimum server supported by currently published worker. 
Goal is to not break compatibility with this minimum server version (within `stable/2.4.x`) 
* set to `2.4.4`  

<!--end_release_notes-->
