### PR TITLE
feature/enable celery optimisation flags

### DIFF
--- a/src/conf/celeryconf_v1.py
+++ b/src/conf/celeryconf_v1.py
@@ -34,7 +34,7 @@ CELERYD_PREFETCH_MULTIPLIER = 1
 
 # control resource usage of workers
 CELERYD_MAX_MEMORY_PER_CHILD = settings.get('celery', 'worker_max_memory_per_child', fallback=None)
-CELERYD_MAX_TASKS_PER_CHILD = settings.getint('celery', 'worker_max_tasks_per_child', fallback=None)
+CELERYD_MAX_TASKS_PER_CHILD = settings.getint('celery', 'worker_max_tasks_per_child', fallback=1)
 
 CELERY_ACKS_LATE = True
 CELERY_REJECT_ON_WORKER_LOST = False

--- a/src/conf/celeryconf_v2.py
+++ b/src/conf/celeryconf_v2.py
@@ -50,7 +50,7 @@ CELERY_INHERIT_PARENT_PRIORITY = True
 
 # control resource usage of workers
 CELERYD_MAX_MEMORY_PER_CHILD = settings.get('celery', 'worker_max_memory_per_child', fallback=None)
-CELERYD_MAX_TASKS_PER_CHILD = settings.getint('celery', 'worker_max_tasks_per_child', fallback=None)
+CELERYD_MAX_TASKS_PER_CHILD = settings.getint('celery', 'worker_max_tasks_per_child', fallback=1)
 
 
 def crontab_from_string(s):


### PR DESCRIPTION

<!--start_release_notes-->
### feature/enable celery optimisation flags
enables the following flags: 
- `OASIS_CELERY_WORKER_MAX_MEMORY_PER_CHILD`:  `worker_max_tasks_per_child`
- `OASIS_CELERY_MAX_TASKS_PER_CHILD`: `worker_max_memory_per_child`
<!--end_release_notes-->
