### PR TITLE
Fix Gunicorn number of workers 

### DIFF
--- a/wsgi/run-wsgi.sh
+++ b/wsgi/run-wsgi.sh
@@ -4,7 +4,8 @@
 # https://docs.gunicorn.org/en/stable/settings.html
 
 BIND_ADDR='0.0.0.0:8000'
-WORKERS=$(nproc --all)
+WORKERS=$(python3 -c "import os; print(len(os.sched_getaffinity(0)))" 2>/dev/null)
+WORKERS=${WORKERS:-1}
 TIMEOUT=600
 LOG_LEVEL='info'
 


### PR DESCRIPTION
<!--start_release_notes-->
### Fix Gunicorn number of workers 
Nproc returned the wrong number of core which caused the server overload its DB connections
<!--end_release_notes-->
