### PR TITLE
removed workaround for exposure run endpoint

### DIFF
--- a/src/model_execution_worker/server_tasks.py
+++ b/src/model_execution_worker/server_tasks.py
@@ -49,7 +49,6 @@ def run_exposure_run(loc_filepath, acc_filepath, ri_filepath, rl_filepath,
         os.chdir(tmpdir)
         params = OasisManager()._params_run_exposure()
         params['print_summary'] = False
-        params['intermediary_csv'] = True   # workaround for https://github.com/OasisLMF/OasisLMF/issues/1895 remember to remove when fixed
         update_params(params, given_params)
         if reporting_currency != "" and currency_conversion_json:
             params['currency_conversion_json'] = currency_conversion_json


### PR DESCRIPTION
Removing workaround from issue in exposure run with items.csv missing after new pr fix is in lmf