### PR TITLE
combine remove analysis copying from inputs

### DIFF
--- a/src/model_execution_worker/server_tasks.py
+++ b/src/model_execution_worker/server_tasks.py
@@ -15,7 +15,6 @@ import logging
 import tarfile
 from celery.utils.log import get_task_logger
 import filelock
-import shutil
 
 app = Celery()
 


### PR DESCRIPTION
<!--start_release_notes-->
### combine remove analysis copying from inputs
- from https://github.com/OasisLMF/ODS_Tools/pull/240 combine tool no longer needs `analysis_settings.json` in root
<!--end_release_notes-->
