### PR TITLE
Remove Debian image from CI workflow

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -63,9 +63,6 @@ on:
       worker_image:
         description:
         value:  'coreoasis/github-actions:model_worker-${{ jobs.build.outputs.image_tag }}'
-      worker_deb_image:
-        description:
-        value:  'coreoasis/github-actions:model_worker_deb-${{ jobs.build.outputs.image_tag }}'
       worker_controller_image:
         description:
         value:  'coreoasis/github-actions:worker_controller-${{ jobs.build.outputs.image_tag }}'
@@ -87,7 +84,7 @@ jobs:
       image_tag: ${{ steps.set_tag.outputs.image_tag }}
     strategy:
       matrix:
-        image: [worker, worker_deb, server, worker_controller]
+        image: [worker, server, worker_controller]
         include:
 
         - image: server
@@ -104,14 +101,6 @@ jobs:
           report: 'worker-scan.sarif'
           dive: 'worker-layers.txt'
           exit-code: '1'
-          context: '.'
-
-        - image: worker_deb
-          tag: 'model_worker_deb'
-          file: 'Dockerfile.model_worker_debian'
-          report: 'worker-deb-scan.sarif'
-          dive: 'worker-deb-layers.txt'
-          exit-code: '0' # scan but don't fail
           context: '.'
 
         - image: worker_controller

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -242,9 +242,6 @@ jobs:
         docker tag  ${{ needs.build_images.outputs.worker_image }} coreoasis/model_worker:${{ env.release_tag }}
         docker tag  ${{ needs.build_images.outputs.worker_image }} coreoasis/model_worker:${{ env.latest_tag }}
         docker tag  ${{ needs.build_images.outputs.worker_image }} coreoasis/model_worker:latest
-        # Worker-dev
-        docker pull ${{ needs.build_images.outputs.worker_deb_image }}
-        docker tag  ${{ needs.build_images.outputs.worker_deb_image }} coreoasis/model_worker:${{ env.release_tag }}-debian
         # Worker-controller
         docker pull ${{ needs.build_images.outputs.worker_controller_image }}
         docker tag  ${{ needs.build_images.outputs.worker_controller_image }} coreoasis/worker_controller:${{ env.release_tag }}
@@ -406,7 +403,6 @@ jobs:
         docker push coreoasis/api_server:${{ env.release_tag }}
         docker push coreoasis/model_worker:${{ env.release_tag }}
         docker push coreoasis/worker_controller:${{ env.release_tag }}
-        docker push coreoasis/model_worker:${{ env.release_tag }}-debian
         docker push coreoasis/piwind_worker:${{ env.release_tag }}
 
     - name: Push images (Latest)

--- a/.github/workflows/test-images.yml
+++ b/.github/workflows/test-images.yml
@@ -68,8 +68,6 @@ jobs:
       build_server_tag: ${{ steps.built_images.outputs.server_tag }}
       build_worker_img: ${{ steps.built_images.outputs.worker_img }}
       build_worker_tag: ${{ steps.built_images.outputs.worker_tag }}
-      build_deb_worker_img: ${{ steps.built_images.outputs.deb_worker_img }}
-      build_deb_worker_tag: ${{ steps.built_images.outputs.deb_worker_tag }}
 
     steps:
       - name: Checkout Platform
@@ -153,11 +151,6 @@ jobs:
           echo "worker_img=$worker_img" >> $GITHUB_OUTPUT
           echo "worker_tag=$worker_tag" >> $GITHUB_OUTPUT
 
-          deb_worker_img=$(echo ${{ needs.build_images.outputs.worker_deb_image }} | awk '{split($0,a,":"); print a[1];}')
-          deb_worker_tag=$(echo ${{ needs.build_images.outputs.worker_deb_image }} | awk '{split($0,a,":"); print a[2];}')
-          echo "deb_worker_img=$deb_worker_img" >> $GITHUB_OUTPUT
-          echo "deb_worker_tag=$deb_worker_tag" >> $GITHUB_OUTPUT
-
   all_checks_v1:
     name: V1 all checks
     secrets: inherit
@@ -225,22 +218,6 @@ jobs:
       debug_mode: 1
       pytest_opts: "--docker-compose=./docker/plat2-v2.s3.docker-compose.yml ${{ needs.setup.outputs.pytest_opts }}"
       storage_suffix: '_s3-v2'
-
-  worker_debian:
-    name: Worker Debian
-    secrets: inherit
-    needs: [setup]
-    uses: OasisLMF/OasisPiWind/.github/workflows/integration.yml@main
-    with:
-      piwind_branch: ${{ needs.setup.outputs.piwind_branch }}
-      server_image: ${{ needs.setup.outputs.build_server_img }}
-      server_tag: ${{ needs.setup.outputs.build_server_tag }}
-      worker_image: ${{ needs.setup.outputs.build_deb_worker_img }}
-      worker_tag: ${{ needs.setup.outputs.build_deb_worker_tag }}
-      worker_api_ver: 'v2'
-      debug_mode: 1
-      pytest_opts: "--docker-compose=./docker/plat2-v2.docker-compose.yml ${{ needs.setup.outputs.pytest_opts }}"
-      storage_suffix: '-worker-debian'
 
   stable_worker_1-15:
     name: Test stable worker (${{ needs.setup.outputs.release_stable_1-15 }})


### PR DESCRIPTION
<!--start_release_notes-->
### Remove Debian image from CI workflow
At the moment there are two workers build one from ubuntu , the other debian. Better to keep things it to a single worker. 

<!--end_release_notes-->

> Note: might switch to debian anyway with https://github.com/OasisLMF/OasisPlatform/issues/1331