### PR TITLE
Pin trivy-action to commit not a ref that is mutable

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -187,7 +187,7 @@ jobs:
 
     - name: Vulnerability scanner
       if: env.SEVERITY != 'SKIP'
-      uses: aquasecurity/trivy-action@master
+      uses: aquasecurity/trivy-action@57a97c7
       with:
         image-ref: ${{ env.IMAGE_REPO }}:${{ matrix.tag }}-${{ env.IMAGE_TAG }}
         scan-type: 'image'
@@ -198,7 +198,7 @@ jobs:
 
     - name: Create Report
       if: ( success() || failure() ) && env.SEVERITY != 'SKIP' && matrix.exit-code == '1'
-      uses: aquasecurity/trivy-action@master
+      uses: aquasecurity/trivy-action@57a97c7
       with:
         image-ref: ${{ env.IMAGE_REPO }}:${{ matrix.tag }}-${{ env.IMAGE_TAG }}
         format: 'sarif'

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -187,7 +187,7 @@ jobs:
 
     - name: Vulnerability scanner
       if: env.SEVERITY != 'SKIP'
-      uses: aquasecurity/trivy-action@57a97c7
+      uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1
       with:
         image-ref: ${{ env.IMAGE_REPO }}:${{ matrix.tag }}-${{ env.IMAGE_TAG }}
         scan-type: 'image'
@@ -198,7 +198,7 @@ jobs:
 
     - name: Create Report
       if: ( success() || failure() ) && env.SEVERITY != 'SKIP' && matrix.exit-code == '1'
-      uses: aquasecurity/trivy-action@57a97c7
+      uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1
       with:
         image-ref: ${{ env.IMAGE_REPO }}:${{ matrix.tag }}-${{ env.IMAGE_TAG }}
         format: 'sarif'

--- a/.github/workflows/scan-external.yml
+++ b/.github/workflows/scan-external.yml
@@ -67,7 +67,7 @@ jobs:
 
     - name: Vulnerability scanner
       if: env.SEVERITY != ''
-      uses: aquasecurity/trivy-action@57a97c7
+      uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1
       with:
         image-ref: ${{ steps.img.outputs.result }}:${{ steps.ver.outputs.result }}
         scan-type: 'image'
@@ -78,7 +78,7 @@ jobs:
 
     - name: Create Report
       if: success() || failure()
-      uses: aquasecurity/trivy-action@57a97c7
+      uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1
       with:
         image-ref: ${{ steps.img.outputs.result }}:${{ steps.ver.outputs.result }}
         format: 'sarif'

--- a/.github/workflows/scan-external.yml
+++ b/.github/workflows/scan-external.yml
@@ -67,7 +67,7 @@ jobs:
 
     - name: Vulnerability scanner
       if: env.SEVERITY != ''
-      uses: aquasecurity/trivy-action@master
+      uses: aquasecurity/trivy-action@57a97c7
       with:
         image-ref: ${{ steps.img.outputs.result }}:${{ steps.ver.outputs.result }}
         scan-type: 'image'
@@ -78,7 +78,7 @@ jobs:
 
     - name: Create Report
       if: success() || failure()
-      uses: aquasecurity/trivy-action@master
+      uses: aquasecurity/trivy-action@57a97c7
       with:
         image-ref: ${{ steps.img.outputs.result }}:${{ steps.ver.outputs.result }}
         format: 'sarif'

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -64,7 +64,7 @@ jobs:
 
     - name: Trivy vulnerability scanner
       if: env.SEVERITY != ''
-      uses: aquasecurity/trivy-action@57a97c7
+      uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1
       with:
         scan-type: 'fs'
         exit-code: '1'
@@ -75,7 +75,7 @@ jobs:
 
     - name: Trivy Configuration scanner (no fail)
       if: env.SEVERITY != ''
-      uses: aquasecurity/trivy-action@57a97c7
+      uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1
       with:
         scan-type: 'fs'
         exit-code: '0'
@@ -86,7 +86,7 @@ jobs:
 
     - name: Create Report
       if: success() || failure()
-      uses: aquasecurity/trivy-action@57a97c7
+      uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1
       with:
         format: 'sarif'
         output:  ${{ env.REPORT }}

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -64,7 +64,7 @@ jobs:
 
     - name: Trivy vulnerability scanner
       if: env.SEVERITY != ''
-      uses: aquasecurity/trivy-action@master
+      uses: aquasecurity/trivy-action@57a97c7
       with:
         scan-type: 'fs'
         exit-code: '1'
@@ -75,7 +75,7 @@ jobs:
 
     - name: Trivy Configuration scanner (no fail)
       if: env.SEVERITY != ''
-      uses: aquasecurity/trivy-action@master
+      uses: aquasecurity/trivy-action@57a97c7
       with:
         scan-type: 'fs'
         exit-code: '0'
@@ -86,7 +86,7 @@ jobs:
 
     - name: Create Report
       if: success() || failure()
-      uses: aquasecurity/trivy-action@master
+      uses: aquasecurity/trivy-action@57a97c7
       with:
         format: 'sarif'
         output:  ${{ env.REPORT }}


### PR DESCRIPTION
<!--start_release_notes-->
### Pin trivy-action to commit not a ref that is mutable
trivy-action was hacked, replacing a tag with malicious code. Workflow should be pinned to a non mutable github ref  

<!--end_release_notes-->


> See: 
> * https://www.aquasec.com/blog/trivy-supply-chain-attack-what-you-need-to-know/
> * https://www.crowdstrike.com/en-us/blog/from-scanner-to-stealer-inside-the-trivy-action-supply-chain-compromise/


Should also probably do the same with all external actions workflow calls