### PR TITLE
CI fix, run unittest with oasislmf main

### DIFF
--- a/.github/workflows/test-python_api.yml
+++ b/.github/workflows/test-python_api.yml
@@ -81,7 +81,9 @@ jobs:
         pip install ${{ needs.ods_tools.outputs.whl_filename }}
 
     - name: Install oasislmf from branch
-      run: pip install -v oasislmf[extra]@git+https://git@github.com/OasisLMF/OasisLMF.git@${{ env.oasislmf_branch }}
+      run: |
+        pip uninstall oasislmf -y
+        pip install -v oasislmf@git+https://git@github.com/OasisLMF/OasisLMF.git@${{ env.oasislmf_branch }}
 
     - name: Run Pytest
       run: pytest  --cov-config=tox.ini --junitxml=${{ github.workspace  }}/pytest_report.xml --cov=src --cov-report=xml --cov-report=term


### PR DESCRIPTION
<!--start_release_notes-->
### CI fix, run unittest with oasislmf main
Tests are failing after https://github.com/OasisLMF/OasisPlatform/pull/1352 because the required fix is in `main` branch and waiting release.  Run tests with main branch in CI
<!--end_release_notes-->
