### PR TITLE
fix: chainmap import

### DIFF
--- a/src/conf/iniconf.py
+++ b/src/conf/iniconf.py
@@ -6,7 +6,7 @@ import os
 from datetime import timedelta
 from logging.handlers import RotatingFileHandler
 
-from chainmap import ChainMap
+from collections import ChainMap
 
 from configparser import ConfigParser
 


### PR DESCRIPTION
- Fixes #1378 

<!--start_release_notes-->
### Fix: Replace `chainmap` backport import with stdlib `collections.ChainMap`

`src/conf/iniconf.py` imported `ChainMap` from the standalone `chainmap` package (a Python 2 backport). This package was removed as a transitive dependency in 2.5.2 when `oasislmf` dropped it from its requirements, causing `model_worker:2.5.2` to crash on startup with `ModuleNotFoundError: No module named 'chainmap'`. Replaced with `from collections import ChainMap`, which is available in Python 3.3+.

Fixes #1378
<!--end_release_notes-->

