### PR TITLE
Ktools options -> kernel options

### DIFF
--- a/.github/workflows/minikube-cicd.yml
+++ b/.github/workflows/minikube-cicd.yml
@@ -189,7 +189,7 @@ jobs:
           cat <<EOF > test_settings.json
           {
             "computation_settings": {
-              "ktools_num_processes": 1
+              "kernel_num_processes": 1
             },
             "version": "3",
             "analysis_tag": "base_example",

--- a/.github/workflows/minikube-cicd.yml
+++ b/.github/workflows/minikube-cicd.yml
@@ -135,7 +135,7 @@ jobs:
           echo "Delay to wait for authentication server to start"
           sleep 60
           delay=1
-          for i in {1..8}; do
+          for i in {1..10}; do
             delay=$((delay * 2))
             if [ "$USE_OIDC" = "true" ]; then
               echo "Using OIDC authentication"

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,9 +6,8 @@ description-file = README.rst
 
 [tool:pytest]
 DJANGO_SETTINGS_MODULE = src.server.oasisapi.settings
-exclude = .tox,.git,*/migrations/*,*/static/CACHE/*,docs,.ropeproject
 python_classes =
-norecursedirs = out build venv kubernetes
+norecursedirs = out build venv kubernetes .hypothesis .tox .git
 # Oidc/keycloak test cases need to be run separately due to different django configuration
 addopts = --ignore=src/server/oasisapi/auth/tests/test_oidc.py
 

--- a/src/model_execution_worker/tests/test_server_tasks.py
+++ b/src/model_execution_worker/tests/test_server_tasks.py
@@ -392,13 +392,13 @@ class ExposureRun(TestCase):
 )
 def test_exposure_run_params(currency_conversion_json, reporting_currency):
     allowed_params = {
-        'ktools_alloc_rule_il': 2,
+        'kernel_alloc_rule_il': 2,
         'model_perils_covered': 3,
         'loss_factor': 5,
         'fmpy_sort_output': 7,
         'fmpy_low_memory': 11,
         'extra_summary_cols': 13,
-        'ktools_alloc_rule_ri': 17,
+        'kernel_alloc_rule_ri': 17,
         'check_oed': 19,
         'do_disaggregation': 23,
         'verbose': 29
@@ -412,14 +412,14 @@ def test_exposure_run_params(currency_conversion_json, reporting_currency):
     with (patch("src.model_execution_worker.server_tasks.OasisManager") as fake_manager,
             patch('src.model_execution_worker.server_tasks.get_filestore') as _):
         fake_manager.return_value._params_run_exposure.return_value = {
-            'ktools_alloc_rule_il': "H",
+            'kernel_alloc_rule_il': "H",
             'model_perils_covered': "e",
             'loss_factor': "l",
             'supported_oed_coverage_types': "l",
             'fmpy_sort_output': "o",
             'fmpy_low_memory': " ",
             'extra_summary_cols': "W",
-            'ktools_alloc_rule_ri': "o",
+            'kernel_alloc_rule_ri': "o",
             'check_oed': "r",
             'do_disaggregation': "l",
             'verbose': "d",

--- a/src/model_execution_worker/utils.py
+++ b/src/model_execution_worker/utils.py
@@ -350,14 +350,14 @@ def update_params(params, given_params):
     Changes exposure run's given parameters.
     """
     ALLOWED_PARAMS = [
-        'ktools_alloc_rule_il',
+        'kernel_alloc_rule_il',
         'model_perils_covered',
         'loss_factor',
         'supported_oed_coverage_types',
         'fmpy_sort_output',
         'fmpy_low_memory',
         'extra_summary_cols',
-        'ktools_alloc_rule_ri',
+        'kernel_alloc_rule_ri',
         'check_oed',
         'do_disaggregation',
         'verbose'

--- a/src/server/oasisapi/portfolios/v2_api/serializers.py
+++ b/src/server/oasisapi/portfolios/v2_api/serializers.py
@@ -498,7 +498,7 @@ class PortfolioValidationSerializer(serializers.ModelSerializer):
 
 class ExposureRunParamsSerializer(serializers.Serializer):
     """ The expected structure for the `params` field """
-    ktools_alloc_rule_il = serializers.IntegerField(default=2, help_text="Set the fmcalc allocation rule used in direct insured loss")
+    kernel_alloc_rule_il = serializers.IntegerField(default=2, help_text="Set the fmcalc allocation rule used in direct insured loss")
     model_perils_covered = serializers.ListField(child=serializers.CharField(), default=['AA1'], help_text="List of perils covered by the model")
     loss_factor = serializers.ListField(child=serializers.FloatField(), default=[1.0], help_text="Loss factor")
     supported_oed_coverage_types = serializers.ListField(
@@ -513,7 +513,7 @@ class ExposureRunParamsSerializer(serializers.Serializer):
         default=False, help_text="Use memory map instead of RAM to store loss array (may decrease performance but reduce RAM usage drastically)"
     )
     extra_summary_cols = serializers.ListField(child=serializers.CharField(), default=[], help_text="Extra columns to include in the summary")
-    ktools_alloc_rule_ri = serializers.IntegerField(default=3, help_text="Set the fmcalc allocation rule used in reinsurance")
+    kernel_alloc_rule_ri = serializers.IntegerField(default=3, help_text="Set the fmcalc allocation rule used in reinsurance")
     check_oed = serializers.BooleanField(default=True, help_text="If True, check input OED files")
     do_disaggregation = serializers.BooleanField(default=True, help_text="If True, run the Oasis disaggregation")
     verbose = serializers.BooleanField(default=False, help_text="Use verbose logging")


### PR DESCRIPTION
Options in exposure run and in the minikube cicd tests still have not caught up and are using ktools options instead of kernel ones- changes to simply swap them over