### PR TITLE
Fix for 403 when calling analysis-task-statuses with no auth

### DIFF
--- a/src/server/oasisapi/analyses/v2_api/viewsets.py
+++ b/src/server/oasisapi/analyses/v2_api/viewsets.py
@@ -730,8 +730,13 @@ class AnalysisSettingsView(VerifyGroupAccessModelViewSet):
 class AnalysisTaskStatusViewSet(viewsets.ModelViewSet):
     queryset = AnalysisTaskStatus.objects.all()
     serializer_class = AnalysisTaskStatusSerializer
-    permission_classes = [IsAdminUser]
     filterset_class = AnalysisTaskFilter
+
+    def get_permissions(self):
+        from django.conf import settings
+        if getattr(settings, 'API_AUTH_TYPE', 'simple') == 'disabled':
+            return [permission() for permission in api_settings.DEFAULT_PERMISSION_CLASSES]
+        return [IsAdminUser()]
 
     @extend_schema(responses={200: FILE_RESPONSE})
     @action(methods=['get', 'delete'], detail=True)


### PR DESCRIPTION
<!--start_release_notes-->
### Fix for 403 when calling analysis-task-statuses with no auth
Issue missed from https://github.com/OasisLMF/OasisPlatform/pull/1387
<!--end_release_notes-->
