### PR TITLE
fix dummy analysis settings

### DIFF
--- a/src/model_execution_worker/tests/test_tasks.py
+++ b/src/model_execution_worker/tests/test_tasks.py
@@ -102,8 +102,8 @@ class StartAnalysis(TestCase):
                     },
                     "model_name_id": "PiWind",
                     "model_supplier_id": "OasisLMF",
-                    "gul_output": False,
-                    "gul_summaries": []
+                    "gul_output": True,
+                    "gul_summaries": [{'id': 1}]
                 }
 
                 with open(settings_file_path, 'w') as f:


### PR DESCRIPTION
<!--start_release_notes-->
### Update test for https://github.com/OasisLMF/ODS_Tools/pull/271 
- fixes test analysis settings for `src/model_execution_worker/tests/test_tasks.py::StartAnalysis::test_custom_model_runner_does_not_exist___generate_losses_is_called_output_files_are_tared_up`
<!--end_release_notes-->
