### PR TITLE
Fix analysis settings test fixture to pass updated ODS_Tools validation

### DIFF
--- a/src/model_execution_worker/tests/test_tasks.py
+++ b/src/model_execution_worker/tests/test_tasks.py
@@ -102,8 +102,8 @@ class StartAnalysis(TestCase):
                     },
                     "model_name_id": "PiWind",
                     "model_supplier_id": "OasisLMF",
-                    "gul_output": False,
-                    "gul_summaries": []
+                    "gul_output": True,
+                    "gul_summaries": [{"id": 1, "aalcalc": True}]
                 }
 
                 with open(settings_file_path, 'w') as f:


### PR DESCRIPTION
## Summary

- Fixes #1406
- ODS_Tools#271 tightened analysis settings validation: `gul_summaries` must be non-empty and at least one output perspective must be enabled
- The test fixture in `test_tasks.py` used `gul_output: False, gul_summaries: []`, which now fails validation before the mock under test is ever reached
- Updated fixture to `gul_output: True, gul_summaries: [{"id": 1, "aalcalc": True}]`

## Test plan

- [ ] Confirm `test_custom_model_runner_does_not_exist___generate_losses_is_called_output_files_are_tared_up` passes locally
- [ ] Confirm Platform Integration CI is green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)