### PR TITLE
Handle missing S3 log files in handle_task_failure

### DIFF
--- a/src/server/oasisapi/analyses/v2_api/tasks.py
+++ b/src/server/oasisapi/analyses/v2_api/tasks.py
@@ -569,8 +569,14 @@ def handle_task_failure(
                 if hasattr(subtask.error_log, 'read'):
                     tmp_file.write(f'\n=== {subtask.slug} ===\n'.encode('utf-8'))
                     if hasattr(subtask.output_log, 'read'):
-                        tmp_file.write(subtask.output_log.read())
-                    tmp_file.write(subtask.error_log.read())
+                        try:
+                            tmp_file.write(subtask.output_log.read())
+                        except FileNotFoundError:
+                            pass
+                    try:
+                        tmp_file.write(subtask.error_log.read())
+                    except FileNotFoundError:
+                        pass
 
             tmp_file.seek(0)
             setattr(analysis, traceback_property, RelatedFile.objects.create(


### PR DESCRIPTION
## Summary

- Fixes #1408
- When a worker is killed with SIGKILL (e.g. OOM) during input generation, it never writes its log files to S3
- The existing `hasattr(..., 'read')` guard was insufficient — `RelatedFile` always has a `read` method, but the `FileNotFoundError` is only raised lazily when the file is actually opened on first access inside `read()`
- Wraps both `output_log.read()` and `error_log.read()` in `try/except FileNotFoundError` so `handle_task_failure` can still report the failure status correctly even when log files are absent

## Test plan

- [ ] Trigger an analysis where the worker is killed with SIGKILL mid-run (e.g. manually send `kill -9` to the worker process)
- [ ] Confirm the analysis transitions to `INPUTS_GENERATION_ERROR` without a secondary exception in the logs
- [ ] Confirm the traceback file is still created and attached to the analysis

🤖 Generated with [Claude Code](https://claude.com/claude-code)