### PR TITLE
fix/minikube_script_lmfbranchfix

### DIFF
--- a/scripts/minikube-deploy.sh
+++ b/scripts/minikube-deploy.sh
@@ -36,7 +36,7 @@ fi
 
 ODM_BRANCH=''
 ODS_BRANCH=''
-LMF_BRANCH='fix/input_gen_status'
+LMF_BRANCH=''
 
 BUILD_ARGS_WORKER=''
 BUILD_ARGS_SERVER=''


### PR DESCRIPTION
<!--start_release_notes-->
### fix/minikube_script_lmfbranch 
Revert `LMF_BRANCH` in `scripts/minikube-deploy.sh`. Present in 2.5.4, 2.5.5 and currently main

closes https://github.com/OasisLMF/OasisPlatform/issues/1415
<!--end_release_notes-->
