### PR TITLE
Helm: enforce read-only root filesystem and explicit SA token mounting

### DIFF
--- a/kubernetes/charts/oasis-platform/Chart.yaml
+++ b/kubernetes/charts/oasis-platform/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: oasis
-version: 2.4.6
+version: 2.4.7
 type: application
 description: Deploys the Oasis Platform
 appVersion: "1.26.2"

--- a/kubernetes/charts/oasis-platform/templates/_helpers.tpl
+++ b/kubernetes/charts/oasis-platform/templates/_helpers.tpl
@@ -217,6 +217,8 @@ Init container to wait for a service to become available (tcp check only) based 
 {{- $root := (index . 0) -}}
 - name: init-tcp-wait-by-secret
   image: {{ $root.Values.modelImages.init.image }}:{{ $root.Values.modelImages.init.version }}
+  securityContext:
+    readOnlyRootFilesystem: true
   env:
     {{- range $index, $name := slice . 1 }}
     - name: SERVICE_NAME_{{ $index }}
@@ -272,4 +274,36 @@ Set affinity if enabled
 affinity:
   {{- toYaml .Values.affinity | nindent 2 }}
 {{- end -}}
+{{- end -}}
+
+{{/*
+Disable automounting of the pod's ServiceAccount API credentials.
+Pods that genuinely need Kubernetes API access mount the token explicitly instead (see h.projectedServiceAccountToken).
+*/}}
+{{- define "h.disableTokenAutomount" -}}
+automountServiceAccountToken: false
+{{- end -}}
+
+{{/*
+Explicitly project the ServiceAccount token (plus CA cert and namespace) for pods that need Kubernetes API access,
+in place of relying on automountServiceAccountToken.
+*/}}
+{{- define "h.projectedServiceAccountToken" -}}
+- name: kube-api-access
+  projected:
+    defaultMode: 420
+    sources:
+      - serviceAccountToken:
+          expirationSeconds: 3607
+          path: token
+      - configMap:
+          name: kube-root-ca.crt
+          items:
+            - key: ca.crt
+              path: ca.crt
+      - downwardAPI:
+          items:
+            - path: namespace
+              fieldRef:
+                fieldPath: metadata.namespace
 {{- end -}}

--- a/kubernetes/charts/oasis-platform/templates/authentik.yaml
+++ b/kubernetes/charts/oasis-platform/templates/authentik.yaml
@@ -118,6 +118,12 @@ spec:
           volumeMounts:
             - name: tmp
               mountPath: /tmp
+            - name: authentik-media
+              mountPath: /media
+            - name: authentik-certs
+              mountPath: /certs
+            - name: authentik-templates
+              mountPath: /templates
           startupProbe:
             httpGet:
               path: "/authentik/-/health/live/"
@@ -144,6 +150,12 @@ spec:
             failureThreshold: 60
       volumes:
         - name: tmp
+          emptyDir: {}
+        - name: authentik-media
+          emptyDir: {}
+        - name: authentik-certs
+          emptyDir: {}
+        - name: authentik-templates
           emptyDir: {}
 ---
 apiVersion: apps/v1
@@ -188,11 +200,11 @@ spec:
             - name: tmp
               mountPath: /tmp
             - name: authentik-media
-              mountPath: /authentik/media
+              mountPath: /media
             - name: authentik-certs
-              mountPath: /authentik/certs
+              mountPath: /certs
             - name: authentik-templates
-              mountPath: /authentik/templates
+              mountPath: /templates
           startupProbe:
             exec:
               command:

--- a/kubernetes/charts/oasis-platform/templates/authentik.yaml
+++ b/kubernetes/charts/oasis-platform/templates/authentik.yaml
@@ -93,6 +93,7 @@ spec:
         {{- include "h.labels" . | nindent 8 }}
         app: {{ .Values.authentik.name }}
     spec:
+      {{- include "h.disableTokenAutomount" . | nindent 6 }}
       initContainers:
         {{- include "h.initTcpAvailabilityCheckBySecret" (list . .Values.databases.authentik_db.name) | nindent 8}}
       containers:
@@ -102,8 +103,10 @@ spec:
             - server
           ports:
             - containerPort: {{ .Values.authentik.port }}
+          securityContext:
+            readOnlyRootFilesystem: true
           env:
-            - name: AUTHENTIK_LOG_LEVEL 
+            - name: AUTHENTIK_LOG_LEVEL
               value: DEBUG
             - name: AUTHENTIK_WEB__PATH
               value: /authentik/
@@ -112,6 +115,9 @@ spec:
           envFrom:
             - secretRef:
                 name: {{ .Values.authentik.name }}-secret
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
           startupProbe:
             httpGet:
               path: "/authentik/-/health/live/"
@@ -136,6 +142,9 @@ spec:
             periodSeconds: 15
             timeoutSeconds: 10
             failureThreshold: 60
+      volumes:
+        - name: tmp
+          emptyDir: {}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -154,6 +163,7 @@ spec:
         {{- include "h.labels" . | nindent 8 }}
         app: {{ .Values.authentik.name }}-worker
     spec:
+      {{- include "h.disableTokenAutomount" . | nindent 6 }}
       initContainers:
         {{- include "h.initTcpAvailabilityCheckBySecret" (list . .Values.databases.authentik_db.name) | nindent 8}}
       containers:
@@ -161,8 +171,10 @@ spec:
           image: {{ .Values.images.authentik.image }}:{{ .Values.images.authentik.version }}
           args:
             - worker
+          securityContext:
+            readOnlyRootFilesystem: true
           env:
-            - name: AUTHENTIK_LOG_LEVEL 
+            - name: AUTHENTIK_LOG_LEVEL
               value: DEBUG
             - name: AUTHENTIK_DISABLE_UPDATE_CHECK
               value: "true"
@@ -173,6 +185,14 @@ spec:
             - name: blueprint-config
               mountPath: /blueprints/oasis-blueprint.yaml
               subPath: oasis-blueprint.yaml
+            - name: tmp
+              mountPath: /tmp
+            - name: authentik-media
+              mountPath: /authentik/media
+            - name: authentik-certs
+              mountPath: /authentik/certs
+            - name: authentik-templates
+              mountPath: /authentik/templates
           startupProbe:
             exec:
               command:
@@ -204,4 +224,12 @@ spec:
         - name: blueprint-config
           configMap:
             name: {{ .Values.authentik.name }}-blueprint
+        - name: tmp
+          emptyDir: {}
+        - name: authentik-media
+          emptyDir: {}
+        - name: authentik-certs
+          emptyDir: {}
+        - name: authentik-templates
+          emptyDir: {}
 {{- end }}

--- a/kubernetes/charts/oasis-platform/templates/databases.yaml
+++ b/kubernetes/charts/oasis-platform/templates/databases.yaml
@@ -81,6 +81,7 @@ spec:
       annotations:
         checksum/{{ $v.name }}: {{ toJson $v | sha256sum }}
     spec:
+      {{- include "h.disableTokenAutomount" $root | nindent 6 }}
       volumes:
 {{- if or $v.volumeSize (eq $v.type "rabbitmq") }}
         {{- if or $v.volumeSize }}

--- a/kubernetes/charts/oasis-platform/templates/internal-worker.yaml
+++ b/kubernetes/charts/oasis-platform/templates/internal-worker.yaml
@@ -18,13 +18,19 @@ spec:
         {{- include "h.labels" . | nindent 8}}
         app: {{ .Values.internalWorker.name }}
     spec:
+      {{- include "h.disableTokenAutomount" . | nindent 6 }}
       containers:
         - name: {{ .Values.internalWorker.name }}
           image: {{ .Values.images.oasis.worker_internal.image }}:{{ .Values.images.oasis.worker_internal.version }}
           imagePullPolicy: {{ .Values.images.oasis.worker_internal.imagePullPolicy }}
+          securityContext:
+            readOnlyRootFilesystem: true
           env:
             - name: OASIS_RUN_MODE
               value: server-internal
+            # Image bakes NUMBA_CACHE_DIR into the (now read-only) rootfs; redirect it to the writable /tmp mount.
+            - name: NUMBA_CACHE_DIR
+              value: /tmp/numba_cache
             {{- toYaml .Values.internalWorker.env | nindent 12 }}
             {{- include "h.celeryDbVars" . | indent 12}}
             {{- include "h.brokerVars" . | indent 12 }}
@@ -44,7 +50,23 @@ spec:
           volumeMounts:
             - name: shared-fs-persistent-storage
               mountPath: /shared-fs
+            - name: tmp
+              mountPath: /tmp
+            - name: var-log-oasis
+              mountPath: /var/log/oasis
+            - name: var-oasis
+              mountPath: /var/oasis
+            - name: worker-model
+              mountPath: /home/worker/model
       volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: var-log-oasis
+          emptyDir: {}
+        - name: var-oasis
+          emptyDir: {}
+        - name: worker-model
+          emptyDir: {}
 {{- if ((.Values.volumes.host).sharedFs) }}
         - name: shared-fs-persistent-storage
           persistentVolumeClaim:

--- a/kubernetes/charts/oasis-platform/templates/keycloak.yaml
+++ b/kubernetes/charts/oasis-platform/templates/keycloak.yaml
@@ -83,12 +83,15 @@ spec:
         checksum/realm: {{ .Files.Get "resources/oasis-realm.json" | sha256sum }}
     spec:
       {{- include "h.affinity" . | nindent 6 }}
+      {{- include "h.disableTokenAutomount" . | nindent 6 }}
       initContainers:
         {{- include "h.initTcpAvailabilityCheckBySecret" (list . .Values.databases.keycloak_db.name) | nindent 8}}
       containers:
         - name: {{ .Values.keycloak.name }}
           image: {{ .Values.images.keycloak.image }}:{{ .Values.images.keycloak.version }}
           args: ["start", "--import-realm"]
+          securityContext:
+            readOnlyRootFilesystem: true
           ports:
             - containerPort: {{ .Values.keycloak.port }}
           env:
@@ -169,6 +172,10 @@ spec:
             timeoutSeconds: 10
             failureThreshold: 2
           volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+            - name: keycloak-data
+              mountPath: /opt/keycloak/data
             - name: realm-config
               mountPath: /opt/keycloak/data/import/oasis-realm.json
               subPath: oasis
@@ -182,6 +189,10 @@ spec:
             {{- end }}
 
       volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: keycloak-data
+          emptyDir: {}
         - name: realm-config
           configMap:
             name: {{ $realmSecretName }}

--- a/kubernetes/charts/oasis-platform/templates/oasis.yaml
+++ b/kubernetes/charts/oasis-platform/templates/oasis.yaml
@@ -55,13 +55,18 @@ spec:
         checksum/{{ .Values.databases.celery_db.name }}: versions{{ toJson .Values.databases.celery_db | sha256sum }}
     spec:
       {{- include "h.affinity" . | nindent 6 }}
+      {{- include "h.disableTokenAutomount" . | nindent 6 }}
       initContainers:
         {{- include "h.initTcpAvailabilityCheckBySecret" (list . .Values.databases.oasis_db.name .Values.databases.celery_db.name .Values.oasisServer.name .Values.databases.broker.name) | nindent 8}}
       containers:
         - image: {{ .Values.images.oasis.platform.image }}:{{ .Values.images.oasis.platform.version }}
           imagePullPolicy: {{ .Values.images.oasis.platform.imagePullPolicy }}
           name: oasis-v1-worker-monitor
+          securityContext:
+            readOnlyRootFilesystem: true
           env:
+            - name: NUMBA_CACHE_DIR
+              value: /tmp/numba_cache
 {{- include "h.serverDbVars" . | indent 12}}
 {{- include "h.celeryDbVars" . | indent 12}}
 {{- include "h.brokerVars" . | indent 12 }}
@@ -72,6 +77,8 @@ spec:
           volumeMounts:
             - name: shared-fs-persistent-storage
               mountPath: /shared-fs
+            - name: tmp
+              mountPath: /tmp
 {{- if (.Values.azure).secretProvider }}
             - name: azure-secret-provider
               mountPath: "/mnt/azure-secrets-store"
@@ -90,6 +97,8 @@ spec:
             periodSeconds: 60
             timeoutSeconds: 10
       volumes:
+        - name: tmp
+          emptyDir: {}
 {{- if ((.Values.volumes.host).sharedFs) }}
         - name: shared-fs-persistent-storage
           persistentVolumeClaim:
@@ -130,13 +139,18 @@ spec:
         checksum/{{ .Values.databases.celery_db.name }}: versions{{ toJson .Values.databases.celery_db | sha256sum }}
     spec:
       {{- include "h.affinity" . | nindent 6 }}
+      {{- include "h.disableTokenAutomount" . | nindent 6 }}
       initContainers:
         {{- include "h.initTcpAvailabilityCheckBySecret" (list . .Values.databases.oasis_db.name .Values.databases.celery_db.name .Values.oasisServer.name .Values.databases.broker.name) | nindent 8}}
       containers:
         - image: {{ .Values.images.oasis.platform.image }}:{{ .Values.images.oasis.platform.version }}
           imagePullPolicy: {{ .Values.images.oasis.platform.imagePullPolicy }}
           name: oasis-v2-worker-monitor
+          securityContext:
+            readOnlyRootFilesystem: true
           env:
+            - name: NUMBA_CACHE_DIR
+              value: /tmp/numba_cache
 {{- include "h.serverDbVars" . | indent 12}}
 {{- include "h.celeryDbVars" . | indent 12}}
 {{- include "h.brokerVars" . | indent 12 }}
@@ -147,6 +161,8 @@ spec:
           volumeMounts:
             - name: shared-fs-persistent-storage
               mountPath: /shared-fs
+            - name: tmp
+              mountPath: /tmp
 {{- if (.Values.azure).secretProvider }}
             - name: azure-secret-provider
               mountPath: "/mnt/azure-secrets-store"
@@ -165,6 +181,8 @@ spec:
             periodSeconds: 60
             timeoutSeconds: 10
       volumes:
+        - name: tmp
+          emptyDir: {}
 {{- if ((.Values.volumes.host).sharedFs) }}
         - name: shared-fs-persistent-storage
           persistentVolumeClaim:
@@ -203,6 +221,7 @@ spec:
         checksum/{{ .Values.oasisServer.name }}: {{ toJson .Values.oasisServer | sha256sum }}
     spec:
       {{- include "h.affinity" . | nindent 6 }}
+      {{- include "h.disableTokenAutomount" . | nindent 6 }}
       initContainers:
         {{- include "h.initTcpAvailabilityCheckBySecret" (list . .Values.oasisServer.name) | nindent 8}}
       containers:
@@ -280,19 +299,28 @@ spec:
         checksum/{{ .Values.databases.channel_layer.name }}: versions{{ toJson .Values.databases.channel_layer | sha256sum }}
     spec:
       {{- include "h.affinity" . | nindent 6 }}
+      {{- include "h.disableTokenAutomount" . | nindent 6 }}
       initContainers:
         {{- include "h.initTcpAvailabilityCheckBySecret" (list . .Values.databases.oasis_db.name .Values.databases.celery_db.name .Values.databases.channel_layer.name) | nindent 8}}
       containers:
         - image: {{ .Values.images.oasis.platform.image }}:{{ .Values.images.oasis.platform.version }}
           imagePullPolicy: {{ .Values.images.oasis.platform.imagePullPolicy }}
           name: celery-beat
-          command: ["celery", "-A", "src.server.oasisapi.celery_app_v2", "beat", "--loglevel=DEBUG"]
+          command: ["celery", "-A", "src.server.oasisapi.celery_app_v2", "beat", "--loglevel=DEBUG", "--schedule=/var/run/celery-beat/celerybeat-schedule", "--pidfile=/var/run/celery-beat/celerybeat.pid"]
+          securityContext:
+            readOnlyRootFilesystem: true
           env:
+            - name: NUMBA_CACHE_DIR
+              value: /tmp/numba_cache
             {{- include "h.serverDbVars" . | indent 12}}
             {{- include "h.celeryDbVars" . | indent 12}}
             {{- include "h.brokerVars" . | indent 12 }}
             {{- include "h.channelLayerVars" . | indent 12 }}
           volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+            - name: celery-beat-state
+              mountPath: /var/run/celery-beat
 {{- if (.Values.azure).secretProvider }}
             - name: azure-secret-provider
               mountPath: "/mnt/azure-secrets-store"
@@ -310,8 +338,12 @@ spec:
             initialDelaySeconds: 30
             periodSeconds: 60
             timeoutSeconds: 10
-{{- if (.Values.azure).secretProvider }}
       volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: celery-beat-state
+          emptyDir: {}
+{{- if (.Values.azure).secretProvider }}
         - name: azure-secret-provider
           csi:
             driver: secrets-store.csi.k8s.io
@@ -344,6 +376,7 @@ spec:
         checksum/{{ .Values.databases.channel_layer.name }}: versions{{ toJson .Values.databases.channel_layer | sha256sum }}
     spec:
       {{- include "h.affinity" . | nindent 6 }}
+      {{- include "h.disableTokenAutomount" . | nindent 6 }}
       initContainers:
         {{- include "h.initTcpAvailabilityCheckBySecret" (list . .Values.databases.oasis_db.name .Values.databases.celery_db.name .Values.databases.channel_layer.name .Values.databases.broker.name) | nindent 8}}
       containers:
@@ -351,7 +384,11 @@ spec:
           imagePullPolicy: {{ .Values.images.oasis.platform.imagePullPolicy }}
           name: main
           command: ["celery", "-A", "src.server.oasisapi.celery_app_v2", "worker", "--loglevel=INFO", "-Q", "task-controller"]
+          securityContext:
+            readOnlyRootFilesystem: true
           env:
+            - name: NUMBA_CACHE_DIR
+              value: /tmp/numba_cache
             {{- include "h.serverDbVars" . | indent 12}}
             {{- include "h.celeryDbVars" . | indent 12}}
             {{- include "h.brokerVars" . | indent 12 }}
@@ -359,6 +396,8 @@ spec:
             - name: OASIS_DEBUG
               value: "1"
           volumeMounts:
+            - name: tmp
+              mountPath: /tmp
 {{- if (.Values.azure).secretProvider }}
             - name: azure-secret-provider
               mountPath: "/mnt/azure-secrets-store"
@@ -376,8 +415,10 @@ spec:
             initialDelaySeconds: 30
             periodSeconds: 60
             timeoutSeconds: 10
-{{- if (.Values.azure).secretProvider }}
       volumes:
+        - name: tmp
+          emptyDir: {}
+{{- if (.Values.azure).secretProvider }}
         - name: azure-secret-provider
           csi:
             driver: secrets-store.csi.k8s.io

--- a/kubernetes/charts/oasis-platform/templates/oasis_server.yaml
+++ b/kubernetes/charts/oasis-platform/templates/oasis_server.yaml
@@ -59,6 +59,7 @@ spec:
         checksum/{{ .Values.databases.celery_db.name }}: {{ toJson .Values.databases.celery_db | sha256sum }}
     spec:
       {{- include "h.affinity" . | nindent 6 }}
+      {{- include "h.disableTokenAutomount" . | nindent 6 }}
       initContainers:
         {{- $checks := list . .Values.databases.oasis_db.name .Values.databases.celery_db.name .Values.databases.broker.name }}
 
@@ -75,7 +76,11 @@ spec:
         - image: {{ .Values.images.oasis.platform.image }}:{{ .Values.images.oasis.platform.version }}
           name: {{ .Values.oasisWebsocket.name }}
           imagePullPolicy: {{ .Values.images.oasis.platform.imagePullPolicy }}
+          securityContext:
+            readOnlyRootFilesystem: true
           env:
+            - name: NUMBA_CACHE_DIR
+              value: /tmp/numba_cache
             {{- include "h.serverDbVars" . | indent 12}}
             {{- include "h.celeryDbVars" . | indent 12}}
             {{- include "h.brokerVars" . | indent 12 }}
@@ -126,6 +131,8 @@ spec:
           volumeMounts:
             - name: shared-fs-persistent-storage
               mountPath: /shared-fs
+            - name: tmp
+              mountPath: /tmp
 {{- if (.Values.azure).secretProvider }}
             - name: azure-secret-provider
               mountPath: "/mnt/azure-secrets-store"
@@ -145,6 +152,8 @@ spec:
             timeoutSeconds: 10
             failureThreshold: 2
       volumes:
+        - name: tmp
+          emptyDir: {}
 {{- if ((.Values.volumes.host).sharedFs) }}
         - name: shared-fs-persistent-storage
           persistentVolumeClaim:
@@ -198,6 +207,7 @@ spec:
         checksum/{{ .Values.databases.celery_db.name }}: {{ toJson .Values.databases.celery_db | sha256sum }}
     spec:
       {{- include "h.affinity" . | nindent 6 }}
+      {{- include "h.disableTokenAutomount" . | nindent 6 }}
       initContainers:
         {{- $checks := list . .Values.databases.oasis_db.name .Values.databases.celery_db.name .Values.databases.broker.name }}
 
@@ -213,6 +223,8 @@ spec:
         - name: set-mount-permissions
           image: busybox
           command: ["sh", "-c", "find /shared-fs -user root -exec chown 1000:1000 {} \\;"]
+          securityContext:
+            readOnlyRootFilesystem: true
           volumeMounts:
           - mountPath: /shared-fs
             name: shared-fs-persistent-storage
@@ -220,7 +232,11 @@ spec:
         - image: {{ .Values.images.oasis.platform.image }}:{{ .Values.images.oasis.platform.version }}
           name: {{ .Values.oasisServer.name }}
           imagePullPolicy: {{ .Values.images.oasis.platform.imagePullPolicy }}
+          securityContext:
+            readOnlyRootFilesystem: true
           env:
+            - name: NUMBA_CACHE_DIR
+              value: /tmp/numba_cache
             {{- include "h.serverDbVars" . | indent 12}}
             {{- include "h.celeryDbVars" . | indent 12}}
             {{- include "h.brokerVars" . | indent 12 }}
@@ -269,6 +285,8 @@ spec:
           volumeMounts:
             - name: shared-fs-persistent-storage
               mountPath: /shared-fs
+            - name: tmp
+              mountPath: /tmp
 {{- if (.Values.azure).secretProvider }}
             - name: azure-secret-provider
               mountPath: "/mnt/azure-secrets-store"
@@ -292,6 +310,8 @@ spec:
             timeoutSeconds: 10
             failureThreshold: 2
       volumes:
+        - name: tmp
+          emptyDir: {}
 {{- if ((.Values.volumes.host).sharedFs) }}
         - name: shared-fs-persistent-storage
           persistentVolumeClaim:

--- a/kubernetes/charts/oasis-platform/templates/oasis_worker_controller.yaml
+++ b/kubernetes/charts/oasis-platform/templates/oasis_worker_controller.yaml
@@ -51,6 +51,7 @@ spec:
         checksum/{{ .Values.oasisServer.name }}: {{ toJson .Values.oasisWebsocket | sha256sum }}
     spec:
       {{- include "h.affinity" . | nindent 6 }}
+      {{- include "h.disableTokenAutomount" . | nindent 6 }}
       serviceAccountName: {{ $workerControllerServiceAccountName }}
       initContainers:
       {{- include "h.initTcpAvailabilityCheckBySecret" (list . .Values.oasisWebsocket.name) | nindent 8}}
@@ -58,6 +59,14 @@ spec:
         - image: {{ .Values.images.oasis.worker_controller.image }}:{{ .Values.images.oasis.worker_controller.version }}
           imagePullPolicy: {{ .Values.images.oasis.worker_controller.imagePullPolicy }}
           name: main
+          securityContext:
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - name: kube-api-access
+              mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+              readOnly: true
+            - name: tmp
+              mountPath: /tmp
           env:
             {{- include "h.serverApiVars" . | nindent 12}}
             - name: OASIS_SERVICE_USERNAME_OR_ID
@@ -104,8 +113,11 @@ spec:
               value: {{ .modelsLimit | quote }}
               {{- end }}
             {{- end }}
-{{- if (.Values.azure).secretProvider }}
       volumes:
+        - name: tmp
+          emptyDir: {}
+        {{- include "h.projectedServiceAccountToken" . | nindent 8 }}
+{{- if (.Values.azure).secretProvider }}
         - name: azure-secret-provider
           csi:
             driver: secrets-store.csi.k8s.io

--- a/kubernetes/charts/oasis-platform/templates/tests/test-connection.yaml
+++ b/kubernetes/charts/oasis-platform/templates/tests/test-connection.yaml
@@ -7,9 +7,12 @@ metadata:
   annotations:
     "helm.sh/hook": test
 spec:
+  {{- include "h.disableTokenAutomount" . | nindent 2 }}
   containers:
     - name: wget
       image: {{ .Values.images.init.image }}:{{ .Values.images.init.version }}
       command: ['sh']
       args: ['-c', 'wget -O /dev/null {{ .Values.oasisServer.name }}:{{ .Values.oasisServer.port }} && wget -O /dev/null {{ .Values.oasisUI.name }}:{{ .Values.oasisUI.port }}']
+      securityContext:
+        readOnlyRootFilesystem: true
   restartPolicy: Never


### PR DESCRIPTION
## Summary
Closes #895.

- `readOnlyRootFilesystem: true` on the oasis-platform containers, with `emptyDir` volumes added for the paths each image actually writes to at runtime (verified by building `Dockerfile.api_server` and `kubernetes/worker-controller/Dockerfile` and running them `--read-only`).
- `automountServiceAccountToken: false` on every pod. `oasis-worker-controller` is the only workload that talks to the Kubernetes API, so it gets the token mounted explicitly via a projected volume (`kube-root-ca.crt` + `serviceAccountToken` + namespace) instead of relying on the default automount.
- `NUMBA_CACHE_DIR` is redirected to the writable `/tmp` mount on the api-server and internal-worker images. Functional testing surfaced that `ods_tools`' `@numba.jit(cache=True)` decorator raises `RuntimeError: no locator available` at **import time** once its cache directory is unwritable and unset - this would have broken every Django/Celery process (oasis-server, oasis-websocket, celery-beat, oasis-task-controller, both worker-monitors, and the internal worker, whose image bakes `NUMBA_CACHE_DIR` into what is now a read-only path) as soon as `readOnlyRootFilesystem` was enabled.

### Out of scope
- The stock `postgres`/`mysql`/`redis`/`rabbitmq` images and `oasis-ui` are left without `readOnlyRootFilesystem` - their write requirements weren't verified here and they weren't part of the original issue's checklist.
- `keycloak` and `authentik` get `readOnlyRootFilesystem` plus `emptyDir` mounts for their known writable paths, based on upstream docs rather than a built/run functional test (no image build was done for these).

## Test plan
- [x] `helm lint` and `helm template` (via the `alpine/helm:3.14.0` Docker image, since helm isn't installed locally) across the simple/keycloak/authentik auth-type branches and the azure `secretProvider` branch - all render cleanly.
- [x] Built `kubernetes/worker-controller/Dockerfile` and ran it with `--read-only --tmpfs /tmp`; it fails only on missing cluster connectivity/args, not on filesystem writes, confirming the explicit service-account-token mount path matches where the k8s client library expects it.
- [x] Built `Dockerfile.api_server` and ran `django.setup()` + `manage.py check` and a `celery_app_v2` import with `--read-only --tmpfs /tmp`, both before and after the `NUMBA_CACHE_DIR` fix, reproducing and then resolving the numba caching crash described above.
- [ ] Not tested: an actual in-cluster deployment, and the `keycloak`/`authentik`/database containers (no image build performed for these).

🤖 Generated with [Claude Code](https://claude.com/claude-code)