### PR TITLE
fix/subtask_logging

### DIFF
--- a/src/model_execution_worker/tests/test_utils.py
+++ b/src/model_execution_worker/tests/test_utils.py
@@ -1,0 +1,110 @@
+import logging
+import os
+import threading
+from tempfile import TemporaryDirectory
+from unittest import TestCase
+
+from src.model_execution_worker.utils import LoggingTaskContext
+
+
+class LoggingTaskContextThreadIsolation(TestCase):
+    def test_concurrent_tasks_do_not_leak_into_each_others_log_file(self):
+        """ Regression test for https://github.com/OasisLMF/OasisPlatform/issues/799 -
+            under a thread-based Celery pool, two tasks running concurrently in the
+            same process must not write into each other's per-chunk log file.
+        """
+        with TemporaryDirectory() as tmp_dir:
+            log_a = os.path.join(tmp_dir, 'chunk-a.log')
+            log_b = os.path.join(tmp_dir, 'chunk-b.log')
+
+            # Deterministically nest chunk-b's whole run inside chunk-a's open
+            # context window, rather than relying on sleep timing.
+            a_holding_context = threading.Event()
+            b_done = threading.Event()
+
+            def run_a():
+                with LoggingTaskContext(logging.getLogger(), log_filename=log_a, level='INFO', delete_on_exit=False):
+                    logging.info('chunk-a-start')
+                    a_holding_context.set()
+                    b_done.wait(timeout=5)
+                    logging.info('chunk-a-end')
+
+            def run_b():
+                a_holding_context.wait(timeout=5)
+                with LoggingTaskContext(logging.getLogger(), log_filename=log_b, level='INFO', delete_on_exit=False):
+                    logging.info('chunk-b-start')
+                    logging.info('chunk-b-end')
+                b_done.set()
+
+            t_a = threading.Thread(target=run_a)
+            t_b = threading.Thread(target=run_b)
+            t_a.start()
+            t_b.start()
+            t_a.join(timeout=5)
+            t_b.join(timeout=5)
+
+            with open(log_a) as f:
+                content_a = f.read()
+            with open(log_b) as f:
+                content_b = f.read()
+
+            self.assertIn('chunk-a-start', content_a)
+            self.assertIn('chunk-a-end', content_a)
+            self.assertNotIn('chunk-b-start', content_a)
+            self.assertNotIn('chunk-b-end', content_a)
+
+            self.assertIn('chunk-b-start', content_b)
+            self.assertIn('chunk-b-end', content_b)
+            self.assertNotIn('chunk-a-start', content_b)
+            self.assertNotIn('chunk-a-end', content_b)
+
+
+class LoggingTaskContextLevelIsolation(TestCase):
+    def test_one_tasks_exit_does_not_drop_a_still_running_siblings_level(self):
+        """ Regression test: LoggingTaskContext used to restore the root logger's
+            level to whatever it captured on entry. If task A enters first (raising
+            the root level to DEBUG) and task B enters afterwards (nested), A exiting
+            before B finishes used to reset the root level back to A's own pre-entry
+            baseline - silently dropping B's DEBUG logging for the rest of B's run,
+            even though B's own handler was still attached and still wanted DEBUG.
+        """
+        root_logger = logging.getLogger()
+        original_level = root_logger.level
+        root_logger.setLevel(logging.WARNING)
+        try:
+            with TemporaryDirectory() as tmp_dir:
+                log_b = os.path.join(tmp_dir, 'chunk-b.log')
+
+                a_entered = threading.Event()
+                b_entered = threading.Event()
+                a_exited = threading.Event()
+
+                def run_a():
+                    with LoggingTaskContext(root_logger, log_filename=os.path.join(tmp_dir, 'chunk-a.log'),
+                                            level='DEBUG', delete_on_exit=False):
+                        a_entered.set()
+                        b_entered.wait(timeout=5)
+                        # A exits first, while B is still running (crossing overlap, not nested)
+                    a_exited.set()
+
+                def run_b():
+                    a_entered.wait(timeout=5)
+                    with LoggingTaskContext(root_logger, log_filename=log_b, level='DEBUG', delete_on_exit=False):
+                        b_entered.set()
+                        a_exited.wait(timeout=5)
+                        logging.debug('b-debug-after-a-exits')
+
+                t_a = threading.Thread(target=run_a)
+                t_b = threading.Thread(target=run_b)
+                t_a.start()
+                t_b.start()
+                t_a.join(timeout=5)
+                t_b.join(timeout=5)
+
+                with open(log_b) as f:
+                    content_b = f.read()
+
+                self.assertIn('b-debug-after-a-exits', content_b)
+                self.assertEqual(root_logger.level, logging.WARNING)
+        finally:
+            root_logger.setLevel(original_level)

--- a/src/model_execution_worker/tests/test_utils.py
+++ b/src/model_execution_worker/tests/test_utils.py
@@ -9,16 +9,10 @@ from src.model_execution_worker.utils import LoggingTaskContext
 
 class LoggingTaskContextThreadIsolation(TestCase):
     def test_concurrent_tasks_do_not_leak_into_each_others_log_file(self):
-        """ Regression test for https://github.com/OasisLMF/OasisPlatform/issues/799 -
-            under a thread-based Celery pool, two tasks running concurrently in the
-            same process must not write into each other's per-chunk log file.
-        """
         with TemporaryDirectory() as tmp_dir:
             log_a = os.path.join(tmp_dir, 'chunk-a.log')
             log_b = os.path.join(tmp_dir, 'chunk-b.log')
 
-            # Deterministically nest chunk-b's whole run inside chunk-a's open
-            # context window, rather than relying on sleep timing.
             a_holding_context = threading.Event()
             b_done = threading.Event()
 
@@ -61,12 +55,8 @@ class LoggingTaskContextThreadIsolation(TestCase):
 
 class LoggingTaskContextLevelIsolation(TestCase):
     def test_one_tasks_exit_does_not_drop_a_still_running_siblings_level(self):
-        """ Regression test: LoggingTaskContext used to restore the root logger's
-            level to whatever it captured on entry. If task A enters first (raising
-            the root level to DEBUG) and task B enters afterwards (nested), A exiting
-            before B finishes used to reset the root level back to A's own pre-entry
-            baseline - silently dropping B's DEBUG logging for the rest of B's run,
-            even though B's own handler was still attached and still wanted DEBUG.
+        """ Regression test: A exiting used to reset the root logger's level to its
+            own pre-entry baseline, dropping B's DEBUG logging while B was still running.
         """
         root_logger = logging.getLogger()
         original_level = root_logger.level

--- a/src/model_execution_worker/utils.py
+++ b/src/model_execution_worker/utils.py
@@ -94,13 +94,11 @@ class TaskLogFilter(logging.Filter):
 
 
 class _ThreadScopedFilter(logging.Filter):
-    """ Restricts a handler to records emitted by the thread that installed it.
+    """ Restricts a handler to records from the thread that installed it.
 
         The root logger is shared process-wide, so under a thread-based Celery
-        pool (--pool=threads/eventlet/gevent) multiple tasks can have their own
-        FileHandler attached to it at the same time - without this filter every
-        attached handler receives every thread's log records, corrupting each
-        task's per-chunk log file with output from concurrently running chunks.
+        pool multiple tasks can have their own FileHandler attached to it at
+        once; without this, every handler receives every thread's records.
     """
 
     def __init__(self):
@@ -117,15 +115,13 @@ _root_level_baseline = None
 
 
 def _level_to_int(level):
-    # logging.getLevelName(str) is a deprecated way to do a name -> int lookup
+    # logging.getLevelName(str) -> int is deprecated
     return level if isinstance(level, int) else logging.getLevelNamesMapping()[level]
 
 
 def _acquire_root_level(logger, level):
-    """ Raises the root logger's level to admit 'level', tracking every concurrently
-        active request for it so that one task finishing early can't drop the
-        effective level out from under a sibling task that is still running and
-        still relying on it (see _release_root_level).
+    """ Tracks concurrently active level requests so one task finishing early
+        can't drop the root logger's level out from under a still-running sibling.
     """
     global _root_level_baseline
     numeric_level = _level_to_int(level)

--- a/src/model_execution_worker/utils.py
+++ b/src/model_execution_worker/utils.py
@@ -109,33 +109,40 @@ class _ThreadScopedFilter(logging.Filter):
         return record.thread == self.thread_id
 
 
-_root_level_lock = threading.Lock()
-_root_level_requests = []
-_root_level_baseline = None
-
-
 def _level_to_int(level):
     return level if isinstance(level, int) else logging.getLevelNamesMapping()[level]
 
 
-def _acquire_root_level(logger, level):
-    """ Tracks concurrently active level requests so one task finishing early
-        can't drop the root logger's level out from under a still-running sibling.
+class _LevelTracker:
+    """ Tracks concurrently active level requests per logger, so one task
+        finishing early can't drop the effective level out from under a
+        still-running sibling task using the same logger.
     """
-    global _root_level_baseline
-    numeric_level = _level_to_int(level)
-    with _root_level_lock:
-        if not _root_level_requests:
-            _root_level_baseline = logger.level
-        _root_level_requests.append(numeric_level)
-        logger.setLevel(min(_root_level_requests))
+
+    def __init__(self):
+        self._lock = threading.Lock()
+        self._state = {}  # logger -> (baseline_level, [requested_levels])
+
+    def acquire(self, logger, level):
+        numeric_level = _level_to_int(level)
+        with self._lock:
+            baseline, requests = self._state.setdefault(logger, (logger.level, []))
+            requests.append(numeric_level)
+            logger.setLevel(min(requests))
+
+    def release(self, logger, level):
+        numeric_level = _level_to_int(level)
+        with self._lock:
+            baseline, requests = self._state[logger]
+            requests.remove(numeric_level)
+            if requests:
+                logger.setLevel(min(requests))
+            else:
+                logger.setLevel(baseline)
+                del self._state[logger]
 
 
-def _release_root_level(logger, level):
-    numeric_level = _level_to_int(level)
-    with _root_level_lock:
-        _root_level_requests.remove(numeric_level)
-        logger.setLevel(min(_root_level_requests) if _root_level_requests else _root_level_baseline)
+_level_tracker = _LevelTracker()
 
 
 class LoggingTaskContext:
@@ -158,7 +165,7 @@ class LoggingTaskContext:
     def __enter__(self):
         if self.level:
             self.handler.setLevel(self.level)
-            _acquire_root_level(self.logger, self.level)
+            _level_tracker.acquire(self.logger, self.level)
             if _level_to_int(self.level) <= logging.DEBUG:
                 self._filter = TaskLogFilter()
                 self.logger.addFilter(self._filter)
@@ -167,7 +174,7 @@ class LoggingTaskContext:
 
     def __exit__(self, et, ev, tb):
         if self.level:
-            _release_root_level(self.logger, self.level)
+            _level_tracker.release(self.logger, self.level)
             if self._filter:
                 self.logger.removeFilter(self._filter)
         if self.handler:

--- a/src/model_execution_worker/utils.py
+++ b/src/model_execution_worker/utils.py
@@ -115,7 +115,6 @@ _root_level_baseline = None
 
 
 def _level_to_int(level):
-    # logging.getLevelName(str) -> int is deprecated
     return level if isinstance(level, int) else logging.getLevelNamesMapping()[level]
 
 

--- a/src/model_execution_worker/utils.py
+++ b/src/model_execution_worker/utils.py
@@ -24,6 +24,7 @@ import re
 import tempfile
 import shutil
 import subprocess
+import threading
 from datetime import datetime
 from copy import deepcopy
 from celery import signature
@@ -92,6 +93,56 @@ class TaskLogFilter(logging.Filter):
         return True
 
 
+class _ThreadScopedFilter(logging.Filter):
+    """ Restricts a handler to records emitted by the thread that installed it.
+
+        The root logger is shared process-wide, so under a thread-based Celery
+        pool (--pool=threads/eventlet/gevent) multiple tasks can have their own
+        FileHandler attached to it at the same time - without this filter every
+        attached handler receives every thread's log records, corrupting each
+        task's per-chunk log file with output from concurrently running chunks.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.thread_id = threading.get_ident()
+
+    def filter(self, record):
+        return record.thread == self.thread_id
+
+
+_root_level_lock = threading.Lock()
+_root_level_requests = []
+_root_level_baseline = None
+
+
+def _level_to_int(level):
+    # logging.getLevelName(str) is a deprecated way to do a name -> int lookup
+    return level if isinstance(level, int) else logging.getLevelNamesMapping()[level]
+
+
+def _acquire_root_level(logger, level):
+    """ Raises the root logger's level to admit 'level', tracking every concurrently
+        active request for it so that one task finishing early can't drop the
+        effective level out from under a sibling task that is still running and
+        still relying on it (see _release_root_level).
+    """
+    global _root_level_baseline
+    numeric_level = _level_to_int(level)
+    with _root_level_lock:
+        if not _root_level_requests:
+            _root_level_baseline = logger.level
+        _root_level_requests.append(numeric_level)
+        logger.setLevel(min(_root_level_requests))
+
+
+def _release_root_level(logger, level):
+    numeric_level = _level_to_int(level)
+    with _root_level_lock:
+        _root_level_requests.remove(numeric_level)
+        logger.setLevel(min(_root_level_requests) if _root_level_requests else _root_level_baseline)
+
+
 class LoggingTaskContext:
     """ Adds a file log handler to the root logger and pushes a copy all logs to
         the 'log_filename'
@@ -102,18 +153,18 @@ class LoggingTaskContext:
     def __init__(self, logger, log_filename, level=None, close=True, delete_on_exit=True):
         self.logger = logger
         self.level = level
-        self.prev_level = logger.level
         self.log_filename = log_filename
         self.close = close
         self.handler = logging.FileHandler(log_filename)
+        self.handler.addFilter(_ThreadScopedFilter())
         self.delete_on_exit = delete_on_exit
         self._filter = None
 
     def __enter__(self):
         if self.level:
             self.handler.setLevel(self.level)
-            self.logger.setLevel(self.level)
-            if logging.getLevelName(self.level) <= logging.DEBUG:
+            _acquire_root_level(self.logger, self.level)
+            if _level_to_int(self.level) <= logging.DEBUG:
                 self._filter = TaskLogFilter()
                 self.logger.addFilter(self._filter)
         if self.handler:
@@ -121,7 +172,7 @@ class LoggingTaskContext:
 
     def __exit__(self, et, ev, tb):
         if self.level:
-            self.logger.setLevel(self.prev_level)
+            _release_root_level(self.logger, self.level)
             if self._filter:
                 self.logger.removeFilter(self._filter)
         if self.handler:


### PR DESCRIPTION
<!--start_release_notes-->
### fix/subtask_logging
Fixes per-chunk worker task logs (`prepare-keys-file-N`, `generate-losses-chunk-N`) getting cross-contaminated with output from other concurrently-running chunks when the worker uses a thread-based Celery pool (`--pool=threads`/`eventlet`/`gevent`). Root cause: `LoggingTaskContext` attached each task's log file handler to the shared, process-wide root logger with no per-task isolation, so concurrent tasks in the same process wrote into each other's log files. Also fixes a related root-logger level race, where one task finishing early could silently drop DEBUG-level logging for a still-running sibling task and leave the logger's level permanently drifted.

closes https://github.com/OasisLMF/OasisPlatform/issues/799
<!--end_release_notes-->
