### PR TITLE
(2.4.x Backport) Helm: enforce read-only root filesystem and explicit SA token mountin…

### DIFF
--- a/kubernetes/charts/oasis-platform/Chart.yaml
+++ b/kubernetes/charts/oasis-platform/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: oasis
-version: 2.4.6
+version: 2.4.14
 type: application
 description: Deploys the Oasis Platform
 appVersion: "1.26.2"

--- a/kubernetes/charts/oasis-platform/templates/_helpers.tpl
+++ b/kubernetes/charts/oasis-platform/templates/_helpers.tpl
@@ -217,6 +217,8 @@ Init container to wait for a service to become available (tcp check only) based 
 {{- $root := (index . 0) -}}
 - name: init-tcp-wait-by-secret
   image: {{ $root.Values.modelImages.init.image }}:{{ $root.Values.modelImages.init.version }}
+  securityContext:
+    readOnlyRootFilesystem: true
   env:
     {{- range $index, $name := slice . 1 }}
     - name: SERVICE_NAME_{{ $index }}
@@ -272,4 +274,36 @@ Set affinity if enabled
 affinity:
   {{- toYaml .Values.affinity | nindent 2 }}
 {{- end -}}
+{{- end -}}
+
+{{/*
+Disable automounting of the pod's ServiceAccount API credentials.
+Pods that genuinely need Kubernetes API access mount the token explicitly instead (see h.projectedServiceAccountToken).
+*/}}
+{{- define "h.disableTokenAutomount" -}}
+automountServiceAccountToken: false
+{{- end -}}
+
+{{/*
+Explicitly project the ServiceAccount token (plus CA cert and namespace) for pods that need Kubernetes API access,
+in place of relying on automountServiceAccountToken.
+*/}}
+{{- define "h.projectedServiceAccountToken" -}}
+- name: kube-api-access
+  projected:
+    defaultMode: 420
+    sources:
+      - serviceAccountToken:
+          expirationSeconds: 3607
+          path: token
+      - configMap:
+          name: kube-root-ca.crt
+          items:
+            - key: ca.crt
+              path: ca.crt
+      - downwardAPI:
+          items:
+            - path: namespace
+              fieldRef:
+                fieldPath: metadata.namespace
 {{- end -}}

--- a/kubernetes/charts/oasis-platform/templates/databases.yaml
+++ b/kubernetes/charts/oasis-platform/templates/databases.yaml
@@ -81,6 +81,7 @@ spec:
       annotations:
         checksum/{{ $v.name }}: {{ toJson $v | sha256sum }}
     spec:
+      {{- include "h.disableTokenAutomount" $root | nindent 6 }}
       volumes:
 {{- if or $v.volumeSize (eq $v.type "rabbitmq") }}
         {{- if or $v.volumeSize }}

--- a/kubernetes/charts/oasis-platform/templates/internal-worker.yaml
+++ b/kubernetes/charts/oasis-platform/templates/internal-worker.yaml
@@ -18,13 +18,19 @@ spec:
         {{- include "h.labels" . | nindent 8}}
         app: {{ .Values.internalWorker.name }}
     spec:
+      {{- include "h.disableTokenAutomount" . | nindent 6 }}
       containers:
         - name: {{ .Values.internalWorker.name }}
           image: {{ .Values.images.oasis.worker_internal.image }}:{{ .Values.images.oasis.worker_internal.version }}
           imagePullPolicy: {{ .Values.images.oasis.worker_internal.imagePullPolicy }}
+          securityContext:
+            readOnlyRootFilesystem: true
           env:
             - name: OASIS_RUN_MODE
               value: server-internal
+            # Image bakes NUMBA_CACHE_DIR into the (now read-only) rootfs; redirect it to the writable /tmp mount.
+            - name: NUMBA_CACHE_DIR
+              value: /tmp/numba_cache
             {{- toYaml .Values.internalWorker.env | nindent 12 }}
             {{- include "h.celeryDbVars" . | indent 12}}
             {{- include "h.brokerVars" . | indent 12 }}
@@ -44,7 +50,23 @@ spec:
           volumeMounts:
             - name: shared-fs-persistent-storage
               mountPath: /shared-fs
+            - name: tmp
+              mountPath: /tmp
+            - name: var-log-oasis
+              mountPath: /var/log/oasis
+            - name: var-oasis
+              mountPath: /var/oasis
+            - name: worker-model
+              mountPath: /home/worker/model
       volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: var-log-oasis
+          emptyDir: {}
+        - name: var-oasis
+          emptyDir: {}
+        - name: worker-model
+          emptyDir: {}
 {{- if ((.Values.volumes.host).sharedFs) }}
         - name: shared-fs-persistent-storage
           persistentVolumeClaim:

--- a/kubernetes/charts/oasis-platform/templates/keycloak.yaml
+++ b/kubernetes/charts/oasis-platform/templates/keycloak.yaml
@@ -89,12 +89,15 @@ spec:
         checksum/realm: {{ .Files.Get "resources/oasis-realm.json" | sha256sum }}
     spec:
       {{- include "h.affinity" . | nindent 6 }}
+      {{- include "h.disableTokenAutomount" . | nindent 6 }}
       initContainers:
         {{- include "h.initTcpAvailabilityCheckBySecret" (list . .Values.databases.keycloak_db.name) | nindent 8}}
       containers:
         - name: {{ .Values.keycloak.name }}
           image: {{ .Values.images.keycloak.image }}:{{ .Values.images.keycloak.version }}
           args: ["start", "--import-realm"]
+          securityContext:
+            readOnlyRootFilesystem: true
           ports:
             - containerPort: {{ .Values.keycloak.port }}
           env:
@@ -175,6 +178,10 @@ spec:
             timeoutSeconds: 10
             failureThreshold: 2
           volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+            - name: keycloak-data
+              mountPath: /opt/keycloak/data
             - name: realm-config
               mountPath: /opt/keycloak/data/import/oasis-realm.json
               subPath: oasis
@@ -188,6 +195,10 @@ spec:
             {{- end }}
 
       volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: keycloak-data
+          emptyDir: {}
         - name: realm-config
           configMap:
             name: {{ $realmSecretName }}

--- a/kubernetes/charts/oasis-platform/templates/oasis.yaml
+++ b/kubernetes/charts/oasis-platform/templates/oasis.yaml
@@ -53,13 +53,18 @@ spec:
         checksum/{{ .Values.databases.celery_db.name }}: versions{{ toJson .Values.databases.celery_db | sha256sum }}
     spec:
       {{- include "h.affinity" . | nindent 6 }}
+      {{- include "h.disableTokenAutomount" . | nindent 6 }}
       initContainers:
         {{- include "h.initTcpAvailabilityCheckBySecret" (list . .Values.databases.oasis_db.name .Values.databases.celery_db.name .Values.oasisServer.name .Values.databases.broker.name) | nindent 8}}
       containers:
         - image: {{ .Values.images.oasis.platform.image }}:{{ .Values.images.oasis.platform.version }}
           imagePullPolicy: {{ .Values.images.oasis.platform.imagePullPolicy }}
           name: oasis-v1-worker-monitor
+          securityContext:
+            readOnlyRootFilesystem: true
           env:
+            - name: NUMBA_CACHE_DIR
+              value: /tmp/numba_cache
 {{- include "h.serverDbVars" . | indent 12}}
 {{- include "h.celeryDbVars" . | indent 12}}
 {{- include "h.brokerVars" . | indent 12 }}
@@ -70,6 +75,8 @@ spec:
           volumeMounts:
             - name: shared-fs-persistent-storage
               mountPath: /shared-fs
+            - name: tmp
+              mountPath: /tmp
 {{- if (.Values.azure).secretProvider }}
             - name: azure-secret-provider
               mountPath: "/mnt/azure-secrets-store"
@@ -88,6 +95,8 @@ spec:
             periodSeconds: 60
             timeoutSeconds: 10
       volumes:
+        - name: tmp
+          emptyDir: {}
 {{- if ((.Values.volumes.host).sharedFs) }}
         - name: shared-fs-persistent-storage
           persistentVolumeClaim:
@@ -128,13 +137,18 @@ spec:
         checksum/{{ .Values.databases.celery_db.name }}: versions{{ toJson .Values.databases.celery_db | sha256sum }}
     spec:
       {{- include "h.affinity" . | nindent 6 }}
+      {{- include "h.disableTokenAutomount" . | nindent 6 }}
       initContainers:
         {{- include "h.initTcpAvailabilityCheckBySecret" (list . .Values.databases.oasis_db.name .Values.databases.celery_db.name .Values.oasisServer.name .Values.databases.broker.name) | nindent 8}}
       containers:
         - image: {{ .Values.images.oasis.platform.image }}:{{ .Values.images.oasis.platform.version }}
           imagePullPolicy: {{ .Values.images.oasis.platform.imagePullPolicy }}
           name: oasis-v2-worker-monitor
+          securityContext:
+            readOnlyRootFilesystem: true
           env:
+            - name: NUMBA_CACHE_DIR
+              value: /tmp/numba_cache
 {{- include "h.serverDbVars" . | indent 12}}
 {{- include "h.celeryDbVars" . | indent 12}}
 {{- include "h.brokerVars" . | indent 12 }}
@@ -145,6 +159,8 @@ spec:
           volumeMounts:
             - name: shared-fs-persistent-storage
               mountPath: /shared-fs
+            - name: tmp
+              mountPath: /tmp
 {{- if (.Values.azure).secretProvider }}
             - name: azure-secret-provider
               mountPath: "/mnt/azure-secrets-store"
@@ -163,6 +179,8 @@ spec:
             periodSeconds: 60
             timeoutSeconds: 10
       volumes:
+        - name: tmp
+          emptyDir: {}
 {{- if ((.Values.volumes.host).sharedFs) }}
         - name: shared-fs-persistent-storage
           persistentVolumeClaim:
@@ -201,6 +219,7 @@ spec:
         checksum/{{ .Values.oasisServer.name }}: {{ toJson .Values.oasisServer | sha256sum }}
     spec:
       {{- include "h.affinity" . | nindent 6 }}
+      {{- include "h.disableTokenAutomount" . | nindent 6 }}
       initContainers:
         {{- include "h.initTcpAvailabilityCheckBySecret" (list . .Values.oasisServer.name) | nindent 8}}
       containers:
@@ -274,19 +293,28 @@ spec:
         checksum/{{ .Values.databases.channel_layer.name }}: versions{{ toJson .Values.databases.channel_layer | sha256sum }}
     spec:
       {{- include "h.affinity" . | nindent 6 }}
+      {{- include "h.disableTokenAutomount" . | nindent 6 }}
       initContainers:
         {{- include "h.initTcpAvailabilityCheckBySecret" (list . .Values.databases.oasis_db.name .Values.databases.celery_db.name .Values.databases.channel_layer.name) | nindent 8}}
       containers:
         - image: {{ .Values.images.oasis.platform.image }}:{{ .Values.images.oasis.platform.version }}
           imagePullPolicy: {{ .Values.images.oasis.platform.imagePullPolicy }}
           name: celery-beat
-          command: ["celery", "-A", "src.server.oasisapi.celery_app_v2", "beat", "--loglevel=DEBUG"]
+          command: ["celery", "-A", "src.server.oasisapi.celery_app_v2", "beat", "--loglevel=DEBUG", "--schedule=/var/run/celery-beat/celerybeat-schedule", "--pidfile=/var/run/celery-beat/celerybeat.pid"]
+          securityContext:
+            readOnlyRootFilesystem: true
           env:
+            - name: NUMBA_CACHE_DIR
+              value: /tmp/numba_cache
             {{- include "h.serverDbVars" . | indent 12}}
             {{- include "h.celeryDbVars" . | indent 12}}
             {{- include "h.brokerVars" . | indent 12 }}
             {{- include "h.channelLayerVars" . | indent 12 }}
           volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+            - name: celery-beat-state
+              mountPath: /var/run/celery-beat
 {{- if (.Values.azure).secretProvider }}
             - name: azure-secret-provider
               mountPath: "/mnt/azure-secrets-store"
@@ -304,8 +332,12 @@ spec:
             initialDelaySeconds: 30
             periodSeconds: 60
             timeoutSeconds: 10
-{{- if (.Values.azure).secretProvider }}
       volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: celery-beat-state
+          emptyDir: {}
+{{- if (.Values.azure).secretProvider }}
         - name: azure-secret-provider
           csi:
             driver: secrets-store.csi.k8s.io
@@ -338,6 +370,7 @@ spec:
         checksum/{{ .Values.databases.channel_layer.name }}: versions{{ toJson .Values.databases.channel_layer | sha256sum }}
     spec:
       {{- include "h.affinity" . | nindent 6 }}
+      {{- include "h.disableTokenAutomount" . | nindent 6 }}
       initContainers:
         {{- include "h.initTcpAvailabilityCheckBySecret" (list . .Values.databases.oasis_db.name .Values.databases.celery_db.name .Values.databases.channel_layer.name .Values.databases.broker.name) | nindent 8}}
       containers:
@@ -345,7 +378,11 @@ spec:
           imagePullPolicy: {{ .Values.images.oasis.platform.imagePullPolicy }}
           name: main
           command: ["celery", "-A", "src.server.oasisapi.celery_app_v2", "worker", "--loglevel=INFO", "-Q", "task-controller"]
+          securityContext:
+            readOnlyRootFilesystem: true
           env:
+            - name: NUMBA_CACHE_DIR
+              value: /tmp/numba_cache
             {{- include "h.serverDbVars" . | indent 12}}
             {{- include "h.celeryDbVars" . | indent 12}}
             {{- include "h.brokerVars" . | indent 12 }}
@@ -353,6 +390,8 @@ spec:
             - name: OASIS_DEBUG
               value: "1"
           volumeMounts:
+            - name: tmp
+              mountPath: /tmp
 {{- if (.Values.azure).secretProvider }}
             - name: azure-secret-provider
               mountPath: "/mnt/azure-secrets-store"
@@ -370,8 +409,10 @@ spec:
             initialDelaySeconds: 30
             periodSeconds: 60
             timeoutSeconds: 10
-{{- if (.Values.azure).secretProvider }}
       volumes:
+        - name: tmp
+          emptyDir: {}
+{{- if (.Values.azure).secretProvider }}
         - name: azure-secret-provider
           csi:
             driver: secrets-store.csi.k8s.io

--- a/kubernetes/charts/oasis-platform/templates/oasis_server.yaml
+++ b/kubernetes/charts/oasis-platform/templates/oasis_server.yaml
@@ -78,12 +78,15 @@ spec:
         checksum/{{ .Values.databases.celery_db.name }}: {{ toJson .Values.databases.celery_db | sha256sum }}
     spec:
       {{- include "h.affinity" . | nindent 6 }}
+      {{- include "h.disableTokenAutomount" . | nindent 6 }}
       initContainers:
         {{- include "h.initTcpAvailabilityCheckBySecret" (list . .Values.databases.oasis_db.name .Values.databases.celery_db.name .Values.keycloak.name .Values.databases.broker.name) | nindent 8}}
       containers:
         - image: {{ .Values.images.oasis.platform.image }}:{{ .Values.images.oasis.platform.version }}
           name: {{ .Values.oasisWebsocket.name }}
           imagePullPolicy: {{ .Values.images.oasis.platform.imagePullPolicy }}
+          securityContext:
+            readOnlyRootFilesystem: true
           env:
             - name: OASIS_ADMIN_USER
               valueFrom:
@@ -95,6 +98,8 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.oasisWebsocket.name }}
                   key: password
+            - name: NUMBA_CACHE_DIR
+              value: /tmp/numba_cache
             {{- include "h.serverDbVars" . | indent 12}}
             {{- include "h.celeryDbVars" . | indent 12}}
             {{- include "h.brokerVars" . | indent 12 }}
@@ -124,6 +129,8 @@ spec:
           volumeMounts:
             - name: shared-fs-persistent-storage
               mountPath: /shared-fs
+            - name: tmp
+              mountPath: /tmp
 {{- if (.Values.azure).secretProvider }}
             - name: azure-secret-provider
               mountPath: "/mnt/azure-secrets-store"
@@ -143,6 +150,8 @@ spec:
             timeoutSeconds: 10
             failureThreshold: 2
       volumes:
+        - name: tmp
+          emptyDir: {}
 {{- if ((.Values.volumes.host).sharedFs) }}
         - name: shared-fs-persistent-storage
           persistentVolumeClaim:
@@ -196,11 +205,14 @@ spec:
         checksum/{{ .Values.databases.celery_db.name }}: {{ toJson .Values.databases.celery_db | sha256sum }}
     spec:
       {{- include "h.affinity" . | nindent 6 }}
+      {{- include "h.disableTokenAutomount" . | nindent 6 }}
       initContainers:
         {{- include "h.initTcpAvailabilityCheckBySecret" (list . .Values.databases.oasis_db.name .Values.databases.celery_db.name .Values.keycloak.name .Values.databases.broker.name) | nindent 8}}
         - name: set-mount-permissions
           image: busybox
           command: ["sh", "-c", "find /shared-fs -user root -exec chown 1000:1000 {} \\;"]
+          securityContext:
+            readOnlyRootFilesystem: true
           volumeMounts:
           - mountPath: /shared-fs
             name: shared-fs-persistent-storage
@@ -208,6 +220,8 @@ spec:
         - image: {{ .Values.images.oasis.platform.image }}:{{ .Values.images.oasis.platform.version }}
           name: {{ .Values.oasisServer.name }}
           imagePullPolicy: {{ .Values.images.oasis.platform.imagePullPolicy }}
+          securityContext:
+            readOnlyRootFilesystem: true
           env:
             - name: OASIS_ADMIN_USER
               valueFrom:
@@ -219,6 +233,8 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.oasisServer.name }}
                   key: password
+            - name: NUMBA_CACHE_DIR
+              value: /tmp/numba_cache
             {{- include "h.serverDbVars" . | indent 12}}
             {{- include "h.celeryDbVars" . | indent 12}}
             {{- include "h.brokerVars" . | indent 12 }}
@@ -246,6 +262,8 @@ spec:
           volumeMounts:
             - name: shared-fs-persistent-storage
               mountPath: /shared-fs
+            - name: tmp
+              mountPath: /tmp
 {{- if (.Values.azure).secretProvider }}
             - name: azure-secret-provider
               mountPath: "/mnt/azure-secrets-store"
@@ -269,6 +287,8 @@ spec:
             timeoutSeconds: 10
             failureThreshold: 2
       volumes:
+        - name: tmp
+          emptyDir: {}
 {{- if ((.Values.volumes.host).sharedFs) }}
         - name: shared-fs-persistent-storage
           persistentVolumeClaim:

--- a/kubernetes/charts/oasis-platform/templates/oasis_worker_controller.yaml
+++ b/kubernetes/charts/oasis-platform/templates/oasis_worker_controller.yaml
@@ -51,6 +51,7 @@ spec:
         checksum/{{ .Values.oasisServer.name }}: {{ toJson .Values.oasisWebsocket | sha256sum }}
     spec:
       {{- include "h.affinity" . | nindent 6 }}
+      {{- include "h.disableTokenAutomount" . | nindent 6 }}
       serviceAccountName: {{ $workerControllerServiceAccountName }}
       initContainers:
       {{- include "h.initTcpAvailabilityCheckBySecret" (list . .Values.oasisWebsocket.name) | nindent 8}}
@@ -58,6 +59,14 @@ spec:
         - image: {{ .Values.images.oasis.worker_controller.image }}:{{ .Values.images.oasis.worker_controller.version }}
           imagePullPolicy: {{ .Values.images.oasis.worker_controller.imagePullPolicy }}
           name: main
+          securityContext:
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - name: kube-api-access
+              mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+              readOnly: true
+            - name: tmp
+              mountPath: /tmp
           env:
             {{- include "h.serverApiVars" . | nindent 12}}
             - name: OASIS_USERNAME
@@ -99,8 +108,11 @@ spec:
               value: {{ .modelsLimit | quote }}
               {{- end }}
             {{- end }}
-{{- if (.Values.azure).secretProvider }}
       volumes:
+        - name: tmp
+          emptyDir: {}
+        {{- include "h.projectedServiceAccountToken" . | nindent 8 }}
+{{- if (.Values.azure).secretProvider }}
         - name: azure-secret-provider
           csi:
             driver: secrets-store.csi.k8s.io

--- a/kubernetes/charts/oasis-platform/templates/tests/test-connection.yaml
+++ b/kubernetes/charts/oasis-platform/templates/tests/test-connection.yaml
@@ -7,9 +7,12 @@ metadata:
   annotations:
     "helm.sh/hook": test
 spec:
+  {{- include "h.disableTokenAutomount" . | nindent 2 }}
   containers:
     - name: wget
       image: {{ .Values.images.init.image }}:{{ .Values.images.init.version }}
       command: ['sh']
       args: ['-c', 'wget -O /dev/null {{ .Values.oasisServer.name }}:{{ .Values.oasisServer.port }} && wget -O /dev/null {{ .Values.oasisUI.name }}:{{ .Values.oasisUI.port }}']
+      securityContext:
+        readOnlyRootFilesystem: true
   restartPolicy: Never


### PR DESCRIPTION
…g (#1431)

* Enforce read-only root filesystem and explicit SA token mounting in helm charts

Addresses #895: enable readOnlyRootFilesystem on all oasis-platform containers (with emptyDir volumes for the paths each image actually writes to, verified by building and running the api-server and worker-controller images read-only), and disable
automountServiceAccountToken on every pod, mounting the token explicitly only for oasis-worker-controller which genuinely needs Kubernetes API access.

Also redirects NUMBA_CACHE_DIR to a writable volume on the api-server and internal-worker images - numba's JIT cache locator otherwise raises at import time once its cache directory is no longer writable.

Left the stock database images (postgres/mysql/redis/rabbitmq) and oasis-ui out of scope: their filesystem write requirements aren't verified here and weren't part of the original issue's checklist.



* Fix authentik media/certs/templates mount paths for read-only root fs

CI's minikube job showed the actual failure: authentik's migration step writes to /media/public at startup, not /authentik/media as I'd assumed, so it crashed with "Read-only file system: '/media/public'" and never came up - which cascaded into oasis-server, oasis-websocket, oasis-ui, the worker-controller and both worker-monitors all sitting in Pending waiting on their authentik TCP check, and the Authenticate step timing out. Also missing the same mounts on the authentik server deployment, which runs the same migration on startup.



---------

<!--start_release_notes-->
### Release notes feature title 
... Release notes description / summary 
... Any text between these two tags will be automatically pulled into the platform release notes 
<!--end_release_notes-->
